### PR TITLE
Add parser porting plan

### DIFF
--- a/docs/parser-plan.md
+++ b/docs/parser-plan.md
@@ -1,0 +1,74 @@
+# Parser Porting Plan
+
+This document outlines how to port the Haskell parser found in
+`differential-datalog-1.2.3/src/Language/DifferentialDatalog/Parse.hs` to a Rust
+implementation that leverages the `chumsky` parser combinator library and builds
+a `rowan`-based Concrete Syntax Tree (CST) alongside the Abstract Syntax Tree
+(AST).
+
+## 1. Review the Existing Haskell Parser
+
+1. Study the token definitions and parser entry points in the Haskell source.
+2. Identify each grammar production and note its corresponding structure in the
+   AST.
+3. Enumerate lexical elements, including keywords, operators and punctuation.
+   These will become tokens.
+
+## 2. Define `SyntaxKind`
+
+Follow the guidance in the design document:
+
+- Create a `SyntaxKind` enum covering every token and node in the grammar.
+- Derive `FromPrimitive` and `ToPrimitive` and use `#[repr(u16)]` so that each
+  kind can map to `rowan::SyntaxKind`. The design notes this pattern
+  explicitly【F:docs/ddlint-design-and-road-map.md†L71-L122】.
+- Include an `N_ERROR` variant for error recovery.
+
+Implement `rowan::Language` for a `DdlogLanguage` newtype, using the conversions
+provided by `num-derive`. This allows `rowan` to store `SyntaxKind` tags
+transparently.
+
+## 3. Build a Tokeniser
+
+Use `chumsky`'s text utilities (or integrate a `logos` lexer if preferred) to
+convert the source text into a stream of `(SyntaxKind, Span)` pairs. Each span
+records byte offsets so that the resulting CST can precisely mirror the input.
+Whitespace and comments should produce tokens so they can be preserved.
+
+## 4. Construct the Parser with `chumsky`
+
+1. Express each grammar rule using `chumsky` combinators. The parser should
+   return both an AST node and instructions for the CST builder.
+2. Wrap every recognised token into its `SyntaxKind` and push it into a
+   `GreenNodeBuilder` from `rowan`.
+3. For syntactic errors, emit an `N_ERROR` node and recover by skipping to a
+   known synchronisation point, as recommended by the design
+   document【F:docs/ddlint-design-and-road-map.md†L124-L139】.
+
+The parser's final output is the AST root together with a `GreenNode` that
+contains the full CST.
+
+## 5. Map CST Nodes to AST Structures
+
+Implement lightweight AST types that reference the CST. Each AST node should
+store a `SyntaxNode` from `rowan`, allowing rules to navigate the tree while
+still providing ergonomic typed access for semantic processing.
+
+## 6. Testing Strategy
+
+1. Reuse examples from the Haskell project as fixtures. Ensure the new parser
+   produces equivalent AST structures and that the CST round-trips to the source
+   text.
+2. Write unit tests for individual grammar constructs and integration tests for
+   whole files.
+
+## 7. Integration Steps
+
+1. Add the new parser module under `src/parser` and expose a `parse` function
+   returning `(GreenNode, AstRoot)`.
+2. Update the build system to depend on `chumsky` and `rowan`.
+3. Replace any existing placeholders with the new parser in the linter pipeline.
+
+This plan bridges the mature Haskell implementation with the CST-first approach
+outlined in the design document, ensuring that parsing, error recovery, and CST
+construction happen in one efficient pass.

--- a/docs/parser-plan.md
+++ b/docs/parser-plan.md
@@ -11,7 +11,7 @@ a `rowan`-based Concrete Syntax Tree (CST) alongside the Abstract Syntax Tree
 1. Study the token definitions and parser entry points in the Haskell source.
 2. Identify each grammar production and note its corresponding structure in the
    AST.
-3. Enumerate lexical elements, including keywords, operators and punctuation.
+3. Enumerate lexical elements, including keywords, operators, and punctuation.
    These will become tokens.
 
 ## 2. Define `SyntaxKind`
@@ -20,15 +20,15 @@ Follow the guidance in the design document:
 
 - Create a `SyntaxKind` enum covering every token and node in the grammar.
 - Derive `FromPrimitive` and `ToPrimitive` and use `#[repr(u16)]` so that each
-  kind can map to `rowan::SyntaxKind`. The design notes this pattern
-  explicitly【F:docs/ddlint-design-and-road-map.md†L71-L122】.
+  kind can map to `rowan::SyntaxKind`. The design notes this pattern explicitly
+  ([design document](docs/ddlint-design-and-road-map.md#L71-L122)).
 - Include an `N_ERROR` variant for error recovery.
 
 Implement `rowan::Language` for a `DdlogLanguage` newtype, using the conversions
 provided by `num-derive`. This allows `rowan` to store `SyntaxKind` tags
 transparently.
 
-## 3. Build a Tokeniser
+## 3. Build a Tokenizer
 
 Use `chumsky`'s text utilities (or integrate a `logos` lexer if preferred) to
 convert the source text into a stream of `(SyntaxKind, Span)` pairs. Each span
@@ -39,11 +39,11 @@ Whitespace and comments should produce tokens so they can be preserved.
 
 1. Express each grammar rule using `chumsky` combinators. The parser should
    return both an AST node and instructions for the CST builder.
-2. Wrap every recognised token into its `SyntaxKind` and push it into a
+2. Wrap every recognized token into its `SyntaxKind` and push it into a
    `GreenNodeBuilder` from `rowan`.
 3. For syntactic errors, emit an `N_ERROR` node and recover by skipping to a
-   known synchronisation point, as recommended by the design
-   document【F:docs/ddlint-design-and-road-map.md†L124-L139】.
+   known synchronisation point, as recommended by the design document
+   ([design document](docs/ddlint-design-and-road-map.md#L124-L139)).
 
 The parser's final output is the AST root together with a `GreenNode` that
 contains the full CST.
@@ -72,3 +72,24 @@ still providing ergonomic typed access for semantic processing.
 This plan bridges the mature Haskell implementation with the CST-first approach
 outlined in the design document, ensuring that parsing, error recovery, and CST
 construction happen in one efficient pass.
+
+## 8. Handling Left-Recursive Grammar
+
+Chumsky does not support left recursion directly. Any left-recursive productions
+from the Haskell parser must be refactored into right-recursive or iterative
+forms before translation. For example, left-associative expression chains can be
+parsed using `foldl`-style helpers that combine a list of operands and operators
+after parsing. This avoids infinite recursion while preserving associativity.
+
+## 9. Performance Benchmarks
+
+To catch regressions, add micro-benchmarks that parse representative DDlog files
+and measure throughput and memory allocations. Compare these results with the
+existing Haskell parser using similar inputs. Benchmarks should run in CI so
+performance changes are visible in pull requests.
+
+## 10. Modelling Trivia Tokens
+
+Whitespace and comments are tokenised as `T_WHITESPACE` and `T_COMMENT` variants
+so the CST preserves them. AST wrappers skip over these trivia nodes, ensuring
+that semantic analyses operate on significant tokens only.


### PR DESCRIPTION
## Summary
- outline how to move the Haskell parser to Chumsky
- explain CST generation with rowan

## Testing
- `cargo fmt --all`
- `mdformat-all`
- `cargo clippy --all-targets --all-features -- -D warnings` *(failed: lint_groups_priority and print-stdout)*
- `cargo test --all-targets --all-features`
- `markdownlint --fix docs/parser-plan.md`


------
https://chatgpt.com/codex/tasks/task_e_68599e7c0d9c83228c3e1d2421e6d058

## Summary by Sourcery

Documentation:
- Introduce docs/parser-plan.md with a structured guide for migrating the Haskell parser to a Rust implementation leveraging chumsky for parsing and rowan for CST building, including testing strategies and integration instructions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a detailed plan outlining the steps to port a Haskell parser to Rust, including strategies for tokenisation, syntax tree construction, error recovery, and testing approaches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->