### PR TITLE
Update parser analysis

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,27 +16,27 @@ clean: ## Remove build artifacts
 	$(CARGO) clean
 
 test: ## Run tests with warnings treated as errors
-        RUSTFLAGS="-D warnings" $(CARGO) test --all-targets --all-features $(BUILD_JOBS)
+	RUSTFLAGS="-D warnings" $(CARGO) test --all-targets --all-features $(BUILD_JOBS)
 
 target/%/$(APP): ## Build binary in debug or release mode
-        $(CARGO) build $(BUILD_JOBS) $(if $(findstring release,$(@)),--release) --bin $(APP)
+	$(CARGO) build $(BUILD_JOBS) $(if $(findstring release,$(@)),--release) --bin $(APP)
 
 lint: ## Run Clippy with warnings denied
 	$(CARGO) clippy $(CLIPPY_FLAGS)
 
 fmt: ## Format Rust and Markdown sources
-        $(CARGO) fmt --all
-        mdformat-all
+	$(CARGO) fmt --all
+	mdformat-all
 
 check-fmt: ## Verify formatting
-        $(CARGO) fmt --all -- --check
-        mdformat-all --check
+	$(CARGO) fmt --all -- --check
+	mdformat-all --check
 
 markdownlint: ## Lint Markdown files
-        find . -type f -name '*.md' -not -path './target/*' -print0 | xargs -0 $(MDLINT)
+	find . -type f -name '*.md' -not -path './target/*' -print0 | xargs -0 $(MDLINT)
 
 nixie: ## Validate Mermaid diagrams
-        find . -type f -name '*.md' -not -path './target/*' -print0 | xargs -0 $(NIXIE)
+	find . -type f -name '*.md' -not -path './target/*' -print0 | xargs -0 $(NIXIE)
 
 help: ## Show available targets
 	@grep -E '^[a-zA-Z_-]+:.*?##' $(MAKEFILE_LIST) | \

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help all clean test build release lint fmt check-fmt markdownlint nixie
+.PHONY: help all clean test build release lint fmt check-fmt markdownlint nixie tools
 
 APP ?= ddlint
 CARGO ?= cargo
@@ -19,16 +19,20 @@ test: ## Run tests with warnings treated as errors
 	RUSTFLAGS="-D warnings" $(CARGO) test --all-targets --all-features $(BUILD_JOBS)
 
 target/%/$(APP): ## Build binary in debug or release mode
-	$(CARGO) build $(BUILD_JOBS) $(if $(findstring release,$(@)),--release) --bin $(APP)
+	$(CARGO) build $(BUILD_JOBS) $(if $(filter release,$*),--release) --bin $(APP)
 
 lint: ## Run Clippy with warnings denied
 	$(CARGO) clippy $(CLIPPY_FLAGS)
-
-fmt: ## Format Rust and Markdown sources
+# Ensure essential formatting tools exist to avoid missing-command errors
+tools:
+	@command -v mdformat-all >/dev/null
+	@command -v $(CARGO) >/dev/null
+	@command -v rustfmt >/dev/null
+fmt: tools ## Format Rust and Markdown sources
 	$(CARGO) fmt --all
 	mdformat-all
 
-check-fmt: ## Verify formatting
+check-fmt: tools ## Verify formatting
 	$(CARGO) fmt --all -- --check
 	mdformat-all --check
 

--- a/docs/haskell-parser-analysis.md
+++ b/docs/haskell-parser-analysis.md
@@ -1,11 +1,11 @@
 # Haskell Parser Analysis
 
 This document summarizes the design of the parser implemented in
-`Language.DifferentialDatalog.Parse`. The original code is written in
-Haskell using Parsec. This overview highlights token definitions, entry
-points, major grammar rules, and the AST structures they construct. The
-notes provide a reference for porting the parser to Rust using
-`chumsky` and `rowan` as described in the other design documents.
+`Language.DifferentialDatalog.Parse`. The original code is written in Haskell
+using Parsec. This overview highlights token definitions, entry points, major
+grammar rules, and the AST structures they construct. The notes provide a
+reference for porting the parser to Rust using `chumsky` and `rowan` as
+described in the other design documents.
 
 ## Token Definitions
 
@@ -13,8 +13,8 @@ Tokens are defined using Parsec's `TokenParser` facilities. The parser
 recognizes two sets of keywords:
 
 - **Rust keywords** – reserved to avoid conflicts with future Rust code.
-- **DDlog keywords** – language syntax. These include type names and
-  control constructs.
+- **DDlog keywords** – language syntax. These include type names and control
+  constructs.
 
 The lists of keywords appear in the Haskell source:
 
@@ -57,8 +57,8 @@ reservedOpNames =
 
 【F:Parse.hs†L97-L109】
 
-The token parser configuration defines how comments, identifiers, and
-other lexical items are recognized:
+The token parser configuration defines how comments, identifiers, and other
+lexical items are recognized:
 
 ```haskell
 ccnDef = emptyDef { T.commentStart      = "/*"
@@ -75,13 +75,16 @@ ccnDef = emptyDef { T.commentStart      = "/*"
 
 【F:Parse.hs†L110-L120】
 
-Helper parsers such as `parens`, `braces`, and `identifier` are generated
-from this configuration.
+Helper parsers such as `parens`, `braces`, and `identifier` are generated from
+this configuration.
+
+`reservedNames` is defined simply as `ddlogKeywords ++ rustKeywords`, so
+downstream code must not reuse any of those identifiers.
 
 ## Parser Entry Points
 
-The module exposes `parseDatalogString` as the main entry point. This
-wraps Parsec and returns either a `DatalogProgram` or an error:
+The module exposes `parseDatalogString` as the main entry point. This wraps
+Parsec and returns either a `DatalogProgram` or an error:
 
 ```haskell
 parseDatalogString :: String -> String -> ExceptT String IO DatalogProgram
@@ -102,16 +105,19 @@ exprGrammar    = removeTabs *> ((optional whiteSpace) *> expr <* eof)
 
 【F:Parse.hs†L214-L215】
 
-`datalogGrammar` parses an entire source file while `exprGrammar` parses
-an isolated expression. Both delegate to individual rules described
-below.
+`datalogGrammar` parses an entire source file while `exprGrammar` parses an
+isolated expression. Both delegate to individual rules described below.
+
+`parseDatalogString` wraps the Parsec `parse` function in `ExceptT`. This
+ensures the caller receives a clear error message when parsing fails and that IO
+exceptions remain separated from parse errors.
 
 ## Grammar Productions and AST Mapping
 
-Each parser rule uses `withPos` to attach source locations. The rules
-construct values from `Language.DifferentialDatalog.Syntax`, providing
-an explicit AST. The top-level `spec` rule gathers a list of
-`SpecItem` values, then builds a `DatalogProgram`:
+Each parser rule uses `withPos` to attach source locations. The rules construct
+values from `Language.DifferentialDatalog.Syntax`, providing an explicit AST.
+The top-level `spec` rule gathers a list of `SpecItem` values, then builds a
+`DatalogProgram`:
 
 ```haskell
 spec = do
@@ -139,10 +145,10 @@ spec = do
 
 ### Declarations
 
-`decl` recognizes one of several declaration forms, each constructing a
-specific AST node (`Import`, `TypeDef`, `Relation`, `Index`, `Function`,
-`Transformer`, `Rule` or `Apply`). Attributes encountered before the
-item are attached to the resulting node when applicable.
+`decl` recognizes one of several declaration forms, each constructing a specific
+AST node (`Import`, `TypeDef`, `Relation`, `Index`, `Function`, `Transformer`,
+`Rule` or `Apply`). Attributes encountered before the item are attached to the
+resulting node when applicable.
 
 ```haskell
 decl =  do attrs <- attributes
@@ -163,41 +169,137 @@ decl =  do attrs <- attributes
 Other notable grammar rules include:
 
 - `imprt` – parses an import statement and yields an `Import` AST node.
-- `typeDef` – handles regular and `extern` type definitions, producing
-  `TypeDef` values.
+- `typeDef` – handles regular and `extern` type definitions, producing `TypeDef`
+  values.
 - `func` – parses function definitions, optionally with a body.
-- `transformer` – restricted to `extern` forms, returning a
-  `Transformer` node.
+- `transformer` – restricted to `extern` forms, returning a `Transformer` node.
 - `index` – defines an index on a relation.
-- `relation` – parses a relation declaration and its optional primary
-  key.
-- `rule` – parses a rule head followed by an optional list of body
-  clauses.
-- `statement` and its helpers – parse imperative statements used within
-  rules.
-- `expr` – an expression parser built via `buildExpressionParser`; it
-  handles literals, operators and function calls.
+- `relation` – parses a relation declaration and its optional primary key.
+- `rule` – parses a rule head followed by an optional list of body clauses.
+- `statement` and its helpers – parse imperative statements used within rules.
+- `expr` – an expression parser built via `buildExpressionParser`; it handles
+  literals, operators and function calls.
+
+### Control-Flow Statements
+
+The parser contains dedicated rules for imperative constructs used in rules:
+
+```haskell
+parseForStatement = withPos $
+                    ForStatement nopos <$ reserved "for"
+                                       <*> (symbol "(" *> atom False)
+                                       <*> (optionMaybe (reserved "if" *> expr))
+                                       <*> (symbol ")" *> statement)
+
+parseIfStatement = IfStatement nopos <$ reserved "if"
+                                    <*> (parens expr) <*> statement
+                                    <*> (optionMaybe (reserved "else" *> statement))
+```
+
+【F:Parse.hs†L364-L395】
+
+`parseForStatement` recognises `for (pat in expr)` loops with an optional `if`
+guard, while `parseIfStatement` handles conditional branching with an optional
+`else` clause. Both return structured statement nodes used by the rule parser.
+
+### Expression Grammar
+
+The `expr` rule is defined through `buildExpressionParser` and a series of
+helper terms:
+
+```haskell
+expr = buildExpressionParser etable term
+    <?> "expression"
+
+term  =  elhs
+     <|> (withPos $ eTuple <$> (parens $ commaSepEnd expr))
+     <|> braces eseq
+     <|> term'
+     <?> "expression term"
+term' = withPos $
+         ebinding
+     <|> epholder
+     <|> estruct
+     <|> enumber
+     <|> ebool
+     <|> estring
+     <|> einterned_string
+     <|> efunc
+     <|> evar
+     <|> ematch
+     <|> eite
+     <|> efor
+     <|> evardcl
+     <|> econtinue
+     <|> ebreak
+     <|> ereturn
+     <|> emap_literal
+     <|> evec_literal
+     <|> eclosure
+```
+
+【F:Parse.hs†L566-L611】
+
+The table `etable` defines operator precedence, including assignment and logical
+connectives. Complex features such as group-by extraction are handled in helper
+functions like `extractGroupBy`.
+
+### Supporting Utilities
+
+Two helper mechanisms appear throughout the parser. `removeTabs` sanitises the
+input by replacing any tab character with a single space:
+
+```haskell
+removeTabs = do s <- getInput
+                let s' = map (\c -> if c == '\t' then ' ' else c ) s
+                setInput s'
+```
+
+【F:Parse.hs†L182-L186】
+
+Position information is attached using the `withPos` combinator from the `Pos`
+module:
+
+```haskell
+withPos x = (\ s a e -> atPos a (s,e)) <$> getPosition <*> x <*> getPosition
+```
+
+【F:Pos.hs†L92-L94】
+
+`withPosMany` performs the same operation for lists of nodes. These helpers
+allow downstream analyses to preserve accurate source spans.
 
 Each rule constructs an appropriate structure from
-`Language.DifferentialDatalog.Syntax`, ensuring that positions and
-attributes are preserved.
+`Language.DifferentialDatalog.Syntax`, ensuring that positions and attributes
+are preserved.
 
 ## Lexical Elements
 
 The complete set of lexical tokens derived from the parser includes:
 
 - **Keywords** – the union of `ddlogKeywords` and `rustKeywords`.
-- **Operators** – all strings in `reservedOpNames` such as `::`, `=>`,
-  `==`, `>=`, and so on.
-- **Punctuation** – parentheses, brackets, braces, commas, semicolons,
-  dots and colons as provided by the `TokenParser` helpers.
-- **Comments** – block comments delimited by `/*` and `*/` and line
-  comments starting with `//`.
-- **Identifiers** – parsed using `identifier`, `lcIdentifier` and
-  `ucIdentifier` which enforce naming rules for variables, types and
-  constructors.
+- **Operators** – all strings in `reservedOpNames` such as `::`, `=>`, `==`,
+  `>=`, and so on.
+- **Punctuation** – parentheses, brackets, braces, commas, semicolons, dots and
+  colons as provided by the `TokenParser` helpers.
+- **Comments** – block comments delimited by `/*` and `*/` and line comments
+  starting with `//`.
+- **Identifiers** – parsed using `identifier`, `lcIdentifier` and `ucIdentifier`
+  which enforce naming rules for variables, types and constructors.
 
-These lexical elements will translate directly into `SyntaxKind` token
-variants in the Rust implementation.
+These lexical elements will translate directly into `SyntaxKind` token variants
+in the Rust implementation.
 
----
+## Porting Notes
+
+When porting to Rust, the constructs above can be expressed with `chumsky`
+combinators and a `rowan` CST. The `expr` grammar maps well to
+`chumsky::recursive`, while the statement parsers become small combinators that
+emit both AST nodes and CST events. Group-by extraction can be implemented using
+a post-processing step mirroring `extractGroupBy`. Patterns for `match` and
+`for` loops translate to nested `chumsky` parsers building structured nodes.
+
+Keep this file in lockstep with `Parse.hs` when changes land so that the Rust
+implementation remains accurate.
+
+______________________________________________________________________

--- a/docs/haskell-parser-analysis.md
+++ b/docs/haskell-parser-analysis.md
@@ -198,7 +198,7 @@ parseIfStatement = IfStatement nopos <$ reserved "if"
 
 【F:Parse.hs†L364-L395】
 
-`parseForStatement` recognises `for (pat in expr)` loops with an optional `if`
+`parseForStatement` recognizes `for (pat in expr)` loops with an optional `if`
 guard, while `parseIfStatement` handles conditional branching with an optional
 `else` clause. Both return structured statement nodes used by the rule parser.
 

--- a/docs/haskell-parser-analysis.md
+++ b/docs/haskell-parser-analysis.md
@@ -10,7 +10,7 @@ described in the other design documents.
 ## Token Definitions
 
 Tokens are defined using Parsec's `TokenParser` facilities. The parser
-recognises two sets of keywords:
+recognizes two sets of keywords:
 
 - **Rust keywords** – reserved to avoid conflicts with future Rust code.
 - **DDlog keywords** – language syntax. These include type names and control
@@ -43,7 +43,7 @@ ddlogKeywords =
 
 【F:Parse.hs†L70-L96】
 
-Operators and punctuation recognised as single tokens are listed under
+Operators and punctuation recognized as single tokens are listed under
 `reservedOpNames`:
 
 ```haskell
@@ -58,7 +58,7 @@ reservedOpNames =
 【F:Parse.hs†L97-L109】
 
 The token parser configuration defines how comments, identifiers, and other
-lexical items are recognised:
+lexical items are recognized:
 
 ```haskell
 ccnDef = emptyDef { T.commentStart      = "/*"
@@ -145,7 +145,7 @@ spec = do
 
 ### Declarations
 
-`decl` recognises one of several declaration forms, each constructing a specific
+`decl` recognizes one of several declaration forms, each constructing a specific
 AST node (`Import`, `TypeDef`, `Relation`, `Index`, `Function`, `Transformer`,
 `Rule` or `Apply`). Attributes encountered before the item are attached to the
 resulting node when applicable.
@@ -246,7 +246,7 @@ functions like `extractGroupBy`.
 
 ### Supporting Utilities
 
-Two helper mechanisms appear throughout the parser. `removeTabs` sanitises the
+Two helper mechanisms appear throughout the parser. `removeTabs` sanitizes the
 input by replacing any tab character with a single space:
 
 ```haskell

--- a/docs/haskell-parser-analysis.md
+++ b/docs/haskell-parser-analysis.md
@@ -10,7 +10,7 @@ described in the other design documents.
 ## Token Definitions
 
 Tokens are defined using Parsec's `TokenParser` facilities. The parser
-recognizes two sets of keywords:
+recognises two sets of keywords:
 
 - **Rust keywords** – reserved to avoid conflicts with future Rust code.
 - **DDlog keywords** – language syntax. These include type names and control
@@ -43,7 +43,7 @@ ddlogKeywords =
 
 【F:Parse.hs†L70-L96】
 
-Operators and punctuation recognized as single tokens are listed under
+Operators and punctuation recognised as single tokens are listed under
 `reservedOpNames`:
 
 ```haskell
@@ -58,7 +58,7 @@ reservedOpNames =
 【F:Parse.hs†L97-L109】
 
 The token parser configuration defines how comments, identifiers, and other
-lexical items are recognized:
+lexical items are recognised:
 
 ```haskell
 ccnDef = emptyDef { T.commentStart      = "/*"
@@ -145,7 +145,7 @@ spec = do
 
 ### Declarations
 
-`decl` recognizes one of several declaration forms, each constructing a specific
+`decl` recognises one of several declaration forms, each constructing a specific
 AST node (`Import`, `TypeDef`, `Relation`, `Index`, `Function`, `Transformer`,
 `Rule` or `Apply`). Attributes encountered before the item are attached to the
 resulting node when applicable.


### PR DESCRIPTION
## Summary
- document control-flow parsers and helper utilities
- explain error handling and rust port guidance
- fix Makefile tab characters so `make` runs

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make markdownlint`


------
https://chatgpt.com/codex/tasks/task_e_6859d251b1a08322974d3df30daa4dcd

## Summary by Sourcery

Update the Haskell parser analysis documentation with new sections on control-flow parsing, helper utilities, error handling, and Rust porting guidance, and fix Makefile indentation to ensure make targets execute correctly.

Build:
- Fix Makefile indentation to use tabs for all targets so that `make` commands run successfully

Documentation:
- Expand the parser analysis with dedicated sections for `for` and `if` statement rules and helper utilities like `removeTabs` and `withPos`,`Describe the error-handling approach in `parseDatalogString` for clear error messages and IO separation`,`Add porting notes detailing mapping of Haskell grammar to Rust using `chumsky` and `rowan` combinators

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Improved formatting and expanded explanations in the parser analysis document, including detailed grammar descriptions, code examples, and a new section on porting to Rust.
- **Style**
  - Corrected indentation in the Makefile to use tabs as required for proper command execution.
- **Chores**
  - Added a new Makefile target to verify essential formatting tools before running commands, enhancing build reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->