### PR TITLE
Improve Makefile tool diagnostics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,9 +25,18 @@ lint: ## Run Clippy with warnings denied
 	$(CARGO) clippy $(CLIPPY_FLAGS)
 # Ensure essential formatting tools exist to avoid missing-command errors
 tools:
-	@command -v mdformat-all >/dev/null
-	@command -v $(CARGO) >/dev/null
-	@command -v rustfmt >/dev/null
+	command -v mdformat-all >/dev/null || { \
+		echo 'mdformat-all is required but not installed. Please install it to continue.' >&2; \
+		exit 1; \
+	}
+	command -v $(CARGO) >/dev/null || { \
+		echo '$(CARGO) is required but not installed. Please install Rust.' >&2; \
+		exit 1; \
+	}
+	command -v rustfmt >/dev/null || { \
+		echo 'rustfmt is required but not installed. Please install the rustfmt component.' >&2; \
+		exit 1; \
+	}
 fmt: tools ## Format Rust and Markdown sources
 	$(CARGO) fmt --all
 	mdformat-all

--- a/Makefile
+++ b/Makefile
@@ -23,20 +23,15 @@ target/%/$(APP): ## Build binary in debug or release mode
 
 lint: ## Run Clippy with warnings denied
 	$(CARGO) clippy $(CLIPPY_FLAGS)
+# Macro ensuring a tool exists in PATH
+ensure_tool = $(if $(shell command -v $(1) >/dev/null 2>&1 && echo y),,\
+       $(error $(1) is required but not installed))
+
 # Ensure essential formatting tools exist to avoid missing-command errors
 tools:
-	command -v mdformat-all >/dev/null || { \
-		echo 'mdformat-all is required but not installed. Please install it to continue.' >&2; \
-		exit 1; \
-	}
-	command -v $(CARGO) >/dev/null || { \
-		echo '$(CARGO) is required but not installed. Please install Rust.' >&2; \
-		exit 1; \
-	}
-	command -v rustfmt >/dev/null || { \
-		echo 'rustfmt is required but not installed. Please install the rustfmt component.' >&2; \
-		exit 1; \
-	}
+       $(call ensure_tool,mdformat-all)
+       $(call ensure_tool,$(CARGO))
+       $(call ensure_tool,rustfmt)
 fmt: tools ## Format Rust and Markdown sources
 	$(CARGO) fmt --all
 	mdformat-all

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
-.PHONY: help all clean test build release lint fmt check-fmt markdownlint nixie tools
+.PHONY: help all clean test build release lint fmt check-fmt markdownlint \
+        nixie tools
 
 APP ?= ddlint
 CARGO ?= cargo
@@ -24,14 +25,16 @@ target/%/$(APP): ## Build binary in debug or release mode
 lint: ## Run Clippy with warnings denied
 	$(CARGO) clippy $(CLIPPY_FLAGS)
 # Macro ensuring a tool exists in PATH
-ensure_tool = $(if $(shell command -v $(1) >/dev/null 2>&1 && echo y),,\
-       $(error $(1) is required but not installed))
+define ensure_tool
+$(if $(shell command -v $(1) >/dev/null 2>&1 && echo y),,\
+$(error $(1) is required but not installed))
+endef
 
 # Ensure essential formatting tools exist to avoid missing-command errors
 tools:
-       $(call ensure_tool,mdformat-all)
-       $(call ensure_tool,$(CARGO))
-       $(call ensure_tool,rustfmt)
+	$(call ensure_tool,mdformat-all)
+	$(call ensure_tool,$(CARGO))
+	$(call ensure_tool,rustfmt)
 fmt: tools ## Format Rust and Markdown sources
 	$(CARGO) fmt --all
 	mdformat-all


### PR DESCRIPTION
## Summary
- provide explicit error messages when required tools are missing

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make markdownlint`
- `make nixie`


------
https://chatgpt.com/codex/tasks/task_e_6859f9bbddec8322b6a1177cf688dc4d

## Summary by Sourcery

Add explicit tool presence checks and improve Makefile diagnostics

Enhancements:
- Introduce an ensure_tool Makefile macro that emits clear errors when required tools are missing
- Refactor the tools target to use ensure_tool instead of silent command checks
- Break the .PHONY declaration into multiple lines for improved readability

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling in the build process by providing clear messages when required formatting tools are missing, ensuring users are promptly informed and the process stops if dependencies are not found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->