### PR TITLE
Implement import parser

### DIFF
--- a/docs/building-an-error-recovering-parser-with-chumsky.md
+++ b/docs/building-an-error-recovering-parser-with-chumsky.md
@@ -1,50 +1,71 @@
-## DON’T PANIC: A Hitchhiker’s Guide to Building an Error-Recovering Parser with **Chumsky**
+# DON’T PANIC: Building an Error-Recovering Parser with **Chumsky**
 
-> *A completely remarkable book. Probably the most remarkable, certainly the most successful book ever to come out of the great publishing corporations of Ursa Minor.*
+> *A completely remarkable book. Probably the most remarkable, certainly the
+> most successful book ever to come out of the great publishing corporations of
+> Ursa Minor.*
 
-### 1 Know Where Your Towel (and Grammar) Is
+## 1 Know Where Your Towel (and Grammar) Is
 
-Before you even think about summoning Chumsky’s combinators, write your grammar down — preferably in EBNF, biro on a napkin, or etched into the side of a Vogon constructor fleet. Chumsky mirrors whatever you hand it; change the napkin later and you’ll be spelunking inside recursive lambdas at 2 a.m.
+Before you even think about summoning Chumsky’s combinators, write your grammar
+down — preferably in EBNF, biro on a napkin, or etched into the side of a Vogon
+constructor fleet. Chumsky mirrors whatever you hand it; change the napkin later
+and you’ll be spelunking inside recursive lambdas at 2 a.m.
 
-**Checklist**
+### Checklist
 
 - A complete token list
-- Precedence rules in plain English (“multiply before add, semicolons end statements, tea before Arthur, etc.”)
+- Precedence rules in plain English (“multiply before add, semicolons end
+  statements, tea before Arthur, etc.”)
 - Examples of legal *and* illegal programmes
 
 ### 2 Feed It Tokens, Not Breadcrumbs
 
-Chumsky is much happier when it’s nibbling on a neat `Vec<TokenSpan>` than on raw characters. Use the `logos` crate (or your favourite lexical life-form) to slice the source first. You’ll get:
+Chumsky is much happier when it’s nibbling on a neat `Vec<TokenSpan>` than on
+raw characters. Use the `logos` crate (or your favourite lexical life-form) to
+slice the source first. You’ll get:
 
 - Cleaner error messages (“unexpected `KwIf`”)
 - Simple span maths: every token already knows its start & end byte
-- The freedom to invent helpful token kinds (e.g. “Indent”, “Dedent”, “Unified Field Theory Symbol”)
+- The freedom to invent helpful token kinds (e.g. “Indent”, “Dedent”, “Unified
+  Field Theory Symbol”)
 
 ### 3 Dealing with Left-Recursion, Infinite Loops and Other Things That Ate Betelgeuse
 
-Left-recursive rules make top-down parsers seize up like Marvin’s shoulder joints. Rewrite them with repetition combinators (`many()`, `foldl()`), or use a precedence-climbing expression parser.
+Left-recursive rules make top-down parsers seize up like Marvin’s shoulder
+joints. Rewrite them with repetition combinators (`many()`, `foldl()`), or use a
+precedence-climbing expression parser.
 
-Forward references? Wrap them in `recursive(|expr| { … })` so Chumsky can see round corners.
+Forward references? Wrap them in `recursive(|expr| { … })` so Chumsky can see
+round corners.
 
-Ambiguity? Break overlapping prefixes into separate branches *first* and only then hand the survivors to `choice()`.
+Ambiguity? Break overlapping prefixes into separate branches *first* and only
+then hand the survivors to `choice()`.
 
-### 4 Panic? No. Recovery? Yes.
+### 4 Panic? No. Recovery? Yes
 
 Error recovery is what turns your parser from Vogon poetry into a Babel fish.
 
-1. **Anchors:** Tell Chumsky that `;`, `}`, `]` and other setters of cosmic balance are “hard delimiters”. Use `recover_with(skip_until([]))`.
-2. **Labels:** Tag sub-parsers with `.labelled("expression")` so the diagnostics mention something friendlier than “expected `Unknown(42)`”.
-3. **Tri-state nodes:** Return `Option<AstNode>`; missing bits propagate but the parse soldier on.
+1. **Anchors:** Tell Chumsky that `;`, `}`, `]` and other setters of cosmic
+   balance are “hard delimiters”. Use `recover_with(skip_until([]))`.
+2. **Labels:** Tag sub-parsers with `.labelled("expression")` so the diagnostics
+   mention something friendlier than “expected `Unknown(42)`”.
+3. **Tri-state nodes:** Return `Option<AstNode>`; missing bits propagate but the
+   parse soldier on.
 
-In practice you’ll compose the built-ins (`NestedDelimiters`, `SkipUntil`) with a couple of bespoke closures and quickly look like you own the place.
+In practice you’ll compose the built-ins (`NestedDelimiters`, `SkipUntil`) with
+a couple of bespoke closures and quickly look like you own the place.
 
 ### 5 Getting Codex to Behave (or: How to Babysit a 2-Metre Tall Neural Net)
 
 Codex is a marvellous companion so long as you:
 
-- **Constrain its universe.** Include the token enums, AST structs, and the precise combinators in the prompt.
-- **Ask for one production at a time.** Whole-grammar requests invite hallucinations of alternate dimensions.
-- **Round-trip ruthlessly.** Generate random AST → pretty-print → re-parse → assert equality. Failures mean Codex (or you) has mis-remembered the Restaurant at the End of the File.
+- **Constrain its universe.** Include the token enums, AST structs, and the
+  precise combinators in the prompt.
+- **Ask for one production at a time.** Whole-grammar requests invite
+  hallucinations of alternate dimensions.
+- **Round-trip ruthlessly.** Generate random AST → pretty-print → re-parse →
+  assert equality. Failures mean Codex (or you) has mis-remembered the
+  Restaurant at the End of the File.
 
 ### 6 Linting: The First Sip of the Differential Logic Engine
 
@@ -52,20 +73,28 @@ Treat the linter as the pre-solver phase of your differential logic engine:
 
 1. Build symbol tables and scope graphs.
 2. Run the cheap local checks (duplicates, arity, type holes).
-3. Emit a constraint set and immediately feed it to the solver; conflicts become diagnostics.
+3. Emit a constraint set and immediately feed it to the solver; conflicts become
+   diagnostics.
 
-Because differential logic supports incremental re-checking, you can deliver IDE feedback faster than a hyperspace bypass.
+Because differential logic supports incremental re-checking, you can deliver IDE
+feedback faster than a hyperspace bypass.
 
 ### 7 Keeping the Whole Show Flying
 
-- **CI Pipeline:** `cargo insta test`, `cargo clippy --deny warnings`, and your round-trip parser tests on every push.
-- **Editor integration:** Convert Chumsky’s `Rich` errors into LSP diagnostics; line/column already sorted.
-- **Performance guardrails:** Benchmark on a late-game save. If a commit slows parsing or solving by &gt; 20 %, trigger the Heart of Gold and revert reality.
+- **CI Pipeline:** `cargo insta test`, `cargo clippy --deny warnings`, and your
+  round-trip parser tests on every push.
+- **Editor integration:** Convert Chumsky’s `Rich` errors into LSP diagnostics;
+  line/column already sorted.
+- **Performance guardrails:** Benchmark on a late-game save. If a commit slows
+  parsing or solving by > 20 %, trigger the Heart of Gold and revert reality.
 
----
+______________________________________________________________________
 
 ### TL;DR (because life is short and full of Thursdays)
 
-Write the grammar first, lex separately, tame left-recursion, anchor recovery on hard delimiters, keep Codex on a tight leash, and let your linter double as the logic engine’s warm-up act.
+Write the grammar first, lex separately, tame left-recursion, anchor recovery on
+hard delimiters, keep Codex on a tight leash, and let your linter double as the
+logic engine’s warm-up act.
 
-And always keep your towel handy. It’s the most massively useful thing an interstellar parser hacker can carry.
+And always keep your towel handy. It’s the most massively useful thing an
+interstellar parser hacker can carry.

--- a/docs/building-an-error-recovering-parser-with-chumsky.md
+++ b/docs/building-an-error-recovering-parser-with-chumsky.md
@@ -16,7 +16,7 @@ and you’ll be spelunking inside recursive lambdas at 2 a.m.
 - A complete token list
 - Precedence rules in plain English (“multiply before add, semicolons end
   statements, tea before Arthur, etc.”)
-- Examples of legal *and* illegal programmes
+- Examples of legal *and* illegal programmes.
 
 ### 2 Feed It Tokens, Not Breadcrumbs
 
@@ -50,7 +50,7 @@ Error recovery is what turns your parser from Vogon poetry into a Babel fish.
 2. **Labels:** Tag sub-parsers with `.labelled("expression")` so the diagnostics
    mention something friendlier than “expected `Unknown(42)`”.
 3. **Tri-state nodes:** Return `Option<AstNode>`; missing bits propagate but the
-   parse soldier on.
+   parser soldiers on.
 
 In practice you’ll compose the built-ins (`NestedDelimiters`, `SkipUntil`) with
 a couple of bespoke closures and quickly look like you own the place.

--- a/docs/rust-parser-testing-comprehensive-guide.md
+++ b/docs/rust-parser-testing-comprehensive-guide.md
@@ -94,11 +94,14 @@ To navigate the different testing methodologies, the following table summarizes
 the primary tools and their roles within the context of parser development. It
 serves as a mental model for selecting the right tool for a given testing task.
 
-| **Strategy**               | **Primary Tool(s)** | **Core Purpose**                                                            | **Best Suited For**                                                                                 |
-| :------------------------- | :------------------ | :-------------------------------------------------------------------------- | :-------------------------------------------------------------------------------------------------- |
-| **Example-Based Testing**  | `rstest`            | Verify known correct and incorrect behaviors against explicit expectations. | Specific edge cases, happy paths, known bugs, individual token definitions, simple parser rules. 10 |
-| **Snapshot Testing**       | `insta`             | Detect regressions in complex, large, or frequently changing outputs.       | Full AST/CST structures, formatted error diagnostics, pretty-printed source code. 11                |
-| **Property-Based Testing** | `proptest`          | Discover unknown/unforeseen bugs via automated, random input generation.    | Round-trip validation (parse/unparse), fuzzing for panics, checking universal invariants. 13        |
+The main strategies and tools are:
+
+- **Example-Based Testing** with `rstest` verifies specific behaviours and
+  handles edge cases or known bugs.
+- **Snapshot Testing** using `insta` detects regressions in full syntax trees or
+  error diagnostics.
+- **Property-Based Testing** powered by `proptest` uncovers unforeseen bugs via
+  random input generation and round-trip validation.
 
 This structured approach, combining conventional file organization with a clear
 understanding of each testing paradigm's purpose, lays the groundwork for the

--- a/docs/rust-parser-testing-comprehensive-guide.md
+++ b/docs/rust-parser-testing-comprehensive-guide.md
@@ -96,12 +96,15 @@ serves as a mental model for selecting the right tool for a given testing task.
 
 The main strategies and tools are:
 
-- **Example-Based Testing** with `rstest` verifies specific behaviours and
-  handles edge cases or known bugs.
-- **Snapshot Testing** using `insta` detects regressions in full syntax trees or
-  error diagnostics.
-- **Property-Based Testing** powered by `proptest` uncovers unforeseen bugs via
-  random input generation and round-trip validation.
+- **Example-Based Testing** with `rstest`: Verifies specific behaviours and
+  handles edge cases or known bugs. Best used for token validation, precedence
+  rules and edge case handling.
+- **Snapshot Testing** using `insta`: Detects regressions in full syntax trees
+  or error diagnostics. Best used for AST structure validation, error message
+  quality and CST losslessness verification.
+- **Property-Based Testing** powered by `proptest`: Uncovers unforeseen bugs via
+  random input generation and round-trip validation. Best used for parser
+  robustness, AST round-trips and invariant testing.
 
 This structured approach, combining conventional file organization with a clear
 understanding of each testing paradigm's purpose, lays the groundwork for the

--- a/src/language.rs
+++ b/src/language.rs
@@ -162,7 +162,7 @@ pub enum SyntaxKind {
     N_HO_FIELD,
     N_TRANSFORMER,
     N_APPLY,
-    N_IMPORT,
+    N_IMPORT_STMT,
     N_DATALOG_PROGRAM,
     // Special
     N_ERROR,

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -49,14 +49,9 @@ impl Parsed {
 #[must_use]
 pub fn parse(src: &str) -> Parsed {
     let tokens = tokenize(src);
-    let (parsed_kinds, errors) = parse_tokens(&tokens, src.len());
-    debug_assert_eq!(
-        parsed_kinds.len(),
-        tokens.len(),
-        "parser output token count differs from lexer",
-    );
+    let (import_spans, errors) = parse_tokens(&tokens, src.len());
 
-    let green = build_green_tree(tokens, src);
+    let green = build_green_tree(tokens, src, &import_spans);
     let root = ast::Root::from_green(green.clone());
 
     Parsed {
@@ -66,30 +61,59 @@ pub fn parse(src: &str) -> Parsed {
     }
 }
 
-fn parse_tokens(
-    tokens: &[(SyntaxKind, Span)],
-    len: usize,
-) -> (Vec<SyntaxKind>, Vec<Simple<SyntaxKind>>) {
+fn parse_tokens(tokens: &[(SyntaxKind, Span)], len: usize) -> (Vec<Span>, Vec<Simple<SyntaxKind>>) {
     let stream = Stream::from_iter(0..len, tokens.iter().cloned());
 
-    let parser = any::<SyntaxKind, Simple<SyntaxKind>>()
-        .repeated()
-        .then_ignore(end());
-    let (parsed_kinds, errors) = parser.parse_recovery(stream);
+    let ws = filter(|kind: &SyntaxKind| {
+        matches!(kind, SyntaxKind::T_WHITESPACE | SyntaxKind::T_COMMENT)
+    })
+    .ignored();
 
-    let result = parsed_kinds.unwrap_or_default();
-    debug_assert_eq!(
-        result.len(),
-        tokens.len(),
-        "parser combinator output differs from input token count",
-    );
-    (result, errors)
+    let ident = just(SyntaxKind::T_IDENT).ignored().padded_by(ws.repeated());
+
+    let module_path = ident
+        .then(
+            just(SyntaxKind::T_COLON_COLON)
+                .padded_by(ws.repeated())
+                .ignore_then(ident)
+                .repeated(),
+        )
+        .ignored();
+
+    let alias = just(SyntaxKind::K_AS)
+        .padded_by(ws.repeated())
+        .ignore_then(ident);
+
+    let imprt = just(SyntaxKind::K_IMPORT)
+        .padded_by(ws.repeated())
+        .ignore_then(module_path)
+        .then(alias.or_not())
+        .padded_by(ws.repeated())
+        .map_with_span(|_, span| span);
+
+    let parser = imprt.repeated().then_ignore(end());
+    let (res, errors) = parser.parse_recovery(stream);
+    (res.unwrap_or_default(), errors)
 }
 
-fn build_green_tree(tokens: Vec<(SyntaxKind, Span)>, src: &str) -> GreenNode {
+fn build_green_tree(tokens: Vec<(SyntaxKind, Span)>, src: &str, imports: &[Span]) -> GreenNode {
     let mut builder = GreenNodeBuilder::new();
     builder.start_node(DdlogLanguage::kind_to_raw(SyntaxKind::N_DATALOG_PROGRAM));
+    let mut import_iter = imports.iter().peekable();
     for (kind, span) in tokens {
+        while let Some(next) = import_iter.peek() {
+            if span.start >= next.end {
+                import_iter.next();
+            } else {
+                break;
+            }
+        }
+        if import_iter
+            .peek()
+            .is_some_and(|current| span.start == current.start)
+        {
+            builder.start_node(DdlogLanguage::kind_to_raw(SyntaxKind::N_IMPORT_STMT));
+        }
         let text = src.get(span.clone()).map_or_else(
             || {
                 warn!(
@@ -107,6 +131,13 @@ fn build_green_tree(tokens: Vec<(SyntaxKind, Span)>, src: &str) -> GreenNode {
             builder.finish_node();
         } else {
             builder.token(DdlogLanguage::kind_to_raw(kind), text);
+        }
+        if import_iter
+            .peek()
+            .is_some_and(|current| span.end >= current.end)
+        {
+            builder.finish_node();
+            import_iter.next();
         }
     }
     builder.finish_node();
@@ -164,6 +195,67 @@ pub mod ast {
         #[must_use]
         pub fn text(&self) -> String {
             self.syntax.text().to_string()
+        }
+
+        /// Collect all `import` statements under this root.
+        #[must_use]
+        pub fn imports(&self) -> Vec<Import> {
+            self.syntax
+                .children()
+                .filter(|n| n.kind() == SyntaxKind::N_IMPORT_STMT)
+                .map(|syntax| Import { syntax })
+                .collect()
+        }
+    }
+
+    /// Typed wrapper for an `import` statement.
+    #[derive(Debug, Clone)]
+    pub struct Import {
+        pub(crate) syntax: SyntaxNode<DdlogLanguage>,
+    }
+
+    impl Import {
+        /// Access the underlying syntax node.
+        #[must_use]
+        pub fn syntax(&self) -> &SyntaxNode<DdlogLanguage> {
+            &self.syntax
+        }
+
+        /// The module path text as written in the source.
+        #[must_use]
+        pub fn path(&self) -> String {
+            let mut capture = false;
+            let mut out = String::new();
+            for element in self.syntax.children_with_tokens() {
+                if let rowan::NodeOrToken::Token(tok) = element {
+                    match tok.kind() {
+                        SyntaxKind::K_IMPORT => capture = true,
+                        SyntaxKind::K_AS => break,
+                        _ => {
+                            if capture {
+                                out.push_str(tok.text());
+                            }
+                        }
+                    }
+                }
+            }
+            out.trim().to_string()
+        }
+
+        /// The alias assigned with `as`, if any.
+        #[must_use]
+        pub fn alias(&self) -> Option<String> {
+            let mut seen_as = false;
+            for element in self.syntax.children_with_tokens() {
+                if let rowan::NodeOrToken::Token(tok) = element {
+                    match tok.kind() {
+                        SyntaxKind::K_AS => seen_as = true,
+                        SyntaxKind::T_IDENT if seen_as => return Some(tok.text().to_string()),
+                        _ => {}
+                    }
+                }
+            }
+            None
         }
     }
 }

--- a/tests/parser.rs
+++ b/tests/parser.rs
@@ -73,3 +73,40 @@ fn error_token_produces_error_node() {
         .any(|node| node.kind() == SyntaxKind::N_ERROR);
     assert!(has_error);
 }
+
+#[rstest]
+fn import_statement_standard_case() {
+    let src = "import standard_library";
+    let parsed = parse(src);
+    assert!(parsed.errors().is_empty());
+    let imports = parsed.root().imports();
+    assert_eq!(imports.len(), 1);
+    let Some(imp) = imports.first() else {
+        panic!("expected import");
+    };
+    assert_eq!(imp.path(), "standard_library");
+    assert!(imp.alias().is_none());
+}
+
+#[rstest]
+fn import_statement_with_alias() {
+    let src = "import collections::vector as vec";
+    let parsed = parse(src);
+    assert!(parsed.errors().is_empty());
+    let imports = parsed.root().imports();
+    assert_eq!(imports.len(), 1);
+    let Some(imp) = imports.first() else {
+        panic!("expected import");
+    };
+    assert_eq!(imp.path(), "collections::vector");
+    assert_eq!(imp.alias(), Some("vec".to_string()));
+}
+
+#[rstest]
+fn import_statement_invalid_missing_path() {
+    let src = "import as missing_path";
+    let parsed = parse(src);
+    assert!(!parsed.errors().is_empty());
+    let imports = parsed.root().imports();
+    assert!(imports.is_empty());
+}

--- a/tests/parser.rs
+++ b/tests/parser.rs
@@ -4,7 +4,7 @@
 //! property holds for simple inputs. Grammar-specific assertions will be added
 //! once the parser rules are implemented.
 
-use ddlint::{SyntaxKind, parse};
+use ddlint::{SyntaxKind, ast::Import, parse};
 use rstest::{fixture, rstest};
 
 /// Collect the text of a syntax subtree.
@@ -104,9 +104,54 @@ fn import_statement_with_alias() {
 
 #[rstest]
 fn import_statement_invalid_missing_path() {
+    use chumsky::error::SimpleReason;
+
     let src = "import as missing_path";
     let parsed = parse(src);
-    assert!(!parsed.errors().is_empty());
+    let errors = parsed.errors();
+    assert_eq!(errors.len(), 1);
+    let Some(error) = errors.first() else {
+        panic!("expected error");
+    };
+    assert!(matches!(error.reason(), SimpleReason::Unexpected));
+    assert!(
+        error
+            .expected()
+            .any(|e| e.as_ref().is_some_and(|k| *k == SyntaxKind::T_IDENT))
+    );
+    assert_eq!(error.found(), Some(&SyntaxKind::K_AS));
     let imports = parsed.root().imports();
     assert!(imports.is_empty());
+}
+
+#[rstest]
+fn import_statement_multi_segment() {
+    let src = "import foo::bar::baz";
+    let parsed = parse(src);
+    assert!(parsed.errors().is_empty());
+    let paths: Vec<_> = parsed.root().imports().iter().map(Import::path).collect();
+    assert_eq!(paths, ["foo::bar::baz"]);
+}
+
+#[rstest]
+fn import_statement_whitespace_variations() {
+    let src = "  import  foo  as  f  ";
+    let parsed = parse(src);
+    assert!(parsed.errors().is_empty());
+    let imports = parsed.root().imports();
+    let Some(imp) = imports.first() else {
+        panic!("expected import");
+    };
+    assert_eq!(imp.path(), "foo");
+    assert_eq!(imp.alias(), Some("f".into()));
+}
+
+#[rstest]
+fn import_multiple_statements() {
+    let src = "import a\nimport b as c";
+    let parsed = parse(src);
+    assert!(parsed.errors().is_empty());
+    let imports = parsed.root().imports();
+    let paths: Vec<_> = imports.iter().map(|i| (i.path(), i.alias())).collect();
+    assert_eq!(paths, [("a".into(), None), ("b".into(), Some("c".into()))]);
 }


### PR DESCRIPTION
## Summary
- recognise `import` statements with optional aliases
- represent import declarations with a new syntax node
- expose typed `Import` nodes from the AST
- add tests for valid and invalid import syntax
- align docs with markdownlint

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_685c87ad564483229c5578b4c71e1094

## Summary by Sourcery

Implement import statement parsing with AST support, tests, and updated documentation

New Features:
- Recognize and parse import statements with optional aliases into the AST
- Expose typed Import nodes with path() and alias() accessors
- Provide Root.imports() method to collect import statements

Enhancements:
- Annotate import spans in the green tree builder and rename SyntaxKind::N_IMPORT to N_IMPORT_STMT
- Refactor parser combinators to specifically handle import syntax
- Revise Markdown docs and testing guide formatting for markdownlint compliance

Documentation:
- Update parser and testing documentation with improved headings, bullet lists, and formatting adjustments

Tests:
- Add tests for standard, aliased, and invalid import statements