### PR TITLE
Implement import parsing

### DIFF
--- a/src/language.rs
+++ b/src/language.rs
@@ -162,7 +162,7 @@ pub enum SyntaxKind {
     N_HO_FIELD,
     N_TRANSFORMER,
     N_APPLY,
-    N_IMPORT,
+    N_IMPORT_STMT,
     N_DATALOG_PROGRAM,
     // Special
     N_ERROR,

--- a/tests/parser.rs
+++ b/tests/parser.rs
@@ -73,3 +73,17 @@ fn error_token_produces_error_node() {
         .any(|node| node.kind() == SyntaxKind::N_ERROR);
     assert!(has_error);
 }
+
+#[fixture]
+fn import_prog() -> &'static str {
+    "import foo;"
+}
+
+#[rstest]
+fn import_item_parsed(import_prog: &str) {
+    let parsed = parse(import_prog);
+    assert!(matches!(
+        parsed.items().first(),
+        Some(ddlint::parser::ast::Item::Import(i)) if i.module == "foo"
+    ));
+}


### PR DESCRIPTION
## Summary
- add `N_IMPORT_STMT` syntax kind
- parse simple `import` statements with whitespace support
- expose import AST items
- add parser unit tests and update integration tests

## Testing
- `make fmt` *(fails: markdownlint errors)*
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_685c87f279b0832280865bab2c84a4cc