### PR TITLE
Implement typedef and extern type parser

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -13,6 +13,19 @@ use rowan::{GreenNode, GreenNodeBuilder, Language};
 
 use crate::{DdlogLanguage, Span, SyntaxKind, tokenize};
 
+macro_rules! token_dispatch {
+    ( $state:ident, $tokens:ident, {
+        $( $kind:path => $handler:ident ),* $(,)?
+    } ) => {{
+        while let Some((kind, span)) = $tokens.get($state.i).cloned() {
+            match kind {
+                $( $kind => $handler(&mut $state, span), )*
+                _ => $state.i += 1,
+            }
+        }
+    }};
+}
+
 /// Result of a parse operation.
 #[derive(Debug)]
 pub struct Parsed {
@@ -49,9 +62,9 @@ impl Parsed {
 #[must_use]
 pub fn parse(src: &str) -> Parsed {
     let tokens = tokenize(src);
-    let (import_spans, errors) = parse_tokens(&tokens, src.len());
+    let (import_spans, typedef_spans, errors) = parse_tokens(&tokens, src.len(), src);
 
-    let green = build_green_tree(tokens, src, &import_spans);
+    let green = build_green_tree(tokens, src, &import_spans, &typedef_spans);
     let root = ast::Root::from_green(green.clone());
 
     Parsed {
@@ -61,99 +74,252 @@ pub fn parse(src: &str) -> Parsed {
     }
 }
 
-fn parse_tokens(tokens: &[(SyntaxKind, Span)], len: usize) -> (Vec<Span>, Vec<Simple<SyntaxKind>>) {
-    let stream = Stream::from_iter(0..len, tokens.iter().cloned());
+fn parse_tokens(
+    tokens: &[(SyntaxKind, Span)],
+    len: usize,
+    src: &str,
+) -> (Vec<Span>, Vec<Span>, Vec<Simple<SyntaxKind>>) {
+    let (import_spans, errors) = collect_import_spans(tokens, len);
+    let typedef_spans = collect_typedef_spans(tokens, src);
 
-    let ws = filter(|kind: &SyntaxKind| {
-        matches!(kind, SyntaxKind::T_WHITESPACE | SyntaxKind::T_COMMENT)
-    })
-    .ignored();
-
-    let ident = just(SyntaxKind::T_IDENT).ignored().padded_by(ws.repeated());
-
-    let module_path = ident
-        .then(
-            just(SyntaxKind::T_COLON_COLON)
-                .padded_by(ws.repeated())
-                .ignore_then(ident)
-                .repeated(),
-        )
-        .ignored();
-
-    let alias = just(SyntaxKind::K_AS)
-        .padded_by(ws.repeated())
-        .ignore_then(ident);
-
-    let imprt = just(SyntaxKind::K_IMPORT)
-        .padded_by(ws.repeated())
-        .ignore_then(module_path)
-        .then(alias.or_not())
-        .padded_by(ws.repeated())
-        .map_with_span(|_, span| span);
-
-    let parser = imprt.repeated().then_ignore(end());
-    let (res, errors) = parser.parse_recovery(stream);
-    (res.unwrap_or_default(), errors)
+    (import_spans, typedef_spans, errors)
 }
 
-fn build_green_tree(tokens: Vec<(SyntaxKind, Span)>, src: &str, imports: &[Span]) -> GreenNode {
-    let mut builder = GreenNodeBuilder::new();
-    builder.start_node(DdlogLanguage::kind_to_raw(SyntaxKind::N_DATALOG_PROGRAM));
-    // Iterator over the spans recorded for each `import` statement.  Each span
-    // covers the entire statement so we can nest tokens inside an
-    // `N_IMPORT_STMT` node while building the CST.
-    let mut import_iter = imports.iter().peekable();
-    for (kind, span) in tokens {
-        // Advance to the next import span if this token lies after the end of
-        // the current one.  Multiple tokens can share the same span, so we need
-        // to skip spans that have already been closed.
-        while let Some(next) = import_iter.peek() {
-            if span.start >= next.end {
-                import_iter.next();
-            } else {
-                break;
-            }
-        }
-        // Begin an `N_IMPORT_STMT` node when this token marks the start of an
-        // import span. Tokens emitted by the lexer appear in order, so equality
-        // is sufficient here.
-        if import_iter
-            .peek()
-            .is_some_and(|current| span.start == current.start)
-        {
-            builder.start_node(DdlogLanguage::kind_to_raw(SyntaxKind::N_IMPORT_STMT));
-        }
-        let text = src.get(span.clone()).map_or_else(
-            || {
-                warn!(
-                    "token span {:?} out of bounds for source of length {}",
-                    span,
-                    src.len()
-                );
-                ""
-            },
-            |t| t,
-        );
-        if kind == SyntaxKind::N_ERROR {
-            builder.start_node(DdlogLanguage::kind_to_raw(SyntaxKind::N_ERROR));
-            builder.token(DdlogLanguage::kind_to_raw(kind), text);
-            builder.finish_node();
+fn skip_tokens_until(offset: &mut usize, tokens: &[(SyntaxKind, Span)], end: usize) {
+    while let Some(span) = tokens.get(*offset).map(|t| &t.1) {
+        if span.end <= end {
+            *offset += 1;
         } else {
-            builder.token(DdlogLanguage::kind_to_raw(kind), text);
-        }
-        // Close an `N_IMPORT_STMT` when this token reaches or passes the end of
-        // the active import span. Tokens can span multiple characters and may
-        // end exactly on the boundary, so we use `>=` rather than equality.
-        if import_iter
-            .peek()
-            .is_some_and(|current| span.end >= current.end)
-        {
-            builder.finish_node();
-            import_iter.next();
+            break;
         }
     }
+}
+
+fn line_end(tokens: &[(SyntaxKind, Span)], src: &str, start: usize) -> usize {
+    let mut end = tokens.get(start).map_or(0, |t| t.1.end);
+    for tok in tokens.iter().skip(start) {
+        end = tok.1.end;
+        let text = src.get(tok.1.clone()).unwrap_or("");
+        if text.contains('\n') {
+            break;
+        }
+    }
+    end
+}
+
+fn skip_ws_no_newline(tokens: &[(SyntaxKind, Span)], src: &str, index: &mut usize) {
+    while let Some(tok) = tokens.get(*index) {
+        if matches!(tok.0, SyntaxKind::T_WHITESPACE | SyntaxKind::T_COMMENT)
+            && !src.get(tok.1.clone()).unwrap_or("").contains('\n')
+        {
+            *index += 1;
+            continue;
+        }
+        break;
+    }
+}
+
+fn collect_import_spans(
+    tokens: &[(SyntaxKind, Span)],
+    len: usize,
+) -> (Vec<Span>, Vec<Simple<SyntaxKind>>) {
+    struct State<'a> {
+        i: usize,
+        spans: Vec<Span>,
+        errors: Vec<Simple<SyntaxKind>>,
+        tokens: &'a [(SyntaxKind, Span)],
+        len: usize,
+    }
+
+    fn handle_import(st: &mut State<'_>, span: Span) {
+        let ws = filter(|kind: &SyntaxKind| {
+            matches!(kind, SyntaxKind::T_WHITESPACE | SyntaxKind::T_COMMENT)
+        })
+        .ignored();
+
+        let ident = just(SyntaxKind::T_IDENT).ignored().padded_by(ws.repeated());
+
+        let module_path = ident
+            .then(
+                just(SyntaxKind::T_COLON_COLON)
+                    .padded_by(ws.repeated())
+                    .ignore_then(ident)
+                    .repeated(),
+            )
+            .ignored();
+
+        let alias = just(SyntaxKind::K_AS)
+            .padded_by(ws.repeated())
+            .ignore_then(ident);
+
+        let imprt = just(SyntaxKind::K_IMPORT)
+            .padded_by(ws.repeated())
+            .ignore_then(module_path)
+            .then(alias.or_not())
+            .padded_by(ws.repeated())
+            .map_with_span(|_, sp: Span| sp);
+
+        let iter = st.tokens.iter().skip(st.i).cloned();
+        let sub_stream = Stream::from_iter(span.start..st.len, iter);
+        let (res, err) = imprt.parse_recovery(sub_stream);
+        if let Some(sp) = res {
+            st.spans.push(sp.clone());
+            skip_tokens_until(&mut st.i, st.tokens, sp.end);
+        } else {
+            st.errors.extend(err);
+            st.i += 1;
+        }
+    }
+
+    let mut st = State {
+        i: 0,
+        spans: Vec::new(),
+        errors: Vec::new(),
+        tokens,
+        len,
+    };
+
+    token_dispatch!(st, tokens, {
+        SyntaxKind::K_IMPORT => handle_import,
+    });
+
+    (st.spans, st.errors)
+}
+
+fn collect_typedef_spans(tokens: &[(SyntaxKind, Span)], src: &str) -> Vec<Span> {
+    struct State<'a> {
+        i: usize,
+        spans: Vec<Span>,
+        tokens: &'a [(SyntaxKind, Span)],
+        src: &'a str,
+    }
+
+    fn handle_typedef(st: &mut State<'_>, span: Span) {
+        let start = span.start;
+        st.i += 1;
+        let end = line_end(st.tokens, st.src, st.i);
+        skip_tokens_until(&mut st.i, st.tokens, end);
+        st.spans.push(start..end);
+    }
+
+    fn handle_extern(st: &mut State<'_>, span: Span) {
+        let start = span.start;
+        st.i += 1;
+        skip_ws_no_newline(st.tokens, st.src, &mut st.i);
+        if let Some((SyntaxKind::K_TYPE, _)) = st.tokens.get(st.i).cloned() {
+            st.i += 1;
+            let end = line_end(st.tokens, st.src, st.i);
+            skip_tokens_until(&mut st.i, st.tokens, end);
+            st.spans.push(start..end);
+        }
+    }
+
+    let mut st = State {
+        i: 0,
+        spans: Vec::new(),
+        tokens,
+        src,
+    };
+
+    token_dispatch!(st, tokens, {
+        SyntaxKind::K_TYPEDEF => handle_typedef,
+        SyntaxKind::K_EXTERN => handle_extern,
+    });
+
+    st.spans
+}
+
+fn build_green_tree(
+    tokens: Vec<(SyntaxKind, Span)>,
+    src: &str,
+    imports: &[Span],
+    typedefs: &[Span],
+) -> GreenNode {
+    let mut builder = GreenNodeBuilder::new();
+    builder.start_node(DdlogLanguage::kind_to_raw(SyntaxKind::N_DATALOG_PROGRAM));
+
+    let mut import_iter = imports.iter().peekable();
+    let mut typedef_iter = typedefs.iter().peekable();
+
+    for (kind, span) in tokens {
+        advance_span_iter(&mut import_iter, span.start);
+        advance_span_iter(&mut typedef_iter, span.start);
+
+        maybe_start(
+            &mut builder,
+            &mut import_iter,
+            span.start,
+            SyntaxKind::N_IMPORT_STMT,
+        );
+        maybe_start(
+            &mut builder,
+            &mut typedef_iter,
+            span.start,
+            SyntaxKind::N_TYPE_DEF,
+        );
+
+        push_token(&mut builder, kind, span.clone(), src);
+
+        maybe_finish(&mut builder, &mut import_iter, span.end);
+        maybe_finish(&mut builder, &mut typedef_iter, span.end);
+    }
+
     builder.finish_node();
     builder.finish()
+}
+
+fn advance_span_iter(iter: &mut std::iter::Peekable<std::slice::Iter<'_, Span>>, pos: usize) {
+    while let Some(next) = iter.peek() {
+        if pos >= next.end {
+            iter.next();
+        } else {
+            break;
+        }
+    }
+}
+
+fn maybe_start(
+    builder: &mut GreenNodeBuilder,
+    iter: &mut std::iter::Peekable<std::slice::Iter<Span>>,
+    pos: usize,
+    kind: SyntaxKind,
+) {
+    if iter.peek().is_some_and(|current| pos == current.start) {
+        builder.start_node(DdlogLanguage::kind_to_raw(kind));
+    }
+}
+
+fn maybe_finish(
+    builder: &mut GreenNodeBuilder,
+    iter: &mut std::iter::Peekable<std::slice::Iter<Span>>,
+    pos: usize,
+) {
+    if iter.peek().is_some_and(|current| pos >= current.end) {
+        builder.finish_node();
+        iter.next();
+    }
+}
+
+fn push_token(builder: &mut GreenNodeBuilder, kind: SyntaxKind, span: Span, src: &str) {
+    let text = src.get(span.clone()).map_or_else(
+        || {
+            warn!(
+                "token span {:?} out of bounds for source of length {}",
+                span,
+                src.len()
+            );
+            ""
+        },
+        |t| t,
+    );
+
+    if kind == SyntaxKind::N_ERROR {
+        builder.start_node(DdlogLanguage::kind_to_raw(SyntaxKind::N_ERROR));
+        builder.token(DdlogLanguage::kind_to_raw(kind), text);
+        builder.finish_node();
+    } else {
+        builder.token(DdlogLanguage::kind_to_raw(kind), text);
+    }
 }
 
 pub mod ast {
@@ -218,6 +384,16 @@ pub mod ast {
                 .map(|syntax| Import { syntax })
                 .collect()
         }
+
+        /// Collect all `typedef` declarations under this root.
+        #[must_use]
+        pub fn type_defs(&self) -> Vec<TypeDef> {
+            self.syntax
+                .children()
+                .filter(|n| n.kind() == SyntaxKind::N_TYPE_DEF)
+                .map(|syntax| TypeDef { syntax })
+                .collect()
+        }
     }
 
     /// Typed wrapper for an `import` statement.
@@ -267,5 +443,108 @@ pub mod ast {
                     _ => None,
                 })
         }
+    }
+
+    /// Typed wrapper for a `typedef` or `extern type` declaration.
+    #[derive(Debug, Clone)]
+    pub struct TypeDef {
+        pub(crate) syntax: SyntaxNode<DdlogLanguage>,
+    }
+
+    impl TypeDef {
+        /// Access the underlying syntax node.
+        #[must_use]
+        pub fn syntax(&self) -> &SyntaxNode<DdlogLanguage> {
+            &self.syntax
+        }
+
+        /// Name of the defined type.
+        #[must_use]
+        pub fn name(&self) -> Option<String> {
+            let mut iter = self.syntax.children_with_tokens();
+            if !skip_to_keyword(&mut iter) {
+                return None;
+            }
+            take_first_ident(iter)
+        }
+
+        /// Whether this declaration is `extern`.
+        #[must_use]
+        pub fn is_extern(&self) -> bool {
+            self.syntax
+                .children_with_tokens()
+                .any(|e| e.kind() == SyntaxKind::K_EXTERN)
+        }
+    }
+
+    fn skip_to_keyword(
+        iter: &mut impl Iterator<Item = rowan::SyntaxElement<DdlogLanguage>>,
+    ) -> bool {
+        for e in iter.by_ref() {
+            let kind = e.kind();
+            if kind == SyntaxKind::K_EXTERN {
+                continue;
+            }
+            if matches!(kind, SyntaxKind::K_TYPEDEF | SyntaxKind::K_TYPE) {
+                return true;
+            }
+        }
+        false
+    }
+
+    fn take_first_ident(
+        iter: impl Iterator<Item = rowan::SyntaxElement<DdlogLanguage>>,
+    ) -> Option<String> {
+        use rowan::NodeOrToken;
+        for e in iter {
+            match e {
+                NodeOrToken::Token(t) if t.kind() == SyntaxKind::T_IDENT => {
+                    return Some(t.text().to_string());
+                }
+                NodeOrToken::Token(t)
+                    if matches!(t.kind(), SyntaxKind::T_WHITESPACE | SyntaxKind::T_COMMENT) => {}
+                _ => return None,
+            }
+        }
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tokenize;
+    use rstest::rstest;
+
+    #[rstest]
+    fn skip_tokens_until_advances_past_span() {
+        let src = "import foo\n";
+        let tokens = tokenize(src);
+        let mut idx = 0;
+        let end = line_end(&tokens, src, 0);
+        skip_tokens_until(&mut idx, &tokens, end);
+        assert_eq!(idx, tokens.len());
+    }
+
+    #[rstest]
+    fn line_end_returns_span_end() {
+        let src = "typedef A = string\nnext";
+        let tokens = tokenize(src);
+        let start = 1; // token after 'typedef'
+        let end = line_end(&tokens, src, start);
+        let newline = src.find('\n').unwrap_or_else(|| panic!("newline missing"));
+        assert_eq!(end, newline + 1);
+    }
+
+    #[rstest]
+    fn skip_ws_no_newline_skips_spaces() {
+        let src = "extern    type Foo";
+        let tokens = tokenize(src);
+        let mut idx = 1; // after 'extern'
+        skip_ws_no_newline(&tokens, src, &mut idx);
+        assert!(matches!(
+            tokens.get(idx).map(|t| t.0),
+            Some(SyntaxKind::K_TYPE)
+        ));
     }
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -16,13 +16,10 @@ use crate::{DdlogLanguage, Span, SyntaxKind, tokenize};
 /// Iterate over tokens and dispatch to a handler based on the token kind.
 ///
 /// The macro loops until the token slice is exhausted, invoking the matching
-/// handler for each recognised `SyntaxKind`. Any token kinds not provided in the
-/// pattern cause the state's index to advance with no other action.
-/// Iterate over tokens and call a handler for each recognised kind.
-///
-/// The macro expects a state object that contains a `cursor` field tracking the
-/// current position in the token slice. Handlers mutate the state to consume
-/// tokens. Any unhandled kind simply advances the cursor by one.
+/// handler for each recognised `SyntaxKind`. It expects a state object that
+/// contains a `cursor` field tracking the current position in the token slice.
+/// Handlers mutate the state to consume tokens. Any unhandled kind simply
+/// advances the cursor by one.
 ///
 /// # Examples
 ///

--- a/tests/parser.rs
+++ b/tests/parser.rs
@@ -155,3 +155,103 @@ fn import_multiple_statements() {
     let paths: Vec<_> = imports.iter().map(|i| (i.path(), i.alias())).collect();
     assert_eq!(paths, [("a".into(), None), ("b".into(), Some("c".into()))]);
 }
+
+#[rstest]
+fn standard_typedef() {
+    let src = "typedef Uuid = string\n";
+    let parsed = parse(src);
+    assert!(parsed.errors().is_empty());
+    let defs = parsed.root().type_defs();
+    assert_eq!(defs.len(), 1);
+    let def = defs.first().unwrap_or_else(|| panic!("typedef not found"));
+    assert_eq!(def.name(), Some("Uuid".into()));
+    assert!(!def.is_extern());
+}
+
+#[rstest]
+fn complex_typedef() {
+    let src = "typedef UserRecord = (name: string, age: u64, active: bool)\n";
+    let parsed = parse(src);
+    assert!(parsed.errors().is_empty());
+    let defs = parsed.root().type_defs();
+    assert_eq!(defs.len(), 1);
+    let def = defs.first().unwrap_or_else(|| panic!("typedef not found"));
+    assert_eq!(def.name(), Some("UserRecord".into()));
+    assert!(!def.is_extern());
+}
+
+#[rstest]
+fn extern_type() {
+    let src = "extern type FfiHandle\n";
+    let parsed = parse(src);
+    assert!(parsed.errors().is_empty());
+    let defs = parsed.root().type_defs();
+    assert_eq!(defs.len(), 1);
+    let def = defs.first().unwrap_or_else(|| panic!("typedef not found"));
+    assert_eq!(def.name(), Some("FfiHandle".into()));
+    assert!(def.is_extern());
+}
+
+#[rstest]
+#[case("typedef Uuid = string\n", "Uuid", false, "typedef Uuid = string\n")]
+#[case("typedef Foo=bar\n", "Foo", false, "typedef Foo=bar\n")]
+#[case(
+    "typedef Record = (name: string, active: bool)\n",
+    "Record",
+    false,
+    "typedef Record = (name: string, active: bool)\n"
+)]
+#[case("extern type Handle\n", "Handle", true, "extern type Handle\n")]
+#[case("extern type  Extra  \n", "Extra", true, "extern type  Extra  \n")]
+fn typedef_variations(
+    #[case] src: &str,
+    #[case] expected: &str,
+    #[case] is_extern: bool,
+    #[case] expected_text: &str,
+) {
+    let parsed = parse(src);
+    assert!(parsed.errors().is_empty());
+    let defs = parsed.root().type_defs();
+    assert_eq!(defs.len(), 1);
+    let def = defs
+        .first()
+        .unwrap_or_else(|| panic!("typedef should exist for valid source"));
+    assert_eq!(def.name(), Some(expected.to_string()));
+    assert_eq!(def.is_extern(), is_extern);
+    let text = pretty_print(def.syntax());
+    assert_eq!(text, expected_text);
+}
+
+#[test]
+fn typedef_nesting_and_whitespace() {
+    let src = "typedef Foo=string\ntypedef   Bar = u64  \n";
+    let parsed = parse(src);
+    assert!(parsed.errors().is_empty());
+    assert_eq!(pretty_print(parsed.root().syntax()), src);
+    let defs = parsed.root().type_defs();
+    assert_eq!(defs.len(), 2);
+    let first = defs
+        .first()
+        .unwrap_or_else(|| panic!("first typedef missing"));
+    let second = defs
+        .get(1)
+        .unwrap_or_else(|| panic!("second typedef missing"));
+    assert_eq!(pretty_print(first.syntax()), "typedef Foo=string\n");
+    assert_eq!(pretty_print(second.syntax()), "typedef   Bar = u64  \n");
+    let first_end = first.syntax().text_range().end();
+    let second_start = second.syntax().text_range().start();
+    assert!(first_end <= second_start);
+}
+
+#[test]
+fn typedef_missing_name_returns_none() {
+    let src = "typedef = string\n";
+    let parsed = parse(src);
+    assert!(parsed.errors().is_empty());
+    let defs = parsed.root().type_defs();
+    assert_eq!(defs.len(), 1);
+    let def = defs
+        .first()
+        .unwrap_or_else(|| panic!("typedef span exists"));
+    assert_eq!(def.name(), None);
+}


### PR DESCRIPTION
## Summary
- introduce `token_dispatch!` for looping over tokens
- refactor `collect_import_spans` and `collect_typedef_spans` to use new macro

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_685db5653c088322bf9e501b9bd65850

## Summary by Sourcery

Implement parsing for `typedef` and `extern type` statements alongside existing `import` parsing by introducing a reusable token dispatch macro, refactoring span collection, extending the CST builder to group typedef spans, and enriching the AST with a new `TypeDef` node; bolster coverage with targeted unit tests.

New Features:
- Add support for parsing `typedef` and `extern type` declarations and collect their spans
- Introduce a `TypeDef` AST node with methods to retrieve the defined type’s name and extern flag

Enhancements:
- Introduce `token_dispatch!` macro to unify token scanning across import and typedef span collectors
- Refactor import span collection and CST builder to leverage generic dispatch for both import and typedef spans
- Extend CST construction to wrap typedef spans into `N_TYPE_DEF` nodes and validate sorted spans
- Add helper functions (`skip_tokens_until`, `line_end`, `skip_ws_no_newline`, etc.) for improved single-line parsing and span management

Tests:
- Add comprehensive tests for typedef and extern type parsing, including edge cases and error recovery
- Add a test to verify import error recovery followed by valid import parsing