### PR TITLE
Add logger setup guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,5 +16,5 @@ fn main() {
 }
 ```
 
-Control the verbosity with the `RUST_LOG` environment variable. For example,
-`RUST_LOG=warn` will show warnings.
+Control the verbosity with the `RUST_LOG` environment variable. For example, you
+can set `RUST_LOG=warn` to display warnings.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,19 @@
 # Differential Datalog Linter (ddlint)
 
 This is a generated project using [Copier](https://copier.readthedocs.io/).
+
+## Logging
+
+`ddlint` uses the [`log`](https://docs.rs/log/) crate to emit parser warnings.
+Initialise a logger in your `main` function to display these messages. The
+[`env_logger`](https://docs.rs/env_logger/) crate is a simple option:
+
+```rust
+fn main() {
+    env_logger::init();
+    // run ddlint or your integration here
+}
+```
+
+Control the verbosity with the `RUST_LOG` environment variable. For example,
+`RUST_LOG=warn` will show warnings.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Initialise a logger in your `main` function to display these messages. The
 
 ```rust
 fn main() {
+    // Cargo.toml: env_logger = "0.11"
     env_logger::init();
     // run ddlint or your integration here
 }

--- a/docs/ddlint-design-and-road-map.md
+++ b/docs/ddlint-design-and-road-map.md
@@ -558,6 +558,7 @@ routine early in `main` to surface these messages. One convenient option is
 
 ```rust
 fn main() {
+    // Cargo.toml: env_logger = "0.11"
     env_logger::init();
     // run ddlint or your application logic
 }

--- a/docs/ddlint-design-and-road-map.md
+++ b/docs/ddlint-design-and-road-map.md
@@ -549,6 +549,23 @@ This schema provides a clear and powerful way for users to tailor the linter's
 behavior to their project's specific needs, from disabling entire classes of
 rules to fine-tuning the parameters of stylistic checks.
 
+### 4.4. Logging
+
+The parser emits warnings using the [`log`](https://docs.rs/log/) crate. No
+logger is initialised by default. A consuming binary should call a logger setup
+routine early in `main` to surface these messages. One convenient option is
+[`env_logger`](https://docs.rs/env_logger/):
+
+```rust
+fn main() {
+    env_logger::init();
+    // run ddlint or your application logic
+}
+```
+
+Set the `RUST_LOG` environment variable to control verbosity. For example,
+`RUST_LOG=warn` will display warnings while suppressing debug output.
+
 ## V. Advanced Features: Diagnostics and Automated Fixes
 
 The core value of a linter is delivered through its diagnostics and its ability

--- a/docs/ddlint-design-and-road-map.md
+++ b/docs/ddlint-design-and-road-map.md
@@ -564,8 +564,8 @@ fn main() {
 }
 ```
 
-Set the `RUST_LOG` environment variable to control verbosity. For example,
-`RUST_LOG=warn` will display warnings while suppressing debug output.
+Set the `RUST_LOG` environment variable to control verbosity. For example, you
+can set `RUST_LOG=warn` to display warnings while suppressing debug output.
 
 ## V. Advanced Features: Diagnostics and Automated Fixes
 


### PR DESCRIPTION
## Summary
- document how to initialise logging in `README`
- describe logging configuration in the design doc

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make markdownlint`


------
https://chatgpt.com/codex/tasks/task_e_685f54bd26ec8322b3afd42370d7d8d3

## Summary by Sourcery

Document how to initialize and configure logging for parser warnings using the log and env_logger crates.

Documentation:
- Add a logging section to the design doc explaining how to set up a logger and use the RUST_LOG environment variable.
- Add a Logging section to the README with instructions for initializing env_logger and controlling verbosity via RUST_LOG.