### PR TITLE
Add SpanCollector tests

### DIFF
--- a/src/parser/span_collector.rs
+++ b/src/parser/span_collector.rs
@@ -55,3 +55,31 @@ impl<'a, Extra> SpanCollector<'a, Extra> {
         (self.spans, self.extra)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+
+    #[rstest]
+    fn new_initialises_stream_and_state() {
+        let src = "import foo";
+        let tokens = crate::tokenize(src);
+        let collector = SpanCollector::new(&tokens, src, ());
+        assert_eq!(collector.stream.cursor(), 0);
+        assert_eq!(collector.stream.tokens(), tokens.as_slice());
+        assert_eq!(collector.stream.src(), src);
+        assert!(collector.spans.is_empty());
+    }
+
+    #[test]
+    fn into_parts_returns_collected_spans_and_extra() {
+        let src = "input";
+        let tokens = crate::tokenize(src);
+        let mut collector = SpanCollector::new(&tokens, src, 99u8);
+        collector.spans.push(0..5);
+        let (spans, extra) = collector.into_parts();
+        assert_eq!(spans, vec![0..5]);
+        assert_eq!(extra, 99);
+    }
+}

--- a/src/parser/span_collector.rs
+++ b/src/parser/span_collector.rs
@@ -58,11 +58,16 @@ impl<'a, Extra> SpanCollector<'a, Extra> {
 
 #[cfg(test)]
 mod tests {
+    //! Tests for `SpanCollector` using the `TokenStream` abstraction.
+    //!
+    //! These tests validate that the collector exposes its token stream
+    //! correctly and that extra state can be retrieved without consuming the
+    //! collected spans.
     use super::*;
     use rstest::rstest;
 
     #[rstest]
-    fn new_initialises_stream_and_state() {
+    fn new_initialises_state() {
         let src = "import foo";
         let tokens = crate::tokenize(src);
         let collector = SpanCollector::new(&tokens, src, ());


### PR DESCRIPTION
## Summary
- add unit tests for SpanCollector

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_685fdacd5ce88322a1bfdbcb7e28684f

## Summary by Sourcery

Add unit tests for SpanCollector to verify its initialization and into_parts behavior

Tests:
- Verify that SpanCollector::new correctly initializes the stream cursor, tokens, source, and empty spans
- Verify that SpanCollector::into_parts returns the collected spans and extra data