### PR TITLE
Implement relation parser

### DIFF
--- a/src/language.rs
+++ b/src/language.rs
@@ -142,6 +142,7 @@ pub enum SyntaxKind {
     N_IDENTIFIER_WITH_POS,
     N_TYPE,
     N_TYPE_DEF,
+    N_RELATION_DECL,
     N_CONSTRUCTOR,
     N_KEY_EXPR,
     N_RELATION_ROLE,


### PR DESCRIPTION
## Summary
- parse relation declarations
- handle input, output and internal relation spans
- build CST `N_RELATION_DECL` nodes
- expose typed `Relation` wrappers with helpers
- test relation parsing for various cases

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets --all-features`


------
https://chatgpt.com/codex/tasks/task_e_6860946763f88322b755ad3f05e05179

## Summary by Sourcery

Implement parsing of relation declarations and expose them in the CST and AST with helpers.

New Features:
- Extend token parsing to collect spans for input, output, and internal relation declarations
- Update CST builder to include N_RELATION_DECL nodes for relation spans
- Introduce Relation AST type with helpers for name, input/output flags, columns, and primary key extraction

Tests:
- Add fixtures and tests for parsing input, output, and internal relations, including primary key handling