### PR TITLE
Add parser test for index whitespace formatting

### DIFF
--- a/tests/parser.rs
+++ b/tests/parser.rs
@@ -97,6 +97,11 @@ fn index_unbalanced_parentheses() -> &'static str {
     "index Idx_Unbalanced on User(lower(username)"
 }
 
+#[fixture]
+fn index_whitespace_variations() -> &'static str {
+    "  index  Idx_User_ws \t on\n  User (\n    username  )  "
+}
+
 /// Verifies that parsing and pretty-printing preserves the original input text
 /// and produces the expected root node kind.
 #[rstest]
@@ -482,4 +487,19 @@ fn index_unbalanced_parentheses_is_error(index_unbalanced_parentheses: &str) {
     let parsed = parse(index_unbalanced_parentheses);
     assert!(!parsed.errors().is_empty());
     assert!(parsed.root().indexes().is_empty());
+}
+
+#[rstest]
+fn index_declaration_whitespace_variations() {
+    let src = "  index  Idx_User_ws \t on\n  User (\n    username  )  ";
+    let parsed = parse(src);
+    assert!(parsed.errors().is_empty());
+    assert_eq!(pretty_print(parsed.root().syntax()), src);
+    let indexes = parsed.root().indexes();
+    let Some(idx) = indexes.first() else {
+        panic!("expected index");
+    };
+    assert_eq!(idx.name(), Some("Idx_User_ws".into()));
+    assert_eq!(idx.relation(), Some("User".into()));
+    assert_eq!(idx.columns(), vec![String::from("username")]);
 }


### PR DESCRIPTION
## Summary
- add a fixture for whitespace-heavy index syntax
- cover whitespace variations for index declarations

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6861b9a5a0088322a8b0bd93c1d67524