### PR TITLE
Add rule parser

### DIFF
--- a/docs/haskell-parser-analysis.md
+++ b/docs/haskell-parser-analysis.md
@@ -176,7 +176,16 @@ Other notable grammar rules include:
 - `index` — defines an index on a relation. The Rust port keeps the same grammar
   and supports nested parentheses within the column list.
 - `relation` – parses a relation declaration and its optional primary key.
-- `rule` – parses a rule head followed by an optional list of body clauses.
+- `rule` – parses a rule head followed by an optional list of body clauses. The
+  `rule` grammar in Haskell is succinct:
+
+```haskell
+rule = withPos $
+       Rule nopos <$> atom True
+                  <*> option [] (reservedOp "::-" *> commaSep1 literal)
+                  <*  dot
+```
+
 - `statement` and its helpers – parse imperative statements used within rules.
 - `expr` – an expression parser built via `buildExpressionParser`; it handles
   literals, operators and function calls.

--- a/tests/parser.rs
+++ b/tests/parser.rs
@@ -566,3 +566,53 @@ fn fact_rule_parsed(fact_rule: &str) {
     };
     assert_eq!(pretty_print(rule.syntax()), fact_rule);
 }
+
+#[test]
+fn invalid_rule_missing_head() {
+    let input = ":- User(user_id, username, _).";
+    let parsed = parse(input);
+    assert!(
+        !parsed.errors().is_empty(),
+        "Expected errors for missing head"
+    );
+}
+
+#[test]
+fn invalid_rule_missing_body() {
+    let input = "UserLogin(username, session_id) :- .";
+    let parsed = parse(input);
+    assert!(
+        !parsed.errors().is_empty(),
+        "Expected errors for missing body"
+    );
+}
+
+#[test]
+fn invalid_rule_no_colon_dash() {
+    let input = "UserLogin(username, session_id) User(user_id, username, _).";
+    let parsed = parse(input);
+    assert!(
+        !parsed.errors().is_empty(),
+        "Expected errors for missing ':-'"
+    );
+}
+
+#[test]
+fn invalid_rule_missing_period() {
+    let input = "UserLogin(username, session_id) :- User(user_id, username, _)";
+    let parsed = parse(input);
+    assert!(
+        !parsed.errors().is_empty(),
+        "Expected errors for missing period at end"
+    );
+}
+
+#[test]
+fn invalid_rule_garbage() {
+    let input = "This is not a rule!";
+    let parsed = parse(input);
+    assert!(
+        !parsed.errors().is_empty(),
+        "Expected errors for completely invalid input"
+    );
+}

--- a/tests/parser.rs
+++ b/tests/parser.rs
@@ -515,3 +515,54 @@ fn index_declaration_whitespace_variations(#[case] src: &str) {
     assert_eq!(idx.relation(), Some("User".into()));
     assert_eq!(idx.columns(), vec![String::from("username")]);
 }
+
+#[fixture]
+fn simple_rule() -> &'static str {
+    "ActiveUser(user_id) :- User(user_id, _, true)."
+}
+
+#[fixture]
+fn multi_literal_rule() -> &'static str {
+    "UserLogin(username, session_id) :- User(user_id, username, _), UserSession(user_id, session_id, _)."
+}
+
+#[fixture]
+fn fact_rule() -> &'static str {
+    "SystemAlert(\"System is now online.\")."
+}
+
+#[rstest]
+fn simple_rule_parsed(simple_rule: &str) {
+    let parsed = parse(simple_rule);
+    assert!(parsed.errors().is_empty());
+    let rules = parsed.root().rules();
+    assert_eq!(rules.len(), 1);
+    let Some(rule) = rules.first() else {
+        panic!("rule missing");
+    };
+    assert_eq!(pretty_print(rule.syntax()), simple_rule);
+}
+
+#[rstest]
+fn multi_literal_rule_parsed(multi_literal_rule: &str) {
+    let parsed = parse(multi_literal_rule);
+    assert!(parsed.errors().is_empty());
+    let rules = parsed.root().rules();
+    assert_eq!(rules.len(), 1);
+    let Some(rule) = rules.first() else {
+        panic!("rule missing");
+    };
+    assert_eq!(pretty_print(rule.syntax()), multi_literal_rule);
+}
+
+#[rstest]
+fn fact_rule_parsed(fact_rule: &str) {
+    let parsed = parse(fact_rule);
+    assert!(parsed.errors().is_empty());
+    let rules = parsed.root().rules();
+    assert_eq!(rules.len(), 1);
+    let Some(rule) = rules.first() else {
+        panic!("rule missing");
+    };
+    assert_eq!(pretty_print(rule.syntax()), fact_rule);
+}


### PR DESCRIPTION
## Summary
- implement span collection and CST node for rules
- expose `Root::rules` with new `Rule` AST type
- parse rules in `build_green_tree`
- test rule parsing for simple, multi-literal, and fact rules
- document rule grammar snippet in parser analysis

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make markdownlint`


------
https://chatgpt.com/codex/tasks/task_e_6861d1d0dc548322bc8413fbd7bcfff1

## Summary by Sourcery

Implement full support for parsing Datalog rules by collecting rule spans, integrating them into the CST and AST, and verifying correctness through new tests and documentation updates.

New Features:
- Add parsing support for Datalog rule declarations in the parser
- Introduce a new Rule AST node and expose Root::rules to retrieve parsed rules

Documentation:
- Document the rule grammar snippet in the parser analysis

Tests:
- Add unit tests for simple, multi-literal, and fact rule parsing