### PR TITLE
Add function parser

### DIFF
--- a/tests/parser.rs
+++ b/tests/parser.rs
@@ -111,6 +111,21 @@ fn index_whitespace_variations() -> &'static str {
     "  index  Idx_User_ws \t on\n  User (\n    username  )  "
 }
 
+#[fixture]
+fn extern_function() -> &'static str {
+    "extern function hash(data: string): u64"
+}
+
+#[fixture]
+fn function_with_body() -> &'static str {
+    "function to_uppercase(s: string): string { }"
+}
+
+#[fixture]
+fn function_no_return() -> &'static str {
+    "function log_message(msg: string) { }"
+}
+
 /// Verifies that parsing and pretty-printing preserves the original input text
 /// and produces the expected root node kind.
 #[rstest]
@@ -514,4 +529,43 @@ fn index_declaration_whitespace_variations(#[case] src: &str) {
     assert_eq!(idx.name(), Some("Idx_User_ws".into()));
     assert_eq!(idx.relation(), Some("User".into()));
     assert_eq!(idx.columns(), vec![String::from("username")]);
+}
+
+#[rstest]
+fn extern_function_parsed(extern_function: &str) {
+    let parsed = parse(extern_function);
+    assert!(parsed.errors().is_empty());
+    let funcs = parsed.root().functions();
+    assert_eq!(funcs.len(), 1);
+    let Some(func) = funcs.first() else {
+        panic!("function should exist");
+    };
+    assert_eq!(func.name(), Some("hash".into()));
+    assert!(func.is_extern());
+}
+
+#[rstest]
+fn function_with_body_parsed(function_with_body: &str) {
+    let parsed = parse(function_with_body);
+    assert!(parsed.errors().is_empty());
+    let funcs = parsed.root().functions();
+    assert_eq!(funcs.len(), 1);
+    let Some(func) = funcs.first() else {
+        panic!("function should exist");
+    };
+    assert_eq!(func.name(), Some("to_uppercase".into()));
+    assert!(!func.is_extern());
+}
+
+#[rstest]
+fn function_no_return_parsed(function_no_return: &str) {
+    let parsed = parse(function_no_return);
+    assert!(parsed.errors().is_empty());
+    let funcs = parsed.root().functions();
+    assert_eq!(funcs.len(), 1);
+    let Some(func) = funcs.first() else {
+        panic!("function should exist");
+    };
+    assert_eq!(func.name(), Some("log_message".into()));
+    assert!(!func.is_extern());
 }


### PR DESCRIPTION
## Summary
- add parser functions for `function` definitions
- handle `extern function` declarations
- group function spans into CST nodes and expose AST API
- test parsing of function declarations and definitions

## Testing
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68658f3302608322bc4aa1b58a621378

## Summary by Sourcery

Add support for parsing Datalog-style functions, including `extern function` declarations and regular function definitions, and expose them in the CST/AST.

New Features:
- Collect spans for `extern function` declarations and `function` definitions during token parsing.
- Extend the green-tree builder to include function nodes and integrate function spans into the parse pipeline.
- Introduce a typed `Function` AST node with `name()` and `is_extern()` methods and a `Root::functions()` accessor.

Enhancements:
- Extend `parse_tokens` and `build_green_tree` to handle function spans alongside imports, typedefs, relations, and indexes.

Tests:
- Add unit tests verifying parsing of extern functions, functions with bodies, and functions without return types.