### PR TITLE
Implement function parser

### DIFF
--- a/docs/function-parsing-design.md
+++ b/docs/function-parsing-design.md
@@ -1,0 +1,19 @@
+# Function Parsing Design
+
+This document outlines the strategy for parsing `function` definitions and
+declarations within `ddlint`. The parser relies on small helpers to interpret
+parameter lists and optional return types. These helpers are shared with
+relation parsing to avoid duplication.
+
+```mermaid
+classDiagram
+    class parse_name_type_pairs {
+        <<function>>
+    }
+    class parse_type_after_colon {
+        <<function>>
+    }
+    Function ..> parse_name_type_pairs : uses
+    Function ..> parse_type_after_colon : uses
+    Relation ..> parse_name_type_pairs : uses
+```

--- a/docs/parser-plan.md
+++ b/docs/parser-plan.md
@@ -67,6 +67,19 @@ sequenceDiagram
 The parser's final output is the AST root together with a `GreenNode` that
 contains the full CST.
 
+```mermaid
+sequenceDiagram
+    participant Parser
+    participant SpanCollector
+    participant CSTBuilder
+    participant ASTRoot
+    Parser->>SpanCollector: collect_function_spans(tokens, src)
+    SpanCollector-->>Parser: (function_spans, errors)
+    Parser->>CSTBuilder: build_green_tree(..., function_spans, ...)
+    CSTBuilder-->>ASTRoot: Root::from_green(green)
+    ASTRoot->>ASTRoot: functions() -> Vec<Function>
+```
+
 ## 5. Map CST Nodes to AST Structures
 
 Implement lightweight AST types that reference the CST. Each AST node should

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -690,26 +690,14 @@ fn collect_function_spans(
     }
 
     fn handle_func(st: &mut State<'_>, span: Span, is_extern: bool) {
-        if is_extern {
-            let mut idx = st.stream.cursor() + 1;
-            let tokens = st.stream.tokens();
-            while let Some(tok) = tokens.get(idx) {
-                if matches!(tok.0, SyntaxKind::T_WHITESPACE | SyntaxKind::T_COMMENT)
-                    && st
-                        .stream
-                        .src()
-                        .get(tok.1.clone())
-                        .is_some_and(|t| !t.contains('\n'))
-                {
-                    idx += 1;
-                } else {
-                    break;
-                }
-            }
-            if !matches!(tokens.get(idx), Some((SyntaxKind::K_FUNCTION, _))) {
-                st.skip_line();
-                return;
-            }
+        if is_extern
+            && !matches!(
+                st.stream.peek_after_ws_inline().map(|t| t.0),
+                Some(SyntaxKind::K_FUNCTION)
+            )
+        {
+            st.skip_line();
+            return;
         }
 
         let parser = if is_extern {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -12,6 +12,21 @@ use rowan::{GreenNode, GreenNodeBuilder, Language};
 
 use crate::{DdlogLanguage, Span, SyntaxKind, tokenize};
 
+fn token_display(kind: SyntaxKind) -> &'static str {
+    match kind {
+        SyntaxKind::T_LPAREN => "(",
+        SyntaxKind::T_RPAREN => ")",
+        SyntaxKind::T_LBRACE => "{",
+        SyntaxKind::T_RBRACE => "}",
+        SyntaxKind::T_LBRACKET => "[",
+        SyntaxKind::T_RBRACKET => "]",
+        SyntaxKind::T_COMMA => ",",
+        SyntaxKind::T_COLON => ":",
+        SyntaxKind::T_SEMI => ";",
+        _ => "",
+    }
+}
+
 mod token_stream;
 
 mod span_collector;
@@ -137,7 +152,10 @@ fn balanced_block_with_min(
                 }
                 k if k == close => {
                     if depth.get() == 0 {
-                        Err(Simple::custom(span, format!("unexpected '{close:?}'")))
+                        Err(Simple::custom(
+                            span,
+                            format!("unexpected '{}'", token_display(close)),
+                        ))
                     } else {
                         depth.set(depth.get() - 1);
                         Ok(())

--- a/src/parser/token_stream.rs
+++ b/src/parser/token_stream.rs
@@ -204,4 +204,27 @@ impl<'a> TokenStream<'a> {
             self.cursor += 1;
         }
     }
+
+    /// Peeks ahead to the next non-whitespace token on the same line.
+    ///
+    /// Skips inline whitespace and comments without modifying the cursor and
+    /// returns the first subsequent token. Tokens containing a newline end the
+    /// search.
+    #[must_use]
+    pub(crate) fn peek_after_ws_inline(&self) -> Option<&(SyntaxKind, Span)> {
+        let mut idx = self.cursor + 1;
+        while let Some(tok) = self.tokens.get(idx) {
+            if matches!(tok.0, SyntaxKind::T_WHITESPACE | SyntaxKind::T_COMMENT)
+                && self
+                    .src
+                    .get(tok.1.clone())
+                    .is_some_and(|text| !text.contains('\n'))
+            {
+                idx += 1;
+            } else {
+                break;
+            }
+        }
+        self.tokens.get(idx)
+    }
 }

--- a/tests/function_api.rs
+++ b/tests/function_api.rs
@@ -4,43 +4,44 @@
 //! and that the `Function` AST node provides the expected API methods.
 
 use ddlint::parser::parse;
+use rstest::rstest;
 
-#[test]
-#[expect(clippy::expect_used, reason = "Using expect for clearer test failures")]
-fn extern_function_api() {
-    let src = "extern function hash(data: string): u64\n";
+#[rstest]
+#[case(
+    "extern function hash(data: string): u64\n",
+    "hash",
+    true,
+    vec![("data".to_string(), "string".to_string())],
+    Some("u64".to_string()),
+)]
+#[case(
+    "function greet(name: string): string { }\n",
+    "greet",
+    false,
+    vec![("name".to_string(), "string".to_string())],
+    Some("string".to_string()),
+)]
+#[case(
+    "function log(msg: string) { }\n",
+    "log",
+    false,
+    vec![("msg".to_string(), "string".to_string())],
+    None,
+)]
+fn function_api(
+    #[case] src: &str,
+    #[case] name: &str,
+    #[case] is_extern: bool,
+    #[case] params: Vec<(String, String)>,
+    #[case] ret: Option<String>,
+) {
     let parsed = parse(src);
     assert!(parsed.errors().is_empty());
     let funcs = parsed.root().functions();
+    #[expect(clippy::expect_used, reason = "Using expect for clearer test failures")]
     let func = funcs.first().expect("function missing");
-    assert_eq!(func.name(), Some("hash".into()));
-    assert!(func.is_extern());
-    assert_eq!(func.parameters(), vec![("data".into(), "string".into())]);
-    assert_eq!(func.return_type(), Some("u64".into()));
-}
-
-#[test]
-#[expect(clippy::expect_used, reason = "Using expect for clearer test failures")]
-fn regular_function_api() {
-    let src = "function greet(name: string): string { }\n";
-    let parsed = parse(src);
-    assert!(parsed.errors().is_empty());
-    let funcs = parsed.root().functions();
-    let func = funcs.first().expect("function missing");
-    assert_eq!(func.name(), Some("greet".into()));
-    assert!(!func.is_extern());
-    assert_eq!(func.parameters(), vec![("name".into(), "string".into())]);
-    assert_eq!(func.return_type(), Some("string".into()));
-}
-
-#[test]
-#[expect(clippy::expect_used, reason = "Using expect for clearer test failures")]
-fn function_no_return_api() {
-    let src = "function log(msg: string) { }\n";
-    let parsed = parse(src);
-    assert!(parsed.errors().is_empty());
-    let funcs = parsed.root().functions();
-    let func = funcs.first().expect("function missing");
-    assert_eq!(func.name(), Some("log".into()));
-    assert_eq!(func.return_type(), None);
+    assert_eq!(func.name(), Some(name.to_string()));
+    assert_eq!(func.is_extern(), is_extern);
+    assert_eq!(func.parameters(), params);
+    assert_eq!(func.return_type(), ret);
 }

--- a/tests/function_api.rs
+++ b/tests/function_api.rs
@@ -1,0 +1,38 @@
+use ddlint::parser::parse;
+
+#[test]
+fn extern_function_api() {
+    let src = "extern function hash(data: string): u64\n";
+    let parsed = parse(src);
+    assert!(parsed.errors().is_empty());
+    let funcs = parsed.root().functions();
+    let func = funcs.first().unwrap_or_else(|| panic!("function missing"));
+    assert_eq!(func.name(), Some("hash".into()));
+    assert!(func.is_extern());
+    assert_eq!(func.parameters(), vec![("data".into(), "string".into())]);
+    assert_eq!(func.return_type(), Some("u64".into()));
+}
+
+#[test]
+fn regular_function_api() {
+    let src = "function greet(name: string): string { }\n";
+    let parsed = parse(src);
+    assert!(parsed.errors().is_empty());
+    let funcs = parsed.root().functions();
+    let func = funcs.first().unwrap_or_else(|| panic!("function missing"));
+    assert_eq!(func.name(), Some("greet".into()));
+    assert!(!func.is_extern());
+    assert_eq!(func.parameters(), vec![("name".into(), "string".into())]);
+    assert_eq!(func.return_type(), Some("string".into()));
+}
+
+#[test]
+fn function_no_return_api() {
+    let src = "function log(msg: string) { }\n";
+    let parsed = parse(src);
+    assert!(parsed.errors().is_empty());
+    let funcs = parsed.root().functions();
+    let func = funcs.first().unwrap_or_else(|| panic!("function missing"));
+    assert_eq!(func.name(), Some("log".into()));
+    assert_eq!(func.return_type(), None);
+}

--- a/tests/function_api.rs
+++ b/tests/function_api.rs
@@ -1,12 +1,18 @@
+//! Integration tests for the function parsing API.
+//!
+//! These tests verify that the parser correctly parses function declarations
+//! and that the `Function` AST node provides the expected API methods.
+
 use ddlint::parser::parse;
 
 #[test]
+#[expect(clippy::expect_used, reason = "Using expect for clearer test failures")]
 fn extern_function_api() {
     let src = "extern function hash(data: string): u64\n";
     let parsed = parse(src);
     assert!(parsed.errors().is_empty());
     let funcs = parsed.root().functions();
-    let func = funcs.first().unwrap_or_else(|| panic!("function missing"));
+    let func = funcs.first().expect("function missing");
     assert_eq!(func.name(), Some("hash".into()));
     assert!(func.is_extern());
     assert_eq!(func.parameters(), vec![("data".into(), "string".into())]);
@@ -14,12 +20,13 @@ fn extern_function_api() {
 }
 
 #[test]
+#[expect(clippy::expect_used, reason = "Using expect for clearer test failures")]
 fn regular_function_api() {
     let src = "function greet(name: string): string { }\n";
     let parsed = parse(src);
     assert!(parsed.errors().is_empty());
     let funcs = parsed.root().functions();
-    let func = funcs.first().unwrap_or_else(|| panic!("function missing"));
+    let func = funcs.first().expect("function missing");
     assert_eq!(func.name(), Some("greet".into()));
     assert!(!func.is_extern());
     assert_eq!(func.parameters(), vec![("name".into(), "string".into())]);
@@ -27,12 +34,13 @@ fn regular_function_api() {
 }
 
 #[test]
+#[expect(clippy::expect_used, reason = "Using expect for clearer test failures")]
 fn function_no_return_api() {
     let src = "function log(msg: string) { }\n";
     let parsed = parse(src);
     assert!(parsed.errors().is_empty());
     let funcs = parsed.root().functions();
-    let func = funcs.first().unwrap_or_else(|| panic!("function missing"));
+    let func = funcs.first().expect("function missing");
     assert_eq!(func.name(), Some("log".into()));
     assert_eq!(func.return_type(), None);
 }

--- a/tests/parser.rs
+++ b/tests/parser.rs
@@ -668,12 +668,13 @@ fn function_unclosed_params() -> &'static str {
 }
 
 #[rstest]
+#[expect(clippy::expect_used, reason = "Using expect for clearer test failures")]
 fn extern_function_parsed(extern_function: &str) {
     let parsed = parse(extern_function);
     assert!(parsed.errors().is_empty());
     let funcs = parsed.root().functions();
     assert_eq!(funcs.len(), 1);
-    let func = funcs.first().unwrap_or_else(|| panic!("function missing"));
+    let func = funcs.first().expect("function missing");
     assert_eq!(func.name(), Some("hash".into()));
     assert!(func.is_extern());
     assert_eq!(func.parameters(), vec![("data".into(), "string".into())]);
@@ -682,12 +683,13 @@ fn extern_function_parsed(extern_function: &str) {
 }
 
 #[rstest]
+#[expect(clippy::expect_used, reason = "Using expect for clearer test failures")]
 fn function_with_body_parsed(function_with_body: &str) {
     let parsed = parse(function_with_body);
     assert!(parsed.errors().is_empty());
     let funcs = parsed.root().functions();
     assert_eq!(funcs.len(), 1);
-    let func = funcs.first().unwrap_or_else(|| panic!("function missing"));
+    let func = funcs.first().expect("function missing");
     assert_eq!(func.name(), Some("to_uppercase".into()));
     assert!(!func.is_extern());
     assert_eq!(func.parameters(), vec![("s".into(), "string".into())]);
@@ -696,12 +698,13 @@ fn function_with_body_parsed(function_with_body: &str) {
 }
 
 #[rstest]
+#[expect(clippy::expect_used, reason = "Using expect for clearer test failures")]
 fn function_no_return_parsed(function_no_return: &str) {
     let parsed = parse(function_no_return);
     assert!(parsed.errors().is_empty());
     let funcs = parsed.root().functions();
     assert_eq!(funcs.len(), 1);
-    let func = funcs.first().unwrap_or_else(|| panic!("function missing"));
+    let func = funcs.first().expect("function missing");
     assert_eq!(func.name(), Some("log_message".into()));
     assert!(!func.is_extern());
     assert_eq!(func.parameters(), vec![("msg".into(), "string".into())]);
@@ -710,24 +713,26 @@ fn function_no_return_parsed(function_no_return: &str) {
 }
 
 #[rstest]
+#[expect(clippy::expect_used, reason = "Using expect for clearer test failures")]
 fn function_no_params_parsed(function_no_params: &str) {
     let parsed = parse(function_no_params);
     assert!(parsed.errors().is_empty());
     let funcs = parsed.root().functions();
     assert_eq!(funcs.len(), 1);
-    let func = funcs.first().unwrap_or_else(|| panic!("function missing"));
+    let func = funcs.first().expect("function missing");
     assert_eq!(func.name(), Some("greet".into()));
     assert_eq!(func.parameters(), Vec::<(String, String)>::new());
     assert_eq!(func.return_type(), Some("string".into()));
 }
 
 #[rstest]
+#[expect(clippy::expect_used, reason = "Using expect for clearer test failures")]
 fn function_multi_params_parsed(function_multi_params: &str) {
     let parsed = parse(function_multi_params);
     assert!(parsed.errors().is_empty());
     let funcs = parsed.root().functions();
     assert_eq!(funcs.len(), 1);
-    let func = funcs.first().unwrap_or_else(|| panic!("function missing"));
+    let func = funcs.first().expect("function missing");
     assert_eq!(
         func.parameters(),
         vec![("a".into(), "string".into()), ("b".into(), "string".into()),]
@@ -736,12 +741,13 @@ fn function_multi_params_parsed(function_multi_params: &str) {
 }
 
 #[rstest]
+#[expect(clippy::expect_used, reason = "Using expect for clearer test failures")]
 fn function_complex_params_parsed(function_complex_params: &str) {
     let parsed = parse(function_complex_params);
     assert!(parsed.errors().is_empty());
     let funcs = parsed.root().functions();
     assert_eq!(funcs.len(), 1);
-    let func = funcs.first().unwrap_or_else(|| panic!("function missing"));
+    let func = funcs.first().expect("function missing");
     assert_eq!(
         func.parameters(),
         vec![("p".into(), "(u32, (u8, string))".into()),]
@@ -750,12 +756,13 @@ fn function_complex_params_parsed(function_complex_params: &str) {
 }
 
 #[rstest]
+#[expect(clippy::expect_used, reason = "Using expect for clearer test failures")]
 fn function_ws_comments_parsed(function_ws_comments: &str) {
     let parsed = parse(function_ws_comments);
     assert!(parsed.errors().is_empty());
     let funcs = parsed.root().functions();
     assert_eq!(funcs.len(), 1);
-    let func = funcs.first().unwrap_or_else(|| panic!("function missing"));
+    let func = funcs.first().expect("function missing");
     assert_eq!(func.name(), Some("spaced".into()));
     assert_eq!(func.parameters(), vec![("x".into(), "string".into())]);
     assert_eq!(func.return_type(), Some("u8".into()));

--- a/tests/parser.rs
+++ b/tests/parser.rs
@@ -632,6 +632,16 @@ fn function_no_return() -> &'static str {
     "function log_message(msg: string) {\n}\n"
 }
 
+#[fixture]
+fn extern_function_missing_colon() -> &'static str {
+    "extern function missing_colon u32\n"
+}
+
+#[fixture]
+fn function_unterminated_body() -> &'static str {
+    "function foo() {"
+}
+
 #[rstest]
 fn extern_function_parsed(extern_function: &str) {
     let parsed = parse(extern_function);
@@ -672,4 +682,18 @@ fn function_no_return_parsed(function_no_return: &str) {
     assert_eq!(func.parameters(), vec![("msg".into(), "string".into())]);
     assert_eq!(func.return_type(), None);
     assert_eq!(pretty_print(func.syntax()), function_no_return);
+}
+
+#[rstest]
+fn extern_function_missing_colon_is_error(extern_function_missing_colon: &str) {
+    let parsed = parse(extern_function_missing_colon);
+    assert!(!parsed.errors().is_empty());
+    assert!(parsed.root().functions().is_empty());
+}
+
+#[rstest]
+fn function_unterminated_body_is_error(function_unterminated_body: &str) {
+    let parsed = parse(function_unterminated_body);
+    assert!(!parsed.errors().is_empty());
+    assert!(parsed.root().functions().is_empty());
 }

--- a/tests/parser.rs
+++ b/tests/parser.rs
@@ -616,3 +616,60 @@ fn invalid_rule_garbage() {
         "Expected errors for completely invalid input"
     );
 }
+
+#[fixture]
+fn extern_function() -> &'static str {
+    "extern function hash(data: string): u64\n"
+}
+
+#[fixture]
+fn function_with_body() -> &'static str {
+    "function to_uppercase(s: string): string {\n}\n"
+}
+
+#[fixture]
+fn function_no_return() -> &'static str {
+    "function log_message(msg: string) {\n}\n"
+}
+
+#[rstest]
+fn extern_function_parsed(extern_function: &str) {
+    let parsed = parse(extern_function);
+    assert!(parsed.errors().is_empty());
+    let funcs = parsed.root().functions();
+    assert_eq!(funcs.len(), 1);
+    let func = funcs.first().unwrap_or_else(|| panic!("function missing"));
+    assert_eq!(func.name(), Some("hash".into()));
+    assert!(func.is_extern());
+    assert_eq!(func.parameters(), vec![("data".into(), "string".into())]);
+    assert_eq!(func.return_type(), Some("u64".into()));
+    assert_eq!(pretty_print(func.syntax()), extern_function);
+}
+
+#[rstest]
+fn function_with_body_parsed(function_with_body: &str) {
+    let parsed = parse(function_with_body);
+    assert!(parsed.errors().is_empty());
+    let funcs = parsed.root().functions();
+    assert_eq!(funcs.len(), 1);
+    let func = funcs.first().unwrap_or_else(|| panic!("function missing"));
+    assert_eq!(func.name(), Some("to_uppercase".into()));
+    assert!(!func.is_extern());
+    assert_eq!(func.parameters(), vec![("s".into(), "string".into())]);
+    assert_eq!(func.return_type(), Some("string".into()));
+    assert_eq!(pretty_print(func.syntax()), function_with_body);
+}
+
+#[rstest]
+fn function_no_return_parsed(function_no_return: &str) {
+    let parsed = parse(function_no_return);
+    assert!(parsed.errors().is_empty());
+    let funcs = parsed.root().functions();
+    assert_eq!(funcs.len(), 1);
+    let func = funcs.first().unwrap_or_else(|| panic!("function missing"));
+    assert_eq!(func.name(), Some("log_message".into()));
+    assert!(!func.is_extern());
+    assert_eq!(func.parameters(), vec![("msg".into(), "string".into())]);
+    assert_eq!(func.return_type(), None);
+    assert_eq!(pretty_print(func.syntax()), function_no_return);
+}


### PR DESCRIPTION
## Summary
- parse extern and regular functions
- add span collection for function declarations
- build CST nodes for functions
- expose `functions()` and `Function` AST node
- test function parsing

## Testing
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6865a0a33ab08322b5c09c67f746f5f0

## Summary by Sourcery

Implement parsing support for `function` and `extern function` declarations, integrate them into the parser’s span collection, CST and AST, and add extensive tests

New Features:
- Add span collection and CST building for `function` and `extern function` declarations
- Expose a new `Function` AST node and a `functions()` accessor on `Root` with methods for name, extern flag, parameters, and return type

Enhancements:
- Introduce generic span collector helpers (`parse_span`, `push_line_span`, `skip_line`) and refactor other collectors to use `parse_span`
- Extract common name‐type pair parsing logic (`parse_name_type_pairs` and `parse_type_after_colon`) and reuse in relations and functions
- Simplify `Relation.columns()` to delegate to the unified parsing routine

Tests:
- Add comprehensive parser tests for function declarations and definitions, including valid cases (extern, body/no‐body, varied parameters) and error scenarios }