### PR TITLE
Add runtime span ordering checks

### DIFF
--- a/docs/parser-plan.md
+++ b/docs/parser-plan.md
@@ -81,7 +81,7 @@ sequenceDiagram
 ```
 
 `build_green_tree` expects every list of statement spans to be sorted by start
-offset and free from overlaps. If any span is mis-ordered, the builder panics to
+offset and free from overlaps. If any span is misordered, the builder panics to
 prevent mismatched nodes in the resulting CST.
 
 ## 5. Map CST Nodes to AST Structures

--- a/docs/parser-plan.md
+++ b/docs/parser-plan.md
@@ -81,8 +81,9 @@ sequenceDiagram
 ```
 
 `build_green_tree` expects every list of statement spans to be sorted by start
-offset and free from overlaps. If any span is misordered, the builder panics to
-prevent mismatched nodes in the resulting CST.
+offset and free from overlaps. The function checks all span lists and panics
+with aggregated messages if any are misordered, preventing mismatched nodes in
+the resulting CST.
 
 ## 5. Map CST Nodes to AST Structures
 

--- a/docs/parser-plan.md
+++ b/docs/parser-plan.md
@@ -80,6 +80,10 @@ sequenceDiagram
     ASTRoot->>ASTRoot: functions() -> Vec<Function>
 ```
 
+`build_green_tree` expects every list of statement spans to be sorted by start
+offset and free from overlaps. If any span is mis-ordered, the builder panics to
+prevent mismatched nodes in the resulting CST.
+
 ## 5. Map CST Nodes to AST Structures
 
 Implement lightweight AST types that reference the CST. Each AST node should


### PR DESCRIPTION
## Summary
- enforce span list ordering in build_green_tree
- update parser plan docs with span ordering note
- test panic behaviour for overlapping or unsorted spans

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make markdownlint`


------
https://chatgpt.com/codex/tasks/task_e_68672c7943f083228335ff6f3d5022cd

## Summary by Sourcery

Add comprehensive runtime span ordering checks to parser tree construction, with detailed error reporting and updated documentation.

New Features:
- Enforce runtime validation of sorted and non-overlapping span lists in build_green_tree

Enhancements:
- Introduce SpanOrderError and ensure_span_lists_sorted to aggregate and report span ordering violations

Documentation:
- Add span ordering requirement and panic behavior note to parser-plan documentation

Tests:
- Add unit tests for validate_spans_sorted and build_green_tree panic behavior on misordered spans