### PR TITLE
Fix nested delimiter parsing

### DIFF
--- a/tests/parser.rs
+++ b/tests/parser.rs
@@ -668,6 +668,16 @@ fn function_array_params() -> &'static str {
 }
 
 #[fixture]
+fn function_nested_generic_params() -> &'static str {
+    "function nested(item: Vec<Map<string, Vec<u8>>>): bool {}\n"
+}
+
+#[fixture]
+fn function_complex_array_params() -> &'static str {
+    "function mix(arg: [Vec<u32>], other: Vec<Map<string, [u8]>>): bool {}\n"
+}
+
+#[fixture]
 fn function_ws_comments() -> &'static str {
     "function  spaced  (  x : string )  :  u8 { /*empty*/ }\n"
 }
@@ -796,6 +806,39 @@ fn function_array_params_parsed(function_array_params: &str) {
         vec![
             ("values".into(), "[u32]".into()),
             ("nested".into(), "Vec<[u8]>".into()),
+        ],
+    );
+    assert_eq!(func.return_type(), Some("bool".into()));
+}
+
+#[rstest]
+#[expect(clippy::expect_used, reason = "Using expect for clearer test failures")]
+fn function_nested_generic_params_parsed(function_nested_generic_params: &str) {
+    let parsed = parse(function_nested_generic_params);
+    assert!(parsed.errors().is_empty());
+    let funcs = parsed.root().functions();
+    assert_eq!(funcs.len(), 1);
+    let func = funcs.first().expect("function missing");
+    assert_eq!(
+        func.parameters(),
+        vec![("item".into(), "Vec<Map<string, Vec<u8>>>".into())],
+    );
+    assert_eq!(func.return_type(), Some("bool".into()));
+}
+
+#[rstest]
+#[expect(clippy::expect_used, reason = "Using expect for clearer test failures")]
+fn function_complex_array_params_parsed(function_complex_array_params: &str) {
+    let parsed = parse(function_complex_array_params);
+    assert!(parsed.errors().is_empty());
+    let funcs = parsed.root().functions();
+    assert_eq!(funcs.len(), 1);
+    let func = funcs.first().expect("function missing");
+    assert_eq!(
+        func.parameters(),
+        vec![
+            ("arg".into(), "[Vec<u32>]".into()),
+            ("other".into(), "Vec<Map<string, [u8]>>".into(),),
         ],
     );
     assert_eq!(func.return_type(), Some("bool".into()));

--- a/tests/parser.rs
+++ b/tests/parser.rs
@@ -678,6 +678,16 @@ fn function_complex_array_params() -> &'static str {
 }
 
 #[fixture]
+fn function_deep_generic_params() -> &'static str {
+    "function deep(item: Vec<Map<string, Vec<Vec<u8>>>>): bool {}\n"
+}
+
+#[fixture]
+fn function_map_array_generic_params() -> &'static str {
+    "function combos(map: Map<[string], Vec<(u32, [bool])>>): bool {}\n"
+}
+
+#[fixture]
 fn function_ws_comments() -> &'static str {
     "function  spaced  (  x : string )  :  u8 { /*empty*/ }\n"
 }
@@ -822,6 +832,36 @@ fn function_nested_generic_params_parsed(function_nested_generic_params: &str) {
     assert_eq!(
         func.parameters(),
         vec![("item".into(), "Vec<Map<string, Vec<u8>>>".into())],
+    );
+    assert_eq!(func.return_type(), Some("bool".into()));
+}
+
+#[rstest]
+#[expect(clippy::expect_used, reason = "Using expect for clearer test failures")]
+fn function_deep_generic_params_parsed(function_deep_generic_params: &str) {
+    let parsed = parse(function_deep_generic_params);
+    assert!(parsed.errors().is_empty());
+    let funcs = parsed.root().functions();
+    assert_eq!(funcs.len(), 1);
+    let func = funcs.first().expect("function missing");
+    assert_eq!(
+        func.parameters(),
+        vec![("item".into(), "Vec<Map<string, Vec<Vec<u8>>>>".into())],
+    );
+    assert_eq!(func.return_type(), Some("bool".into()));
+}
+
+#[rstest]
+#[expect(clippy::expect_used, reason = "Using expect for clearer test failures")]
+fn function_map_array_generic_params_parsed(function_map_array_generic_params: &str) {
+    let parsed = parse(function_map_array_generic_params);
+    assert!(parsed.errors().is_empty());
+    let funcs = parsed.root().functions();
+    assert_eq!(funcs.len(), 1);
+    let func = funcs.first().expect("function missing");
+    assert_eq!(
+        func.parameters(),
+        vec![("map".into(), "Map<[string], Vec<(u32, [bool])>>".into())],
     );
     assert_eq!(func.return_type(), Some("bool".into()));
 }

--- a/tests/parser.rs
+++ b/tests/parser.rs
@@ -658,6 +658,16 @@ fn function_complex_params() -> &'static str {
 }
 
 #[fixture]
+fn function_generic_params() -> &'static str {
+    "function example(arg: Vec<(u32, string)>, map: Map<string, u64>): bool {}\n"
+}
+
+#[fixture]
+fn function_array_params() -> &'static str {
+    "function arrays(values: [u32], nested: Vec<[u8]>): bool {}\n"
+}
+
+#[fixture]
 fn function_ws_comments() -> &'static str {
     "function  spaced  (  x : string )  :  u8 { /*empty*/ }\n"
 }
@@ -751,6 +761,42 @@ fn function_complex_params_parsed(function_complex_params: &str) {
     assert_eq!(
         func.parameters(),
         vec![("p".into(), "(u32, (u8, string))".into()),]
+    );
+    assert_eq!(func.return_type(), Some("bool".into()));
+}
+
+#[rstest]
+#[expect(clippy::expect_used, reason = "Using expect for clearer test failures")]
+fn function_generic_params_parsed(function_generic_params: &str) {
+    let parsed = parse(function_generic_params);
+    assert!(parsed.errors().is_empty());
+    let funcs = parsed.root().functions();
+    assert_eq!(funcs.len(), 1);
+    let func = funcs.first().expect("function missing");
+    assert_eq!(
+        func.parameters(),
+        vec![
+            ("arg".into(), "Vec<(u32, string)>".into()),
+            ("map".into(), "Map<string, u64>".into()),
+        ],
+    );
+    assert_eq!(func.return_type(), Some("bool".into()));
+}
+
+#[rstest]
+#[expect(clippy::expect_used, reason = "Using expect for clearer test failures")]
+fn function_array_params_parsed(function_array_params: &str) {
+    let parsed = parse(function_array_params);
+    assert!(parsed.errors().is_empty());
+    let funcs = parsed.root().functions();
+    assert_eq!(funcs.len(), 1);
+    let func = funcs.first().expect("function missing");
+    assert_eq!(
+        func.parameters(),
+        vec![
+            ("values".into(), "[u32]".into()),
+            ("nested".into(), "Vec<[u8]>".into()),
+        ],
     );
     assert_eq!(func.return_type(), Some("bool".into()));
 }


### PR DESCRIPTION
## Summary
- handle nested generic and array delimiters in `parse_name_type_pairs`
- parse function parameters containing generics and arrays

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68672ddda7788322964ac58898d58af3

## Summary by Sourcery

Replace the ad-hoc depth counter in parse_name_type_pairs with a dedicated DelimiterDepth tracker and enhance the parser to correctly handle nested generic (<>) and array ([]) delimiters in function parameter lists.

New Features:
- Parse function parameters containing generic, array, and nested generic/array types.

Bug Fixes:
- Fix nested delimiter parsing in parse_name_type_pairs to correctly split name/type pairs at top-level delimiters.

Enhancements:
- Introduce DelimiterDepth struct to track nesting of parentheses, angle brackets, square brackets, and braces during parsing.

Tests:
- Add tests for parsing function parameters with generic types, array types, nested generics, and mixed generic/array combinations.