### PR TITLE
Refactor parser span handling

### DIFF
--- a/docs/parser-plan.md
+++ b/docs/parser-plan.md
@@ -75,7 +75,7 @@ sequenceDiagram
     participant ASTRoot
     Parser->>SpanCollector: collect_function_spans(tokens, src)
     SpanCollector-->>Parser: (function_spans, errors)
-    Parser->>CSTBuilder: build_green_tree(..., function_spans, ...)
+    Parser->>CSTBuilder: build_green_tree(..., spans, ...)
     CSTBuilder-->>ASTRoot: Root::from_green(green)
     ASTRoot->>ASTRoot: functions() -> Vec<Function>
 ```

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -212,24 +212,16 @@ pub struct ParsedSpans {
 }
 
 impl ParsedSpans {
-    /// Iterate over all span slices in declaration order.
-    fn iter_all(&self) -> std::array::IntoIter<&[Span], 6> {
-        [
-            self.imports.as_slice(),
-            self.typedefs.as_slice(),
-            self.relations.as_slice(),
-            self.indexes.as_slice(),
-            self.functions.as_slice(),
-            self.rules.as_slice(),
-        ]
-        .into_iter()
-    }
-
     /// Assert that every span list is sorted and non-overlapping.
     fn assert_sorted(&self) {
-        for spans in self.iter_all() {
-            assert_spans_sorted(spans);
-        }
+        ensure_span_lists_sorted(&[
+            ("imports", &self.imports),
+            ("typedefs", &self.typedefs),
+            ("relations", &self.relations),
+            ("indexes", &self.indexes),
+            ("functions", &self.functions),
+            ("rules", &self.rules),
+        ]);
     }
 }
 
@@ -1792,8 +1784,12 @@ mod tests {
         let src = "import Foo";
         let tokens = tokenize(src);
         let unsorted = vec![1..2, 0..1];
+        let spans = super::ParsedSpans {
+            imports: unsorted,
+            ..Default::default()
+        };
         let result = std::panic::catch_unwind(|| {
-            super::build_green_tree(tokens, src, &unsorted, &[], &[], &[], &[], &[]);
+            super::build_green_tree(tokens, src, &spans);
         });
         let Err(msg) = result else {
             panic!("expected panic")
@@ -1815,8 +1811,13 @@ mod tests {
         let tokens = tokenize(src);
         let imports = vec![1..2, 0..1];
         let typedefs = vec![4..5, 3..4];
+        let spans = super::ParsedSpans {
+            imports,
+            typedefs,
+            ..Default::default()
+        };
         let result = std::panic::catch_unwind(|| {
-            super::build_green_tree(tokens, src, &imports, &typedefs, &[], &[], &[], &[]);
+            super::build_green_tree(tokens, src, &spans);
         });
         let Err(msg) = result else {
             panic!("expected panic")

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -195,7 +195,7 @@ pub struct Parsed {
 }
 
 /// Spans for each parsed statement category.
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, PartialEq)]
 pub struct ParsedSpans {
     /// `import` statement spans.
     pub imports: Vec<Span>,

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -195,7 +195,7 @@ pub struct Parsed {
 }
 
 /// Spans for each parsed statement category.
-#[derive(Debug)]
+#[derive(Debug, Default, Clone)]
 pub struct ParsedSpans {
     /// `import` statement spans.
     pub imports: Vec<Span>,
@@ -209,6 +209,28 @@ pub struct ParsedSpans {
     pub functions: Vec<Span>,
     /// Rule spans.
     pub rules: Vec<Span>,
+}
+
+impl ParsedSpans {
+    /// Iterate over all span slices in declaration order.
+    fn iter_all(&self) -> std::array::IntoIter<&[Span], 6> {
+        [
+            self.imports.as_slice(),
+            self.typedefs.as_slice(),
+            self.relations.as_slice(),
+            self.indexes.as_slice(),
+            self.functions.as_slice(),
+            self.rules.as_slice(),
+        ]
+        .into_iter()
+    }
+
+    /// Assert that every span list is sorted and non-overlapping.
+    fn assert_sorted(&self) {
+        for spans in self.iter_all() {
+            assert_spans_sorted(spans);
+        }
+    }
 }
 
 impl Parsed {
@@ -833,12 +855,7 @@ fn collect_rule_spans(
 /// that tokens are wrapped into well-formed nodes during tree construction.
 /// Spans are checked with debug assertions.
 fn build_green_tree(tokens: Vec<(SyntaxKind, Span)>, src: &str, spans: &ParsedSpans) -> GreenNode {
-    assert_spans_sorted(&spans.imports);
-    assert_spans_sorted(&spans.typedefs);
-    assert_spans_sorted(&spans.relations);
-    assert_spans_sorted(&spans.indexes);
-    assert_spans_sorted(&spans.functions);
-    assert_spans_sorted(&spans.rules);
+    spans.assert_sorted();
     let mut builder = GreenNodeBuilder::new();
     builder.start_node(DdlogLanguage::kind_to_raw(SyntaxKind::N_DATALOG_PROGRAM));
 


### PR DESCRIPTION
## Summary
- collapse parser span arguments into a `ParsedSpans` struct
- adjust `parse` and `build_green_tree` to use new struct
- update documentation for parser plan

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make markdownlint`
- `make nixie`


------
https://chatgpt.com/codex/tasks/task_e_6867382d39a083228a9dab0ba898535c

## Summary by Sourcery

Refactor parser span handling by consolidating individual span lists into a unified `ParsedSpans` struct, updating core functions and documentation to use the new struct, and adding validation for sorted spans.

Enhancements:
- Introduce `ParsedSpans` struct to encapsulate all parser span collections
- Simplify `parse_tokens` and `build_green_tree` signatures to accept a single `ParsedSpans` argument
- Add `assert_sorted` method on `ParsedSpans` to enforce sorted and non-overlapping spans

Documentation:
- Update `parser-plan.md` and inline doc comments to reference `ParsedSpans` instead of individual span lists

Tests:
- Adapt tests for `build_green_tree` to construct and use `ParsedSpans` in panic scenarios