### PR TITLE
Update parser to handle generics in parameter lists

### DIFF
--- a/docs/function-parsing-design.md
+++ b/docs/function-parsing-design.md
@@ -18,3 +18,13 @@ classDiagram
     Function ..> parse_type_after_colon : uses
     Relation ..> parse_name_type_pairs : uses
 ```
+
+## Parameter list parsing
+
+`parse_name_type_pairs` walks the token stream produced for the parameter list.
+Commas end a parameter only when the parser is not inside any nested delimiters.
+A small stack tracks openings of `(`, `<`, `[` and `{`. Closing tokens remove
+entries from the stack, ensuring that nested generics like
+`Vec<Map<string, Vec<u8>>>` do not confuse the outer list terminator. The
+opening `(` of the list is accounted for separately so that the closing `)` can
+be recognised without scanning the stack.

--- a/src/parser/ast/parse_utils.rs
+++ b/src/parser/ast/parse_utils.rs
@@ -154,7 +154,7 @@ fn handle_token(
         SyntaxKind::T_SHR => {
             let closed = close_and_push(token, buf, depth, Delim::Angle, 2);
             if closed < 2 {
-                // TODO: report unmatched '>>'
+                // TODO: report unmatched '>>' (See issue #54)
             }
         }
         SyntaxKind::T_LBRACKET => open_and_push(token, buf, depth, Delim::Bracket, 1),

--- a/tests/parser.rs
+++ b/tests/parser.rs
@@ -801,6 +801,72 @@ fn function_ws_comments_parsed(function_ws_comments: &str) {
     assert_eq!(func.return_type(), Some("u8".into()));
 }
 
+#[fixture]
+fn function_generic_params() -> &'static str {
+    "function example(arg: Vec<(u32, string)>, map: Map<string, u64>): bool {\n}\n"
+}
+
+#[rstest]
+#[expect(clippy::expect_used, reason = "Using expect for clearer test failures")]
+fn function_generic_params_parsed(function_generic_params: &str) {
+    let parsed = parse(function_generic_params);
+    assert!(parsed.errors().is_empty());
+    let funcs = parsed.root().functions();
+    assert_eq!(funcs.len(), 1);
+    let func = funcs.first().expect("function missing");
+    assert_eq!(func.name(), Some("example".into()));
+    assert_eq!(
+        func.parameters(),
+        vec![
+            ("arg".into(), "Vec<(u32, string)>".into()),
+            ("map".into(), "Map<string, u64>".into()),
+        ]
+    );
+    assert_eq!(func.return_type(), Some("bool".into()));
+}
+
+#[fixture]
+fn function_nested_generics() -> &'static str {
+    "function test(p: Vec<Map<string, Vec<u8>>>, arr: [Vec<u32>]): bool {}\n"
+}
+
+#[rstest]
+#[expect(clippy::expect_used, reason = "Using expect for clearer test failures")]
+fn function_nested_generics_parsed(function_nested_generics: &str) {
+    let parsed = parse(function_nested_generics);
+    assert!(parsed.errors().is_empty());
+    let funcs = parsed.root().functions();
+    assert_eq!(funcs.len(), 1);
+    let func = funcs.first().expect("function missing");
+    assert_eq!(func.name(), Some("test".into()));
+    assert_eq!(
+        func.parameters(),
+        vec![
+            ("p".into(), "Vec<Map<string, Vec<u8>>>".into()),
+            ("arr".into(), "[Vec<u32>]".into()),
+        ]
+    );
+    assert_eq!(func.return_type(), Some("bool".into()));
+}
+
+#[fixture]
+fn function_shift_param() -> &'static str {
+    "function shift(x: Vec<<u8>>): bool {}\n"
+}
+
+#[rstest]
+#[expect(clippy::expect_used, reason = "Using expect for clearer test failures")]
+fn function_shift_param_parsed(function_shift_param: &str) {
+    let parsed = parse(function_shift_param);
+    assert!(parsed.errors().is_empty());
+    let funcs = parsed.root().functions();
+    assert_eq!(funcs.len(), 1);
+    let func = funcs.first().expect("function missing");
+    assert_eq!(func.name(), Some("shift".into()));
+    assert_eq!(func.parameters(), vec![("x".into(), "Vec<<u8>>".into())]);
+    assert_eq!(func.return_type(), Some("bool".into()));
+}
+
 #[rstest]
 fn function_unclosed_params_is_error(function_unclosed_params: &str) {
     let parsed = parse(function_unclosed_params);


### PR DESCRIPTION
## Summary
- support nested delimiters when parsing `(name: type)` pairs
- test parsing of generic types in parameters

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68684fa95bd483228e45bc9de529407d

## Summary by Sourcery

Enable parsing of generic types in function parameter lists by tracking nested delimiters across parentheses, angle brackets, brackets, and braces.

New Features:
- Support nested generic types and other delimiters in parameter type declarations.

Enhancements:
- Replace single depth counter with a DelimDepths struct to separately track nesting of parentheses, angle brackets, brackets, and braces when parsing parameter lists.

Tests:
- Add parameter parsing tests for various generic and nested type scenarios, including angle shift cases and array-of-generic types.