### PR TITLE
Implement delimiter mismatch error

### DIFF
--- a/src/parser/ast/parse_utils.rs
+++ b/src/parser/ast/parse_utils.rs
@@ -3,12 +3,12 @@
 //! This module contains small functions reused by multiple AST nodes when
 //! extracting typed data from the CST.
 
-use rowan::{NodeOrToken, SyntaxElement};
+use rowan::{NodeOrToken, SyntaxElement, TextRange};
 
 use super::skip_whitespace_and_comments;
 use crate::{DdlogLanguage, SyntaxKind};
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum Delim {
     Paren,
     Angle,
@@ -22,6 +22,39 @@ enum Delim {
 /// additional counters and ensures they close in the correct order.
 #[derive(Default)]
 struct DelimStack(Vec<Delim>);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct DelimiterError {
+    expected: Delim,
+    found: SyntaxKind,
+    span: TextRange,
+}
+
+impl std::fmt::Display for DelimiterError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let expected = match self.expected {
+            Delim::Paren => ")",
+            Delim::Angle => ">",
+            Delim::Bracket => "]",
+            Delim::Brace => "}",
+        };
+        let found = match self.found {
+            SyntaxKind::T_RPAREN => ")",
+            SyntaxKind::T_GT => ">",
+            SyntaxKind::T_SHR => ">>",
+            SyntaxKind::T_RBRACKET => "]",
+            SyntaxKind::T_RBRACE => "}",
+            _ => "?",
+        };
+        write!(
+            f,
+            "expected '{expected}' before '{found}' at {:#?}",
+            self.span
+        )
+    }
+}
+
+impl std::error::Error for DelimiterError {}
 
 impl DelimStack {
     fn open(&mut self, delim: Delim, count: usize) {
@@ -87,7 +120,7 @@ fn push(token: &rowan::SyntaxToken<DdlogLanguage>, buf: &mut String) {
 /// starting at the opening parenthesis. The returned vector contains
 /// each name and its associated type text.
 #[must_use]
-pub(super) fn parse_name_type_pairs<I>(mut iter: I) -> Vec<(String, String)>
+pub(super) fn parse_name_type_pairs<I>(mut iter: I) -> (Vec<(String, String)>, Vec<DelimiterError>)
 where
     I: Iterator<Item = SyntaxElement<DdlogLanguage>>,
 {
@@ -99,6 +132,7 @@ where
     }
 
     let mut pairs = Vec::new();
+    let mut errors = Vec::new();
     let mut buf = String::new();
     let mut name: Option<String> = None;
     let mut depth = DelimStack::default();
@@ -116,6 +150,7 @@ where
                     &mut pairs,
                     &mut depth,
                     &mut outer_parens,
+                    &mut errors,
                 ) {
                     break;
                 }
@@ -124,7 +159,7 @@ where
         }
     }
 
-    pairs
+    (pairs, errors)
 }
 
 /// Handle a single token during name-type pair parsing.
@@ -135,6 +170,7 @@ fn handle_token(
     pairs: &mut Vec<(String, String)>,
     depth: &mut DelimStack,
     outer_parens: &mut usize,
+    errors: &mut Vec<DelimiterError>,
 ) -> bool {
     match token.kind() {
         SyntaxKind::T_LPAREN => open_and_push(token, buf, depth, Delim::Paren, 1),
@@ -148,22 +184,43 @@ fn handle_token(
         }
         SyntaxKind::T_LT => open_and_push(token, buf, depth, Delim::Angle, 1),
         SyntaxKind::T_GT => {
-            close_and_push(token, buf, depth, Delim::Angle, 1);
+            if close_and_push(token, buf, depth, Delim::Angle, 1) < 1 {
+                errors.push(DelimiterError {
+                    expected: Delim::Angle,
+                    found: token.kind(),
+                    span: token.text_range(),
+                });
+            }
         }
         SyntaxKind::T_SHL => open_and_push(token, buf, depth, Delim::Angle, 2),
         SyntaxKind::T_SHR => {
-            let closed = close_and_push(token, buf, depth, Delim::Angle, 2);
-            if closed < 2 {
-                // TODO: report unmatched '>>' (See issue #54)
+            if close_and_push(token, buf, depth, Delim::Angle, 2) < 2 {
+                errors.push(DelimiterError {
+                    expected: Delim::Angle,
+                    found: token.kind(),
+                    span: token.text_range(),
+                });
             }
         }
         SyntaxKind::T_LBRACKET => open_and_push(token, buf, depth, Delim::Bracket, 1),
         SyntaxKind::T_RBRACKET => {
-            close_and_push(token, buf, depth, Delim::Bracket, 1);
+            if close_and_push(token, buf, depth, Delim::Bracket, 1) < 1 {
+                errors.push(DelimiterError {
+                    expected: Delim::Bracket,
+                    found: token.kind(),
+                    span: token.text_range(),
+                });
+            }
         }
         SyntaxKind::T_LBRACE => open_and_push(token, buf, depth, Delim::Brace, 1),
         SyntaxKind::T_RBRACE => {
-            close_and_push(token, buf, depth, Delim::Brace, 1);
+            if close_and_push(token, buf, depth, Delim::Brace, 1) < 1 {
+                errors.push(DelimiterError {
+                    expected: Delim::Brace,
+                    found: token.kind(),
+                    span: token.text_range(),
+                });
+            }
         }
         SyntaxKind::T_COMMA if depth.is_empty() && *outer_parens == 1 => {
             finalize_pair(name, buf, pairs);
@@ -295,8 +352,17 @@ mod tests {
     ) {
         let _ = src;
         let elements = tokens_for;
-        let result = parse_name_type_pairs(elements.into_iter());
+        let (result, errors) = parse_name_type_pairs(elements.into_iter());
+        assert!(errors.is_empty());
         assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn unmatched_shift_errors() {
+        let src = "function bad(x: Vec<u8>>): bool {}";
+        let elements = tokens_for(src);
+        let (_pairs, errors) = parse_name_type_pairs(elements.into_iter());
+        assert_eq!(errors.len(), 1);
     }
 
     #[rstest]

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1311,7 +1311,7 @@ pub mod ast {
         /// Columns declared for the relation.
         #[must_use]
         pub fn columns(&self) -> Vec<(String, String)> {
-            parse_name_type_pairs(self.syntax.children_with_tokens())
+            parse_name_type_pairs(self.syntax.children_with_tokens()).0
         }
 
         /// Primary key column names if specified.
@@ -1619,7 +1619,7 @@ pub mod ast {
         /// Function parameters as name/type pairs.
         #[must_use]
         pub fn parameters(&self) -> Vec<(String, String)> {
-            parse_name_type_pairs(self.syntax.children_with_tokens())
+            parse_name_type_pairs(self.syntax.children_with_tokens()).0
         }
 
         /// Return type text if specified.

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1309,9 +1309,15 @@ pub mod ast {
         }
 
         /// Columns declared for the relation.
+        ///
+        /// Delimiter errors detected during parsing are ignored.
+        /// This may change in future to surface these diagnostics.
         #[must_use]
         pub fn columns(&self) -> Vec<(String, String)> {
-            parse_name_type_pairs(self.syntax.children_with_tokens()).0
+            let (pairs, errors) = parse_name_type_pairs(self.syntax.children_with_tokens());
+            // Delimiter errors are ignored for now. Future versions may surface them.
+            let _ = errors;
+            pairs
         }
 
         /// Primary key column names if specified.
@@ -1617,9 +1623,15 @@ pub mod ast {
         }
 
         /// Function parameters as name/type pairs.
+        ///
+        /// Delimiter errors detected during parsing are ignored.
+        /// This may change in future to surface these diagnostics.
         #[must_use]
         pub fn parameters(&self) -> Vec<(String, String)> {
-            parse_name_type_pairs(self.syntax.children_with_tokens()).0
+            let (pairs, errors) = parse_name_type_pairs(self.syntax.children_with_tokens());
+            // Delimiter errors are ignored for now. Future versions may surface them.
+            let _ = errors;
+            pairs
         }
 
         /// Return type text if specified.


### PR DESCRIPTION
## Summary
- detect unmatched delimiters while parsing
- surface `DelimiterError` for name/type parsing
- adjust callers to ignore returned errors
- test new mismatch handling

## Testing
- `make fmt`
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68687ee043a083228378d71300497c4f

## Summary by Sourcery

Detect and report unmatched delimiters in name/type pair parsing by introducing a DelimiterError type and extending parse_name_type_pairs to collect errors alongside parsed pairs while preserving existing API behavior.

New Features:
- Add DelimiterError type with Display and Error implementations
- Extend parse_name_type_pairs to return a tuple of parsed pairs and delimiter errors

Enhancements:
- Detect and accumulate delimiter mismatch errors for '>', '>>', ']', and '}' tokens during parsing
- Update AST node methods to extract only the parsed name/type pairs from the new tuple return

Tests:
- Add test for unmatched '>>' to verify delimiter error handling