### PR TITLE
Refine parameter parsing

### DIFF
--- a/docs/function-parsing-design.md
+++ b/docs/function-parsing-design.md
@@ -38,3 +38,8 @@ parenthesis that ended the parameter, so diagnostics can highlight the exact
 location of the issue. Helper functions `collect_parameter_name` and
 `finalise_parameter` keep the main loop small by handling name collection and
 type parsing respectively.
+
+Empty names or types are reported using the same error variant so incomplete
+declarations do not pass silently. `parse_type_expr` filters out whitespace and
+comment nodes when assembling the type string and reports any delimiters left
+unclosed when parsing stops.

--- a/docs/function-parsing-design.md
+++ b/docs/function-parsing-design.md
@@ -11,10 +11,14 @@ classDiagram
     class parse_name_type_pairs {
         <<function>>
     }
+    class parse_type_expr {
+        <<function>>
+    }
     class parse_type_after_colon {
         <<function>>
     }
     Function ..> parse_name_type_pairs : uses
+    parse_name_type_pairs ..> parse_type_expr : uses
     Function ..> parse_type_after_colon : uses
     Relation ..> parse_name_type_pairs : uses
 ```
@@ -22,9 +26,8 @@ classDiagram
 ## Parameter list parsing
 
 `parse_name_type_pairs` walks the token stream produced for the parameter list.
-Commas end a parameter only when the parser is not inside any nested delimiters.
-A small stack tracks openings of `(`, `<`, `[` and `{`. Closing tokens remove
-entries from the stack, ensuring that nested generics like
-`Vec<Map<string, Vec<u8>>>` do not confuse the outer list terminator. The
-opening `(` of the list is accounted for separately so that the closing `)` can
-be recognised without scanning the stack.
+Each time a colon is encountered the function delegates to `parse_type_expr` to
+capture the following type expression. That helper recursively parses nested
+delimiters so constructs like `Vec<Map<string, Vec<u8>>>` are handled without
+maintaining a delimiter stack in `parse_name_type_pairs` itself. Parameters end
+when a comma or the closing `)` of the list is reached.

--- a/docs/function-parsing-design.md
+++ b/docs/function-parsing-design.md
@@ -31,3 +31,10 @@ capture the following type expression. That helper recursively parses nested
 delimiters so constructs like `Vec<Map<string, Vec<u8>>>` are handled without
 maintaining a delimiter stack in `parse_name_type_pairs` itself. Parameters end
 when a comma or the closing `)` of the list is reached.
+
+Missing colons between a parameter name and type trigger a
+`ParseError::MissingColon`. The parser attaches the span of the comma or
+parenthesis that ended the parameter so diagnostics can highlight the exact
+location of the issue. Helper functions `collect_parameter_name` and
+`finalise_parameter` keep the main loop small by handling name collection and
+type parsing respectively.

--- a/docs/function-parsing-design.md
+++ b/docs/function-parsing-design.md
@@ -34,12 +34,12 @@ when a comma or the closing `)` of the list is reached.
 
 Missing colons between a parameter name and type trigger a
 `ParseError::MissingColon`. The parser attaches the span of the comma or
-parenthesis that ended the parameter, so diagnostics can highlight the exact
-location of the issue. Helper functions `collect_parameter_name` and
-`finalise_parameter` keep the main loop small by handling name collection and
-type parsing respectively.
+parenthesis that ended the parameter so diagnostics can pinpoint the location.
+Helper functions `collect_parameter_name` and `finalise_parameter` keep the main
+loop small by handling name collection and type parsing respectively.
 
-Empty names or types are reported using the same error variant so incomplete
-declarations do not pass silently. `parse_type_expr` filters out whitespace and
-comment nodes when assembling the type string and reports any delimiters left
-unclosed when parsing stops.
+Empty names and empty types are reported with `ParseError::MissingName` and
+`ParseError::MissingType`. `parse_type_expr` filters out whitespace and comment
+nodes while recording `ParseError::Delimiter` for mismatched closing tokens and
+`ParseError::UnclosedDelimiter` when the stack contains leftover openings after
+parsing stops.

--- a/docs/function-parsing-design.md
+++ b/docs/function-parsing-design.md
@@ -34,12 +34,12 @@ when a comma or the closing `)` of the list is reached.
 
 Missing colons between a parameter name and type trigger a
 `ParseError::MissingColon`. The parser attaches the span of the comma or
-parenthesis that ended the parameter so diagnostics can pinpoint the location.
+parenthesis that ended the parameter, so diagnostics can pinpoint the location.
 Helper functions `collect_parameter_name` and `finalise_parameter` keep the main
-loop small by handling name collection and type parsing respectively.
+loop small by handling name collection and type parsing, respectively.
 
 Empty names and empty types are reported with `ParseError::MissingName` and
 `ParseError::MissingType`. `parse_type_expr` filters out whitespace and comment
-nodes while recording `ParseError::Delimiter` for mismatched closing tokens and
+nodes while recording `ParseError::Delimiter` for mismatched closing tokens, and
 `ParseError::UnclosedDelimiter` when the stack contains leftover openings after
 parsing stops.

--- a/docs/function-parsing-design.md
+++ b/docs/function-parsing-design.md
@@ -26,15 +26,15 @@ classDiagram
 ## Parameter list parsing
 
 `parse_name_type_pairs` walks the token stream produced for the parameter list.
-Each time a colon is encountered the function delegates to `parse_type_expr` to
+Each time a colon is encountered, the function delegates to `parse_type_expr` to
 capture the following type expression. That helper recursively parses nested
-delimiters so constructs like `Vec<Map<string, Vec<u8>>>` are handled without
+delimiters, so constructs like `Vec<Map<string, Vec<u8>>>` are handled without
 maintaining a delimiter stack in `parse_name_type_pairs` itself. Parameters end
 when a comma or the closing `)` of the list is reached.
 
 Missing colons between a parameter name and type trigger a
 `ParseError::MissingColon`. The parser attaches the span of the comma or
-parenthesis that ended the parameter so diagnostics can highlight the exact
+parenthesis that ended the parameter, so diagnostics can highlight the exact
 location of the issue. Helper functions `collect_parameter_name` and
 `finalise_parameter` keep the main loop small by handling name collection and
 type parsing respectively.

--- a/src/parser/ast/parse_utils.rs
+++ b/src/parser/ast/parse_utils.rs
@@ -462,7 +462,12 @@ where
                 }
             },
             NodeOrToken::Node(n) => {
-                buf.push_str(&n.text().to_string());
+                let text = n.text().to_string();
+                let is_whitespace = text.chars().all(char::is_whitespace);
+                let is_comment = n.kind() == SyntaxKind::T_COMMENT;
+                if !is_whitespace && !is_comment {
+                    buf.push_str(&text);
+                }
                 iter.next();
             }
         }

--- a/src/parser/ast/parse_utils.rs
+++ b/src/parser/ast/parse_utils.rs
@@ -1,7 +1,10 @@
-//! Shared parsing utilities for AST helpers.
+//! Parsing helpers shared across AST modules.
 //!
-//! This module contains small functions reused by multiple AST nodes when
-//! extracting typed data from the CST.
+//! This module provides small utilities for collecting parameter names and
+//! types from the CST and for recursively parsing type expressions. Both the
+//! `Function` and `Relation` nodes import these helpers so they can share the
+//! same logic when interpreting their declarations. See
+//! `docs/function-parsing-design.md` for an overview.
 
 use rowan::{NodeOrToken, SyntaxElement, TextRange, TextSize};
 


### PR DESCRIPTION
## Summary
- add `parse_type_expr` to recursively parse type expressions
- refactor `parse_name_type_pairs` to use the new helper
- document updated approach in the function parsing design guide

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_686977f483dc83228f8534e94b29f356

## Summary by Sourcery

Refine parameter parsing by extracting type expression parsing into parse_type_expr, simplifying name-type pair extraction with helper functions, and unifying error reporting using a new ParseError enum

New Features:
- Add recursive parse_type_expr function for nested type expressions
- Introduce collect_parameter_name and finalise_parameter helpers for parameter parsing
- Add ParseError enum to unify delimiter mismatches and missing-colon errors

Enhancements:
- Refactor parse_name_type_pairs to delegate type parsing and simplify main loop
- Unify error collection to report empty names/types and missing colons with precise spans

Documentation:
- Update function-parsing-design guide to document parse_type_expr integration and new parsing workflow

Tests:
- Extend tests to cover nested generics, missing colons, empty names/types, and unclosed delimiters