### PR TITLE
Rename ParsedSpans method

### DIFF
--- a/docs/function-parsing-design.md
+++ b/docs/function-parsing-design.md
@@ -26,15 +26,15 @@ classDiagram
 ## Parameter list parsing
 
 `parse_name_type_pairs` walks the token stream produced for the parameter list.
-Whenever it encounters a colon, it delegates to `parse_type_expr`.  
-That helper is now fully recursive: on seeing `(`, `[`, `{` or `<`, it calls  
-itself to read the matching closing delimiter. This means nested types such as  
-`Vec<Map<string, Vec<u8>>>` are parsed without any external delimiter stack.  
+Whenever it encounters a colon, it delegates to `parse_type_expr`.\
+That helper is now fully recursive: on seeing `(`, `[`, `{` or `<`, it calls\
+itself to read the matching closing delimiter. This means nested types such as\
+`Vec<Map<string, Vec<u8>>>` are parsed without any external delimiter stack.\
 Parameters end when a comma or the closing `)` of the list is reached.
 
 Missing colons between a parameter name and type trigger
-`ParseError::MissingColon`. The span of the terminating comma or parenthesis is  
-attached, so diagnostics point at the error. Helper functions  
+`ParseError::MissingColon`. The span of the terminating comma or parenthesis is\
+attached, so diagnostics point at the error. Helper functions\
 `collect_parameter_name` and `finalise_parameter` keep the main loop small.
 
 Empty names and types are reported with `ParseError::MissingName` and

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -212,8 +212,8 @@ pub struct ParsedSpans {
 }
 
 impl ParsedSpans {
-    /// Assert that every span list is sorted and non-overlapping.
-    fn assert_sorted(&self) {
+    /// Ensure every span list is sorted and non-overlapping.
+    fn ensure_sorted(&self) {
         ensure_span_lists_sorted(&[
             ("imports", &self.imports),
             ("typedefs", &self.typedefs),
@@ -847,7 +847,7 @@ fn collect_rule_spans(
 /// that tokens are wrapped into well-formed nodes during tree construction.
 /// Spans are checked with debug assertions.
 fn build_green_tree(tokens: &[(SyntaxKind, Span)], src: &str, spans: &ParsedSpans) -> GreenNode {
-    spans.assert_sorted();
+    spans.ensure_sorted();
     let mut builder = GreenNodeBuilder::new();
     builder.start_node(DdlogLanguage::kind_to_raw(SyntaxKind::N_DATALOG_PROGRAM));
 


### PR DESCRIPTION
## Summary
- rename `ParsedSpans::assert_sorted` to `ensure_sorted`
- update call site and docs

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make markdownlint`


------
https://chatgpt.com/codex/tasks/task_e_686c435bc7748322a55a3ed4ea1177dc

## Summary by Sourcery

Rename ParsedSpans::assert_sorted to ensure_sorted and update all references and documentation accordingly

Enhancements:
- Rename ParsedSpans::assert_sorted method to ensure_sorted
- Update call site in build_green_tree to use ensure_sorted

Documentation:
- Adjust line continuations and formatting in function-parsing-design.md to align with code changes