### PR TITLE
Implement transformer parser

### DIFF
--- a/docs/documentation-style-guide.md
+++ b/docs/documentation-style-guide.md
@@ -106,4 +106,4 @@ flowchart TD
     C --> D[Merge]
 ```
 
-[^markdownlint]: A linter that enforces consistent Markdown formatting.
+\[^markdownlint\]: A linter that enforces consistent Markdown formatting.

--- a/docs/documentation-style-guide.md
+++ b/docs/documentation-style-guide.md
@@ -106,4 +106,4 @@ flowchart TD
     C --> D[Merge]
 ```
 
-\[^markdownlint\]: A linter that enforces consistent Markdown formatting.
+[^markdownlint]: A linter that enforces consistent Markdown formatting.


### PR DESCRIPTION
## Summary
- add `transformer` span tracking and CST node
- expose `Transformer` AST wrapper with accessor methods
- parse extern transformer declarations and collect spans
- update parser tests to cover transformer parsing
- keep Markdown formatting consistent

## Testing
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_687194d20f708322999ef4e1be9e7b8e

## Summary by Sourcery

Implement transformer parsing end-to-end by tracking transformer spans in the parser, enriching the AST with a Transformer node and accessors, and adding helper utilities and tests to validate transformer declaration parsing.

New Features:
- Add support for parsing extern transformer declarations with span tracking
- Introduce a Transformer AST node with methods to access its name, inputs, and outputs
- Expose transformers() accessor on the root AST to collect all transformer declarations
- Add a generic collect_extern_declarations helper for parsing extern declarations
- Add parse_ident_list utility for parsing lists of identifiers after a colon

Enhancements:
- Extend ParsedSpans, parser logic, and green tree builder to handle transformer spans
- Apply minor Markdown formatting consistency fix

Tests:
- Add comprehensive parser tests for transformer declarations covering single/multiple I/O, invalid cases, whitespace handling, duplicate names, and reserved keywords