### PR TITLE
Add doc examples for tokenizer and parser

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -328,6 +328,16 @@ impl Parsed {
 /// The function tokenises the source using [`tokenize`], then uses a minimal
 /// `chumsky` parser to wrap those tokens into a CST. Syntactic error recovery
 /// will insert `N_ERROR` nodes when grammar rules fail once they exist.
+///
+/// # Examples
+///
+/// ```rust,no_run
+/// use ddlint::parse;
+///
+/// let parsed = parse("input relation R(x: u32);");
+/// assert!(parsed.errors().is_empty());
+/// assert_eq!(parsed.root().relations().len(), 1);
+/// ```
 #[must_use]
 pub fn parse(src: &str) -> Parsed {
     let tokens = tokenize(src);

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -187,6 +187,16 @@ fn keyword_kind(ident: &str) -> Option<SyntaxKind> {
 }
 
 /// Tokenise the provided `DDlog` source.
+///
+/// # Examples
+///
+/// ```rust,no_run
+/// use ddlint::{tokenize, SyntaxKind};
+///
+/// let tokens = tokenize("input relation R(x: u32);");
+/// assert_eq!(tokens.len(), 12);
+/// assert_eq!(tokens[0].0, SyntaxKind::K_INPUT);
+/// ```
 #[must_use]
 pub fn tokenize(src: &str) -> Vec<(SyntaxKind, Span)> {
     let mut lexer = Token::lexer(src);


### PR DESCRIPTION
## Summary
- document `tokenize` with a minimal example
- document `parse` with a minimal example

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_687572f278108322bd35f9ad94f931c0

## Summary by Sourcery

Add minimal documentation examples for the `tokenize` and `parse` functions.

Documentation:
- Add a usage example for the `tokenize` function in its doc comments
- Add a usage example for the `parse` function in its doc comments