### PR TITLE
Replace unreachable unwrap with expect

### DIFF
--- a/src/language.rs
+++ b/src/language.rs
@@ -182,10 +182,8 @@ impl RowanLanguage for DdlogLanguage {
         SyntaxKind::from_u16(raw.0).unwrap_or(SyntaxKind::N_ERROR)
     }
 
+    #[expect(clippy::expect_used, reason = "all SyntaxKind variants map to u16")]
     fn kind_to_raw(kind: Self::Kind) -> RowanSyntaxKind {
-        RowanSyntaxKind(
-            kind.to_u16()
-                .unwrap_or_else(|| unreachable!("all SyntaxKind variants map to u16")),
-        )
+        RowanSyntaxKind(kind.to_u16().expect("all SyntaxKind variants map to u16"))
     }
 }


### PR DESCRIPTION
## Summary
- replace `unwrap_or_else` call with `expect` in `kind_to_raw`
- note why the `expect` is acceptable using a Clippy `#[expect]` attribute

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68764340b3388322a358388cb3fb737b