### PR TITLE
Refactor relation span parsing

### DIFF
--- a/src/parser/ast/parse_utils.rs
+++ b/src/parser/ast/parse_utils.rs
@@ -14,6 +14,25 @@ use crate::{DdlogLanguage, Span, SyntaxKind};
 use chumsky::prelude::*;
 
 /// Parser for a parenthesised block, returning its span.
+///
+/// This helper wraps [`balanced_block`] to provide the range covering the
+/// entire block. Nested parentheses are handled correctly so callers can skip
+/// or collect the text without building an AST node.
+///
+/// # Examples
+///
+/// ```rust,no_run
+/// use ddlint::parser::ast::parse_utils::paren_block_span;
+/// use ddlint::tokenize;
+/// use chumsky::{Parser, Stream};
+///
+/// let src = "(foo(bar))";
+/// let tokens = tokenize(src);
+/// let span = paren_block_span()
+///     .parse(Stream::from_iter(0..src.len(), tokens.into_iter()))
+///     .unwrap();
+/// assert_eq!(span.start, 0);
+/// ```
 pub(crate) fn paren_block_span() -> impl Parser<SyntaxKind, Span, Error = Simple<SyntaxKind>> + Clone
 {
     balanced_block(SyntaxKind::T_LPAREN, SyntaxKind::T_RPAREN).map_with_span(|(), sp: Span| sp)

--- a/src/parser/ast/parse_utils.rs
+++ b/src/parser/ast/parse_utils.rs
@@ -36,7 +36,7 @@ use chumsky::prelude::*;
 #[inline]
 pub(crate) fn paren_block_span() -> impl Parser<SyntaxKind, Span, Error = Simple<SyntaxKind>> + Clone
 {
-    balanced_block(SyntaxKind::T_LPAREN, SyntaxKind::T_RPAREN).map_with_span(|_, sp: Span| sp)
+    balanced_block(SyntaxKind::T_LPAREN, SyntaxKind::T_RPAREN).map_with_span(|(), sp: Span| sp)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/parser/ast/parse_utils.rs
+++ b/src/parser/ast/parse_utils.rs
@@ -36,7 +36,7 @@ use chumsky::prelude::*;
 #[inline]
 pub(crate) fn paren_block_span() -> impl Parser<SyntaxKind, Span, Error = Simple<SyntaxKind>> + Clone
 {
-    balanced_block(SyntaxKind::T_LPAREN, SyntaxKind::T_RPAREN).map_with_span(|(), sp: Span| sp)
+    balanced_block(SyntaxKind::T_LPAREN, SyntaxKind::T_RPAREN).map_with_span(|_, sp: Span| sp)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/parser/ast/parse_utils.rs
+++ b/src/parser/ast/parse_utils.rs
@@ -8,8 +8,16 @@
 
 use rowan::{NodeOrToken, SyntaxElement, TextRange, TextSize};
 
+use super::super::balanced_block;
 use super::skip_whitespace_and_comments;
-use crate::{DdlogLanguage, SyntaxKind};
+use crate::{DdlogLanguage, Span, SyntaxKind};
+use chumsky::prelude::*;
+
+/// Parser for a parenthesised block, returning its span.
+pub(crate) fn paren_block_span() -> impl Parser<SyntaxKind, Span, Error = Simple<SyntaxKind>> + Clone
+{
+    balanced_block(SyntaxKind::T_LPAREN, SyntaxKind::T_RPAREN).map_with_span(|(), sp: Span| sp)
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum Delim {

--- a/src/parser/ast/parse_utils.rs
+++ b/src/parser/ast/parse_utils.rs
@@ -22,8 +22,8 @@ use chumsky::prelude::*;
 /// # Examples
 ///
 /// ```rust,no_run
-/// use ddlint::parser::ast::parse_utils::paren_block_span;
-/// use ddlint::tokenize;
+/// use crate::parser::ast::parse_utils::paren_block_span;
+/// use crate::tokenize;
 /// use chumsky::{Parser, Stream};
 ///
 /// let src = "(foo(bar))";
@@ -33,6 +33,7 @@ use chumsky::prelude::*;
 ///     .unwrap();
 /// assert_eq!(span.start, 0);
 /// ```
+#[inline]
 pub(crate) fn paren_block_span() -> impl Parser<SyntaxKind, Span, Error = Simple<SyntaxKind>> + Clone
 {
     balanced_block(SyntaxKind::T_LPAREN, SyntaxKind::T_RPAREN).map_with_span(|(), sp: Span| sp)

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -635,22 +635,10 @@ fn collect_relation_spans(tokens: &[(SyntaxKind, Span)], src: &str) -> Vec<Span>
             st.stream.advance();
         }
         st.stream.skip_ws_inline();
-        if matches!(st.stream.peek().map(|t| t.0), Some(SyntaxKind::T_LPAREN)) {
-            st.stream.advance();
-            let mut depth = 1usize;
-            while let Some((kind, _)) = st.stream.peek() {
-                match kind {
-                    SyntaxKind::T_LPAREN => depth += 1,
-                    SyntaxKind::T_RPAREN => {
-                        depth -= 1;
-                        if depth == 0 {
-                            st.stream.advance();
-                            break;
-                        }
-                    }
-                    _ => {}
-                }
-                st.stream.advance();
+        if let Some((SyntaxKind::T_LPAREN, span)) = st.stream.peek().cloned() {
+            let (res, _err) = st.parse_span(ast::parse_utils::paren_block_span(), span.start);
+            if let Some(sp) = res {
+                st.stream.skip_until(sp.end);
             }
         }
     }
@@ -667,22 +655,11 @@ fn collect_relation_spans(tokens: &[(SyntaxKind, Span)], src: &str) -> Vec<Span>
             {
                 st.stream.advance();
                 st.stream.skip_ws_inline();
-                if matches!(st.stream.peek().map(|t| t.0), Some(SyntaxKind::T_LPAREN)) {
-                    st.stream.advance();
-                    let mut depth = 1usize;
-                    while let Some((kind, _)) = st.stream.peek() {
-                        match kind {
-                            SyntaxKind::T_LPAREN => depth += 1,
-                            SyntaxKind::T_RPAREN => {
-                                depth -= 1;
-                                if depth == 0 {
-                                    st.stream.advance();
-                                    break;
-                                }
-                            }
-                            _ => {}
-                        }
-                        st.stream.advance();
+                if let Some((SyntaxKind::T_LPAREN, pspan)) = st.stream.peek().cloned() {
+                    let (res, _err) =
+                        st.parse_span(ast::parse_utils::paren_block_span(), pspan.start);
+                    if let Some(sp) = res {
+                        st.stream.skip_until(sp.end);
                     }
                 }
             }
@@ -1586,7 +1563,7 @@ pub mod ast {
         }
     }
 
-    mod parse_utils;
+    pub(super) mod parse_utils;
     use parse_utils::{parse_name_type_pairs, parse_output_list, parse_type_after_colon};
 
     /// Typed wrapper for a relation declaration.

--- a/tests/parser.rs
+++ b/tests/parser.rs
@@ -107,6 +107,11 @@ fn index_unbalanced_parentheses() -> &'static str {
 }
 
 #[fixture]
+fn relation_unbalanced_parentheses() -> &'static str {
+    "relation Foo(x: u32"
+}
+
+#[fixture]
 fn index_whitespace_variations() -> &'static str {
     "  index  Idx_User_ws \t on\n  User (\n    username  )  "
 }
@@ -529,6 +534,13 @@ fn index_unbalanced_parentheses_is_error(index_unbalanced_parentheses: &str) {
     let parsed = parse(index_unbalanced_parentheses);
     assert!(!parsed.errors().is_empty());
     assert!(parsed.root().indexes().is_empty());
+}
+
+#[rstest]
+fn relation_unbalanced_parentheses_is_error(relation_unbalanced_parentheses: &str) {
+    let parsed = parse(relation_unbalanced_parentheses);
+    assert!(!parsed.errors().is_empty());
+    assert!(parsed.root().relations().is_empty());
 }
 
 #[rstest]


### PR DESCRIPTION
## Summary
- expose parser::ast::parse_utils to parent module
- add `paren_block_span` helper for balanced parentheses
- parse relation columns and PK clauses using the new helper

## Testing
- `make lint`
- `make test`
- `make markdownlint`


------
https://chatgpt.com/codex/tasks/task_e_6876432252108322832d4edd4816bce1

## Summary by Sourcery

Refactor relation span parsing by extracting parentheses handling into a reusable parser helper and replacing manual scanning logic with `paren_block_span`; expose `parse_utils` to the parent module

Enhancements:
- Expose the `parse_utils` module to its parent AST module
- Add a `paren_block_span` parser for balanced parentheses blocks
- Replace manual parentheses depth-tracking in `collect_relation_spans` with `paren_block_span` for relation columns and PK clauses