### PR TITLE
Refactor rule span logic

### DIFF
--- a/src/parser/expression_span.rs
+++ b/src/parser/expression_span.rs
@@ -1,0 +1,57 @@
+//! Utilities for locating and validating expression spans.
+//!
+//! The functions in this module help other parser components extract the byte
+//! ranges of expressions from a token stream. They also allow validating the
+//! text within those ranges using the Pratt expression parser without
+//! introducing additional coupling.
+
+use chumsky::error::Simple;
+
+use crate::parser::expression::parse_expression;
+use crate::{Span, SyntaxKind};
+
+/// Find the span of a rule body expression within a slice of tokens.
+///
+/// The function scans the tokens starting at `start_idx` until `end`. It
+/// returns the range of bytes between the token following `T_IMPLIES` and the
+/// preceding `T_DOT`. `None` is returned if a well formed range cannot be
+/// determined.
+#[must_use]
+pub(crate) fn rule_body_span(
+    tokens: &[(SyntaxKind, Span)],
+    start_idx: usize,
+    end: usize,
+) -> Option<Span> {
+    let mut expr_start = None;
+    let mut expr_end = None;
+    let mut idx = start_idx;
+    while let Some(tok) = tokens.get(idx) {
+        if tok.1.start >= end {
+            break;
+        }
+        match tok.0 {
+            SyntaxKind::T_IMPLIES => {
+                expr_start = tokens.get(idx + 1).map(|t| t.1.start);
+            }
+            SyntaxKind::T_DOT => {
+                expr_end = Some(tok.1.start);
+                break;
+            }
+            _ => {}
+        }
+        idx += 1;
+    }
+    match (expr_start, expr_end) {
+        (Some(s), Some(e)) if s < e => Some(s..e),
+        _ => None,
+    }
+}
+
+/// Parse the text within `span` using the expression parser.
+///
+/// Any syntax errors reported by the parser are returned for the caller to
+/// aggregate. A successful parse yields `()`.
+pub(crate) fn validate_expression(src: &str, span: Span) -> Result<(), Vec<Simple<SyntaxKind>>> {
+    src.get(span.clone())
+        .map_or_else(|| Ok(()), |text| parse_expression(text).map(|_| ()))
+}

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -20,6 +20,7 @@ use span_scanner::parse_tokens;
 mod cst_builder;
 use cst_builder::build_green_tree;
 pub mod expression;
+mod expression_span;
 pub use cst_builder::{Parsed, ParsedSpans};
 
 /// Parse the provided source string.


### PR DESCRIPTION
## Summary
- extract expression span helpers into a new `expression_span` module
- simplify `collect_rule_spans` to use the helpers
- wire the new module into the parser

closes #102

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68872531f4808322abbd6f166d708c95

## Summary by Sourcery

Extract expression span logic into a dedicated module and simplify rule span parsing by using the new helper functions.

Enhancements:
- Move expression span extraction and validation into a new expression_span module
- Replace inline extract_expression_span and parse_expression calls with rule_body_span and validate_expression helpers
- Import and wire the expression_span module into the parser