### PR TITLE
Parse literal tokens in expressions

### DIFF
--- a/docs/pratt-parser-for-ddlog-expressions.md
+++ b/docs/pratt-parser-for-ddlog-expressions.md
@@ -346,6 +346,11 @@ operator table analysed from the Haskell parser. Expression spans are now
 recorded by `span_scanner` and emitted as `N_EXPR_NODE` entries when building
 the CST.
 
+Literal tokens are normalised in a dedicated helper so prefix parsing remains
+readable. The parser maps `T_NUMBER`, `T_STRING`, `K_TRUE` and `K_FALSE` to
+`ast::Literal` variants, ensuring numbers, strings and booleans appear directly
+in the resulting AST.
+
 Operator precedence is centralised in `src/parser/ast/precedence.rs`. Both the
 Pratt parser and any future grammar extensions reference this table, ensuring
 consistent binding power definitions across the codebase.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -99,7 +99,7 @@ control flow. This phase aims to build a complete grammar.
     handle operator precedence and associativity, as outlined in the Haskell
     parser analysis (`docs/haskell-parser-analysis.md`).
 
-  - [ ] Add support for parsing all literal types within expressions (e.g.,
+  - [x] Add support for parsing all literal types within expressions (e.g.,
     strings, numbers, booleans). The `SyntaxKind` enum already defines these.
 
   - [ ] Implement parsers for variable references (`e_var`) and function calls

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@
 pub mod language;
 pub mod parser;
 pub mod syntax_utils;
+pub mod test_util;
 pub mod tokenizer;
 
 pub use language::{DdlogLanguage, SyntaxKind};

--- a/src/parser/expression.rs
+++ b/src/parser/expression.rs
@@ -163,11 +163,11 @@ where
     /// when tokens do not match any prefix production.
     fn parse_prefix(&mut self) -> Option<Expr> {
         let (kind, span) = self.next()?;
-        if let Some(lit) = self.parse_literal(kind, span.clone()) {
+        if let Some(lit) = self.parse_literal(kind, &span) {
             return Some(lit);
         }
         match kind {
-            SyntaxKind::T_IDENT => Some(Expr::Variable(self.slice(span))),
+            SyntaxKind::T_IDENT => Some(Expr::Variable(self.slice(&span))),
             SyntaxKind::T_LPAREN => {
                 let expr = self.parse_expr(0);
                 if !self.expect(SyntaxKind::T_RPAREN) {
@@ -198,7 +198,7 @@ where
     /// # Returns
     /// `Some(expr)` if the token represents a recognised literal, or `None`
     /// otherwise.
-    fn parse_literal(&self, kind: SyntaxKind, span: Span) -> Option<Expr> {
+    fn parse_literal(&self, kind: SyntaxKind, span: &Span) -> Option<Expr> {
         match kind {
             SyntaxKind::T_NUMBER => Some(Expr::Literal(Literal::Number(self.slice(span)))),
             SyntaxKind::T_STRING => {
@@ -274,7 +274,7 @@ where
     ///
     /// # Returns
     /// The corresponding substring, or an empty string if the span is invalid.
-    fn slice(&self, span: Span) -> String {
-        self.src.get(span).unwrap_or("").to_string()
+    fn slice(&self, span: &Span) -> String {
+        self.src.get(span.clone()).unwrap_or("").to_string()
     }
 }

--- a/src/parser/expression.rs
+++ b/src/parser/expression.rs
@@ -163,11 +163,10 @@ where
     /// when tokens do not match any prefix production.
     fn parse_prefix(&mut self) -> Option<Expr> {
         let (kind, span) = self.next()?;
+        if let Some(lit) = self.parse_literal(kind, span.clone()) {
+            return Some(lit);
+        }
         match kind {
-            SyntaxKind::T_NUMBER => Some(Expr::Literal(Literal::Number(self.slice(span)))),
-            SyntaxKind::T_STRING => Some(Expr::Literal(Literal::String(self.slice(span)))),
-            SyntaxKind::K_TRUE => Some(Expr::Literal(Literal::Bool(true))),
-            SyntaxKind::K_FALSE => Some(Expr::Literal(Literal::Bool(false))),
             SyntaxKind::T_IDENT => Some(Expr::Variable(self.slice(span))),
             SyntaxKind::T_LPAREN => {
                 let expr = self.parse_expr(0);
@@ -187,6 +186,33 @@ where
                     expr: Box::new(rhs),
                 })
             }
+        }
+    }
+
+    /// Parse a literal token into an [`Expr`].
+    ///
+    /// # Parameters
+    /// - `kind`: The token kind to interpret as a literal.
+    /// - `span`: The source span to slice when constructing literal values.
+    ///
+    /// # Returns
+    /// `Some(expr)` if the token represents a recognised literal, or `None`
+    /// otherwise.
+    fn parse_literal(&self, kind: SyntaxKind, span: Span) -> Option<Expr> {
+        match kind {
+            SyntaxKind::T_NUMBER => Some(Expr::Literal(Literal::Number(self.slice(span)))),
+            SyntaxKind::T_STRING => {
+                let raw = self.slice(span);
+                let value = raw
+                    .strip_prefix('"')
+                    .and_then(|s| s.strip_suffix('"'))
+                    .unwrap_or(&raw)
+                    .to_string();
+                Some(Expr::Literal(Literal::String(value)))
+            }
+            SyntaxKind::K_TRUE => Some(Expr::Literal(Literal::Bool(true))),
+            SyntaxKind::K_FALSE => Some(Expr::Literal(Literal::Bool(false))),
+            _ => None,
         }
     }
 

--- a/src/parser/tests/expression.rs
+++ b/src/parser/tests/expression.rs
@@ -8,12 +8,30 @@ fn lit_num(n: &str) -> Expr {
     Expr::Literal(Literal::Number(n.into()))
 }
 
+fn lit_str(s: &str) -> Expr {
+    Expr::Literal(Literal::String(s.into()))
+}
+
+fn lit_bool(b: bool) -> Expr {
+    Expr::Literal(Literal::Bool(b))
+}
+
 #[rstest]
 #[case("1 + 2 * 3", Expr::Binary { op: BinaryOp::Add, lhs: Box::new(lit_num("1")), rhs: Box::new(Expr::Binary { op: BinaryOp::Mul, lhs: Box::new(lit_num("2")), rhs: Box::new(lit_num("3")) }) })]
 #[case("8 - 4 - 2", Expr::Binary { op: BinaryOp::Sub, lhs: Box::new(Expr::Binary { op: BinaryOp::Sub, lhs: Box::new(lit_num("8")), rhs: Box::new(lit_num("4")) }), rhs: Box::new(lit_num("2")) })]
 #[case("-5 + 2", Expr::Binary { op: BinaryOp::Add, lhs: Box::new(Expr::Unary { op: UnaryOp::Neg, expr: Box::new(lit_num("5")) }), rhs: Box::new(lit_num("2")) })]
 #[case("-(5 + 2)", Expr::Unary { op: UnaryOp::Neg, expr: Box::new(Expr::Group(Box::new(Expr::Binary { op: BinaryOp::Add, lhs: Box::new(lit_num("5")), rhs: Box::new(lit_num("2")) }))) })]
 fn parses_expressions(#[case] src: &str, #[case] expected: Expr) {
+    let expr = parse_expression(src).unwrap_or_else(|errs| panic!("errors: {errs:?}"));
+    assert_eq!(expr, expected);
+}
+
+#[rstest]
+#[case("\"hi\"", lit_str("hi"))]
+#[case("true", lit_bool(true))]
+#[case("false", lit_bool(false))]
+#[case("42", lit_num("42"))]
+fn parses_literals(#[case] src: &str, #[case] expected: Expr) {
     let expr = parse_expression(src).unwrap_or_else(|errs| panic!("errors: {errs:?}"));
     assert_eq!(expr, expected);
 }

--- a/src/parser/tests/expression.rs
+++ b/src/parser/tests/expression.rs
@@ -1,20 +1,9 @@
 //! Tests for the Pratt expression parser.
 
-use crate::parser::ast::{BinaryOp, Expr, Literal, UnaryOp};
+use crate::parser::ast::{BinaryOp, Expr, UnaryOp};
 use crate::parser::expression::parse_expression;
+use crate::test_util::{lit_bool, lit_num, lit_str};
 use rstest::rstest;
-
-fn lit_num(n: &str) -> Expr {
-    Expr::Literal(Literal::Number(n.into()))
-}
-
-fn lit_str(s: &str) -> Expr {
-    Expr::Literal(Literal::String(s.into()))
-}
-
-fn lit_bool(b: bool) -> Expr {
-    Expr::Literal(Literal::Bool(b))
-}
 
 #[rstest]
 #[case("1 + 2 * 3", Expr::Binary { op: BinaryOp::Add, lhs: Box::new(lit_num("1")), rhs: Box::new(Expr::Binary { op: BinaryOp::Mul, lhs: Box::new(lit_num("2")), rhs: Box::new(lit_num("3")) }) })]

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -1,0 +1,23 @@
+//! Helpers for constructing literal expressions in tests.
+//!
+//! These functions reduce boilerplate when asserting over [`Expr`] nodes.
+
+use crate::parser::ast::{Expr, Literal};
+
+/// Construct a numeric [`Expr::Literal`].
+#[must_use]
+pub fn lit_num(n: &str) -> Expr {
+    Expr::Literal(Literal::Number(n.into()))
+}
+
+/// Construct a string [`Expr::Literal`].
+#[must_use]
+pub fn lit_str(s: &str) -> Expr {
+    Expr::Literal(Literal::String(s.into()))
+}
+
+/// Construct a boolean [`Expr::Literal`].
+#[must_use]
+pub fn lit_bool(b: bool) -> Expr {
+    Expr::Literal(Literal::Bool(b))
+}

--- a/tests/expression_literals.rs
+++ b/tests/expression_literals.rs
@@ -3,21 +3,10 @@
 //! These tests exercise the public `parse_expression` API by feeding it
 //! standalone literals and verifying the resulting AST nodes.
 
-use ddlint::parser::ast::{Expr, Literal};
+use ddlint::parser::ast::Expr;
 use ddlint::parser::expression::parse_expression;
+use ddlint::test_util::{lit_bool, lit_num, lit_str};
 use rstest::rstest;
-
-fn lit_num(n: &str) -> Expr {
-    Expr::Literal(Literal::Number(n.into()))
-}
-
-fn lit_str(s: &str) -> Expr {
-    Expr::Literal(Literal::String(s.into()))
-}
-
-fn lit_bool(b: bool) -> Expr {
-    Expr::Literal(Literal::Bool(b))
-}
 
 #[rstest]
 #[case("42", lit_num("42"))]

--- a/tests/expression_literals.rs
+++ b/tests/expression_literals.rs
@@ -1,0 +1,30 @@
+//! Integration tests for parsing literal expressions.
+//!
+//! These tests exercise the public `parse_expression` API by feeding it
+//! standalone literals and verifying the resulting AST nodes.
+
+use ddlint::parser::ast::{Expr, Literal};
+use ddlint::parser::expression::parse_expression;
+use rstest::rstest;
+
+fn lit_num(n: &str) -> Expr {
+    Expr::Literal(Literal::Number(n.into()))
+}
+
+fn lit_str(s: &str) -> Expr {
+    Expr::Literal(Literal::String(s.into()))
+}
+
+fn lit_bool(b: bool) -> Expr {
+    Expr::Literal(Literal::Bool(b))
+}
+
+#[rstest]
+#[case("42", lit_num("42"))]
+#[case("\"hi\"", lit_str("hi"))]
+#[case("true", lit_bool(true))]
+#[case("false", lit_bool(false))]
+fn parses_literal_expressions(#[case] src: &str, #[case] expected: Expr) {
+    let expr = parse_expression(src).unwrap_or_else(|e| panic!("errors: {e:?}"));
+    assert_eq!(expr, expected);
+}


### PR DESCRIPTION
## Summary
- parse numbers, strings and booleans via a dedicated `parse_literal` helper
- document literal handling and mark roadmap item as done
- exercise literal parsing through unit and integration tests

## Testing
- `make lint`
- `make test`
- `make markdownlint`
- `make nixie` *(fails: ENOENT reading /tmp/bunx-0-@mermaid-js/mermaid-cli@latest/node_modules/semver/internal/lrucache.js)*

------
https://chatgpt.com/codex/tasks/task_e_688ff6412394832298a837f12c04629c

## Summary by Sourcery

Introduce a dedicated helper to parse number, string, and boolean literals in expressions and integrate it into the prefix parser; update documentation and roadmap to reflect literal support; and add unit and integration tests to verify literal parsing.

New Features:
- Add parse_literal helper to handle number, string, and boolean tokens.
- Refactor prefix parsing to delegate literal handling to the new helper.

Enhancements:
- Document literal normalization in the Pratt parser guide and mark literal parsing roadmap item as complete.

Documentation:
- Update roadmap to mark literal parsing support as done.

Tests:
- Add unit tests for literal expressions in the existing expression parser.
- Add integration tests for standalone literal parsing via public parse_expression API.