### PR TITLE
Parse variables and function calls

### DIFF
--- a/docs/pratt-parser-for-ddlog-expressions.md
+++ b/docs/pratt-parser-for-ddlog-expressions.md
@@ -357,7 +357,7 @@ consistent binding power definitions across the codebase.
 
 Variable references are parsed by interpreting identifier tokens as
 `Expr::Variable`. When an identifier is immediately followed by a left
-parenthesis the parser treats it as a function call, parsing a comma-separated
+parenthesis, the parser treats it as a function call, parsing a comma-separated
 list of argument expressions and producing `Expr::Call { name, args }`. This
 postfix form naturally binds tighter than infix operators, so no additional
 precedence entries are required.

--- a/docs/pratt-parser-for-ddlog-expressions.md
+++ b/docs/pratt-parser-for-ddlog-expressions.md
@@ -357,7 +357,7 @@ consistent binding power definitions across the codebase.
 
 Variable references are parsed by interpreting identifier tokens as
 `Expr::Variable`. When an identifier is immediately followed by a left
-parenthesis, the parser treats it as a function call, parsing a comma-separated
-list of argument expressions and producing `Expr::Call { name, args }`. This
-postfix form naturally binds tighter than infix operators, so no additional
-precedence entries are required.
+parenthesis, the parser treats it as a function call, parsing a
+comma-separated list of argument expressions and producing
+`Expr::Call { name, args }`. This postfix form naturally binds tighter than
+infix operators, so no additional precedence entries are required.

--- a/docs/pratt-parser-for-ddlog-expressions.md
+++ b/docs/pratt-parser-for-ddlog-expressions.md
@@ -354,3 +354,10 @@ in the resulting AST.
 Operator precedence is centralised in `src/parser/ast/precedence.rs`. Both the
 Pratt parser and any future grammar extensions reference this table, ensuring
 consistent binding power definitions across the codebase.
+
+Variable references are parsed by interpreting identifier tokens as
+`Expr::Variable`. When an identifier is immediately followed by a left
+parenthesis the parser treats it as a function call, parsing a comma-separated
+list of argument expressions and producing `Expr::Call { name, args }`. This
+postfix form naturally binds tighter than infix operators, so no additional
+precedence entries are required.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -102,7 +102,7 @@ control flow. This phase aims to build a complete grammar.
   - [x] Add support for parsing all literal types within expressions (e.g.,
     strings, numbers, booleans). The `SyntaxKind` enum already defines these.
 
-  - [ ] Implement parsers for variable references (`e_var`) and function calls
+  - [x] Implement parsers for variable references (`e_var`) and function calls
     (`e_func`).
 
   - [ ] Implement parsers for compound data structures: struct literals

--- a/src/parser/ast/expr.rs
+++ b/src/parser/ast/expr.rs
@@ -54,6 +54,13 @@ pub enum Expr {
     Literal(Literal),
     /// Variable reference expression.
     Variable(String),
+    /// Function call expression.
+    Call {
+        /// Name of the function being invoked.
+        name: String,
+        /// Argument expressions supplied to the function.
+        args: Vec<Expr>,
+    },
     /// Unary operation expression.
     Unary { op: UnaryOp, expr: Box<Expr> },
     /// Binary operation expression.
@@ -75,6 +82,14 @@ impl Expr {
             Self::Literal(Literal::String(s)) => format!("\"{s}\""),
             Self::Literal(Literal::Bool(b)) => b.to_string(),
             Self::Variable(name) => name.clone(),
+            Self::Call { name, args } => {
+                if args.is_empty() {
+                    format!("({name})")
+                } else {
+                    let args = args.iter().map(Self::to_sexpr).collect::<Vec<_>>();
+                    format!("({} {})", name, args.join(" "))
+                }
+            }
             Self::Unary { op, expr } => {
                 let op_str = match op {
                     UnaryOp::Not => "not",

--- a/src/parser/expression.rs
+++ b/src/parser/expression.rs
@@ -157,7 +157,7 @@ where
         // peel off any call suffixes before handling infix operators
         while matches!(self.peek(), Some(SyntaxKind::T_LPAREN)) {
             let Some((_, lparen_span)) = self.next() else {
-                break;
+                unreachable!("T_LPAREN was peeked");
             };
             let args = self.parse_args()?;
             if !self.expect(SyntaxKind::T_RPAREN) {
@@ -217,11 +217,10 @@ where
         loop {
             let expr = self.parse_expr(0)?;
             args.push(expr);
-            if matches!(self.peek(), Some(SyntaxKind::T_COMMA)) {
-                self.next();
-                continue;
+            if !matches!(self.peek(), Some(SyntaxKind::T_COMMA)) {
+                break;
             }
-            break;
+            self.next();
         }
         Some(args)
     }

--- a/src/parser/tests/expression.rs
+++ b/src/parser/tests/expression.rs
@@ -2,7 +2,7 @@
 
 use crate::parser::ast::{BinaryOp, Expr, UnaryOp};
 use crate::parser::expression::parse_expression;
-use crate::test_util::{lit_bool, lit_num, lit_str};
+use crate::test_util::{call, lit_bool, lit_num, lit_str, var};
 use rstest::rstest;
 
 #[rstest]
@@ -10,6 +10,9 @@ use rstest::rstest;
 #[case("8 - 4 - 2", Expr::Binary { op: BinaryOp::Sub, lhs: Box::new(Expr::Binary { op: BinaryOp::Sub, lhs: Box::new(lit_num("8")), rhs: Box::new(lit_num("4")) }), rhs: Box::new(lit_num("2")) })]
 #[case("-5 + 2", Expr::Binary { op: BinaryOp::Add, lhs: Box::new(Expr::Unary { op: UnaryOp::Neg, expr: Box::new(lit_num("5")) }), rhs: Box::new(lit_num("2")) })]
 #[case("-(5 + 2)", Expr::Unary { op: UnaryOp::Neg, expr: Box::new(Expr::Group(Box::new(Expr::Binary { op: BinaryOp::Add, lhs: Box::new(lit_num("5")), rhs: Box::new(lit_num("2")) }))) })]
+#[case("x", var("x"))]
+#[case("foo()", call("foo", vec![]))]
+#[case("add(x, 1)", call("add", vec![var("x"), lit_num("1")]))]
 fn parses_expressions(#[case] src: &str, #[case] expected: Expr) {
     let expr = parse_expression(src).unwrap_or_else(|errs| panic!("errors: {errs:?}"));
     assert_eq!(expr, expected);

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -1,4 +1,4 @@
-//! Helpers for constructing literal expressions in tests.
+//! Helpers for constructing expression nodes in tests.
 //!
 //! These functions reduce boilerplate when asserting over [`Expr`] nodes.
 
@@ -20,4 +20,19 @@ pub fn lit_str(s: &str) -> Expr {
 #[must_use]
 pub fn lit_bool(b: bool) -> Expr {
     Expr::Literal(Literal::Bool(b))
+}
+
+/// Construct a variable [`Expr::Variable`].
+#[must_use]
+pub fn var(name: &str) -> Expr {
+    Expr::Variable(name.into())
+}
+
+/// Construct a function call [`Expr::Call`].
+#[must_use]
+pub fn call(name: &str, args: Vec<Expr>) -> Expr {
+    Expr::Call {
+        name: name.into(),
+        args,
+    }
 }

--- a/tests/expression_var_and_call.rs
+++ b/tests/expression_var_and_call.rs
@@ -1,0 +1,18 @@
+//! Integration tests for variable references and function calls.
+//!
+//! These tests cover the public `parse_expression` API to ensure identifiers
+//! become variables and that calls parse their argument lists correctly.
+
+use ddlint::parser::ast::Expr;
+use ddlint::parser::expression::parse_expression;
+use ddlint::test_util::{call, lit_num, var};
+use rstest::rstest;
+
+#[rstest]
+#[case("x", var("x"))]
+#[case("foo()", call("foo", vec![]))]
+#[case("foo(x, 1)", call("foo", vec![var("x"), lit_num("1")]))]
+fn parses_vars_and_calls(#[case] src: &str, #[case] expected: Expr) {
+    let expr = parse_expression(src).unwrap_or_else(|e| panic!("errors: {e:?}"));
+    assert_eq!(expr, expected);
+}


### PR DESCRIPTION
## Summary
- support variable references and function calls in Pratt parser
- record design choices for identifier handling and call parsing
- mark roadmap entry for variable and function parsing as complete

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make markdownlint`
- `make nixie` *(fails: FileNotFound: failed copying files from cache to destination for package @swc/helpers)*

------
https://chatgpt.com/codex/tasks/task_e_6893d8c69d808322955576344b559fd9

## Summary by Sourcery

Implement variable references and function call parsing in the Pratt parser, updating the AST, test utilities, documentation, and adding corresponding tests.

New Features:
- Add support for parsing identifier tokens as variable references
- Add support for parsing function call expressions with comma-separated argument lists

Enhancements:
- Extend test utilities with var() and call() helpers
- Update Expr::to_sexpr to format call expressions

Documentation:
- Document variable and call parsing in parser design doc and mark roadmap entry as complete

Tests:
- Add unit tests for variable and call parsing in expression parser
- Add integration tests for public parse_expression API covering variables and calls