### PR TITLE
Track opening spans for unclosed delimiters

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# Assistant Instructions
+# Assistant instructions
 
 ## Code Style and Structure
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Differential Datalog Linter (ddlint)
+# Differential datalog linter (ddlint)
 
 This is a generated project using [Copier](https://copier.readthedocs.io/).
 
@@ -16,5 +16,5 @@ fn main() {
 }
 ```
 
-Control the verbosity with the `RUST_LOG` environment variable. For example, you
-can set `RUST_LOG=warn` to display warnings.
+Control the verbosity with the `RUST_LOG` environment variable. For example,
+you can set `RUST_LOG=warn` to display warnings.

--- a/docs/building-an-error-recovering-parser-with-chumsky.md
+++ b/docs/building-an-error-recovering-parser-with-chumsky.md
@@ -4,7 +4,7 @@
 > most successful book ever to come out of the great publishing corporations of
 > Ursa Minor.*
 
-## 1 Know Where Your Towel (and Grammar) Is
+## 1 Know where your towel (and grammar) is
 
 Before you even think about summoning Chumsky’s combinators, write your grammar
 down — preferably in EBNF, biro on a napkin, or etched into the side of a Vogon
@@ -18,7 +18,7 @@ later and you’ll be spelunking inside recursive lambdas at 2 a.m.
   statements, tea before Arthur, etc.”)
 - Examples of legal *and* illegal programmes.
 
-### 2 Feed It Tokens, Not Breadcrumbs
+### 2 Feed it tokens, not breadcrumbs
 
 Chumsky is much happier when it’s nibbling on a neat `Vec<TokenSpan>` than on
 raw characters. Use the `logos` crate (or your favourite lexical life-form) to
@@ -29,7 +29,7 @@ slice the source first. You’ll get:
 - The freedom to invent helpful token kinds (e.g. “Indent”, “Dedent”, “Unified
   Field Theory Symbol”)
 
-### 3 Dealing with Left-Recursion, Infinite Loops and Other Things That Ate Betelgeuse
+### 3 Dealing with left-recursion, infinite loops and other things that ate Betelgeuse
 
 Left-recursive rules make top-down parsers seize up like Marvin’s shoulder
 joints. Rewrite them with repetition combinators (`many()`, `foldl()`), or use
@@ -41,7 +41,7 @@ round corners.
 Ambiguity? Break overlapping prefixes into separate branches *first* and only
 then hand the survivors to `choice()`.
 
-### 4 Panic? No. Recovery? Yes
+### 4 Panic? no. Recovery? yes
 
 Error recovery is what turns your parser from Vogon poetry into a Babel fish.
 
@@ -55,7 +55,7 @@ Error recovery is what turns your parser from Vogon poetry into a Babel fish.
 In practice you’ll compose the built-ins (`NestedDelimiters`, `SkipUntil`) with
 a couple of bespoke closures and quickly look like you own the place.
 
-### 5 Getting Codex to Behave (or: How to Babysit a 2-Metre Tall Neural Net)
+### 5 Getting Codex to behave (or: how to babysit a 2-metre tall neural net)
 
 Codex is a marvellous companion so long as you:
 
@@ -67,7 +67,7 @@ Codex is a marvellous companion so long as you:
   assert equality. Failures mean Codex (or you) has mis-remembered the
   Restaurant at the End of the File.
 
-### 6 Linting: The First Sip of the Differential Logic Engine
+### 6 Linting: the first sip of the differential logic engine
 
 Treat the linter as the pre-solver phase of your differential logic engine:
 
@@ -79,7 +79,7 @@ Treat the linter as the pre-solver phase of your differential logic engine:
 Because differential logic supports incremental re-checking, you can deliver
 IDE feedback faster than a hyperspace bypass.
 
-### 7 Keeping the Whole Show Flying
+### 7 Keeping the whole show flying
 
 - **CI Pipeline:** `cargo insta test`, `cargo clippy --deny warnings`, and your
   round-trip parser tests on every push.

--- a/docs/building-an-error-recovering-parser-with-chumsky.md
+++ b/docs/building-an-error-recovering-parser-with-chumsky.md
@@ -1,4 +1,4 @@
-# DON’T PANIC: A Hitchhiker’s Guide to Building an Error-Recovering Parser with **Chumsky**
+# DON’T panic: a hitchhiker’s guide to building an error-recovering parser with **Chumsky**
 
 > *A completely remarkable book. Probably the most remarkable, certainly the
 > most successful book ever to come out of the great publishing corporations of
@@ -8,8 +8,8 @@
 
 Before you even think about summoning Chumsky’s combinators, write your grammar
 down — preferably in EBNF, biro on a napkin, or etched into the side of a Vogon
-constructor fleet. Chumsky mirrors whatever you hand it; change the napkin later
-and you’ll be spelunking inside recursive lambdas at 2 a.m.
+constructor fleet. Chumsky mirrors whatever you hand it; change the napkin
+later and you’ll be spelunking inside recursive lambdas at 2 a.m.
 
 ### Checklist
 
@@ -32,8 +32,8 @@ slice the source first. You’ll get:
 ### 3 Dealing with Left-Recursion, Infinite Loops and Other Things That Ate Betelgeuse
 
 Left-recursive rules make top-down parsers seize up like Marvin’s shoulder
-joints. Rewrite them with repetition combinators (`many()`, `foldl()`), or use a
-precedence-climbing expression parser.
+joints. Rewrite them with repetition combinators (`many()`, `foldl()`), or use
+a precedence-climbing expression parser.
 
 Forward references? Wrap them in `recursive(|expr| { … })` so Chumsky can see
 round corners.
@@ -76,8 +76,8 @@ Treat the linter as the pre-solver phase of your differential logic engine:
 3. Emit a constraint set and immediately feed it to the solver; conflicts become
    diagnostics.
 
-Because differential logic supports incremental re-checking, you can deliver IDE
-feedback faster than a hyperspace bypass.
+Because differential logic supports incremental re-checking, you can deliver
+IDE feedback faster than a hyperspace bypass.
 
 ### 7 Keeping the Whole Show Flying
 
@@ -92,9 +92,9 @@ ______________________________________________________________________
 
 ### TL;DR (because life is short and full of Thursdays)
 
-Write the grammar first, lex separately, tame left-recursion, anchor recovery on
-hard delimiters, keep Codex on a tight leash, and let your linter double as the
-logic engine’s warm-up act.
+Write the grammar first, lex separately, tame left-recursion, anchor recovery
+on hard delimiters, keep Codex on a tight leash, and let your linter double as
+the logic engine’s warm-up act.
 
 And always keep your towel handy. It’s the most massively useful thing an
 interstellar parser hacker can carry.

--- a/docs/complexity-antipatterns-and-refactoring-strategies.md
+++ b/docs/complexity-antipatterns-and-refactoring-strategies.md
@@ -243,9 +243,8 @@ Preventing the Bumpy Road begins with a commitment to sound software
 engineering principles from the outset.
 
 1. **Adherence to Single Responsibility Principle (SRP):** Ensure that each
-   function or method has one clear, well-defined responsibility.8 If a
-   function starts handling multiple distinct logical blocks, it's a sign that
-   it needs to be decomposed.
+   function or method has one clear, well-defined responsibility.8 When a
+   function handles multiple distinct logical blocks, decompose it immediately.
 
 2. **Incremental Refactoring:** Don't wait for complexity to accumulate.
    Refactor code regularly as part of the development process, not as a
@@ -370,8 +369,8 @@ escalating into full-blown Bumpy Roads.
 7. **Declining Code Health Metrics:** Tools like CodeScene provide "Code Health"
    metrics which can degrade if Bumpy Roads are introduced.6
 
-Address these red flags through disciplined refactoring to maintain a smoother,
-more navigable codebase.
+By proactively addressing these red flags through disciplined refactoring,
+teams can maintain a smoother, more navigable codebase.
 
 ## V. Broader Implications and Clean Refactoring Approaches
 
@@ -417,9 +416,9 @@ CQRS is an architectural pattern that segregates operations that modify state
 (Commands) from operations that read state (Queries).18 Commands are task-based
 and should represent specific business intentions (e.g.,
 
-`BookHotelRoomCommand` rather than `SetReservationStatusCommand`).18 Queries,
-on the other hand, never alter data and return Data Transfer Objects (DTOs)
-optimized for display needs.18
+`BookHotelRoomCommand` rather than `SetReservationStatusCommand`).18 Queries
+never alter data and return Data Transfer Objects (DTOs) optimised for display
+needs.18
 
 While CQRS operates at a higher architectural level than a single Bumpy Road
 method, the principles are related. Complex methods often arise when read and

--- a/docs/complexity-antipatterns-and-refactoring-strategies.md
+++ b/docs/complexity-antipatterns-and-refactoring-strategies.md
@@ -545,7 +545,7 @@ and method structure.
   - Break large methods into smaller, cohesive units
   - Benefit: shorter methods and clearer intent
   - Solves spaghetti code and Bumpy Road issues
-- **Structural Pattern Matching**
+- **Structural pattern matching**
   - Replace complex if/else or switch constructs with pattern matching
   - Benefit: simpler conditional logic and data extraction
   - Solves deeply nested conditionals
@@ -558,12 +558,12 @@ and method structure.
   - Benefit: removes large conditional blocks
   - Solves complex switch statements
 
-1\. Structural Pattern Matching
+1. Structural pattern matching
 
 Structural pattern matching, available in languages like Python (since 3.10
 with match-case) and C#, offers a declarative and expressive way to handle
 complex conditional logic, often replacing verbose if-elif-else chains or
-switch statements.31
+switch statements.31.
 
 It works by allowing code to match against the *structure* of data—such as its
 type, shape, or specific values within sequences (lists, tuples) or mappings
@@ -573,7 +573,7 @@ comes from the direct mapping of data shapes to code blocks, making it easier
 to understand the conditions under which a piece of code executes.31 For
 instance, instead of multiple
 
-`isinstance` checks followed by key lookups and value comparisons in a nested
+`isinstance` checks followed by key lookups and value comparisons in a nested.
 `if` structure to parse a JSON object, a single `case` statement with a mapping
 pattern can define the expected structure and extract the necessary values
 concisely.32 This shifts the focus from an imperative sequence of checks to a
@@ -753,7 +753,7 @@ By thoughtfully applying these refactoring strategies, developers can
 significantly reduce cognitive complexity, making codebases more
 understandable, maintainable, and adaptable to future changes.
 
-## VI. Conclusion: Towards a More Maintainable and Understandable Codebase
+## VI. Conclusion: towards a more maintainable and understandable codebase
 
 Managing software complexity, particularly the cognitive load it imposes on
 developers, is not a one-time task but a continuous discipline crucial for the
@@ -763,7 +763,7 @@ different aspects of this challenge, with Cognitive Complexity offering a more
 nuanced view of human understandability. The Bumpy Road antipattern serves as a
 clear indicator of localized, excessive complexity, often stemming from
 violations of the Single Responsibility Principle and a lack of timely
-refactoring.
+refactorings.
 
 The journey towards a more maintainable codebase involves recognizing such
 antipatterns and understanding their connection to fundamental principles like

--- a/docs/complexity-antipatterns-and-refactoring-strategies.md
+++ b/docs/complexity-antipatterns-and-refactoring-strategies.md
@@ -46,8 +46,8 @@ the number of edges, N is the number of nodes, and P is the number of connected
 components (typically 1 for a single program or method).3 A simpler formulation
 for a single subroutine is
 
-M=number of decision points+1, where decision points include constructs like
-`if` statements and conditional loops.3
+M = number of decision points + 1, where decision points include constructs
+like `if` statements and conditional loops.3
 
 Thresholds and Implications:
 
@@ -338,8 +338,8 @@ perform auto-refactoring for certain languages.6
 
 ### C. Red Flags Portending the Bumpy Road
 
-Being vigilant for early warning signs can help prevent a minor complexity
-issue from escalating into a full-blown Bumpy Road.
+Recognising early warning signs can prevent minor complexity issues from
+escalating into full-blown Bumpy Roads.
 
 1. **Increasing Cognitive Complexity Scores:** A rising Cognitive Complexity
    score for a method in static analysis tools is a direct indicator.8
@@ -370,15 +370,15 @@ issue from escalating into a full-blown Bumpy Road.
 7. **Declining Code Health Metrics:** Tools like CodeScene provide "Code Health"
    metrics which can degrade if Bumpy Roads are introduced.6
 
-By proactively addressing these red flags through disciplined refactoring,
-teams can maintain a smoother, more navigable codebase.
+Address these red flags through disciplined refactoring to maintain a smoother,
+more navigable codebase.
 
 ## V. Broader Implications and Clean Refactoring Approaches
 
-The challenges posed by high complexity and antipatterns like the Bumpy Road
-are deeply intertwined with fundamental software design principles.
-Understanding these connections and employing sophisticated refactoring
-techniques are key to building truly maintainable systems.
+High complexity and antipatterns like the Bumpy Road stem from violations of
+fundamental software design principles. Understanding these connections and
+applying sophisticated refactoring techniques are essential for building
+maintainable systems.
 
 ### A. Relation to Separation of Concerns and CQRS
 
@@ -466,12 +466,12 @@ discourages methods from accumulating diverse responsibilities.18
 
 When refactoring complex, tangled code (often called "Spaghetti Code" 2), a
 common approach is to break it down into smaller pieces, such as functions or
-classes. However, if this is done without careful consideration for cohesion
-and appropriate levels of abstraction, it can lead to "Ravioli Code".24 Ravioli
-Code is characterized by a multitude of small, often overly granular classes or
-functions, where understanding the overall program flow requires navigating
-through numerous tiny, disconnected pieces, making it as hard to follow as the
-original spaghetti.24
+classes. However, without careful consideration for cohesion and appropriate
+abstraction levels, this approach can create "Ravioli Code".24 Ravioli Code
+consists of numerous small, overly granular classes or functions where
+understanding the overall programme flow requires navigating through many tiny,
+disconnected pieces—making it as difficult to follow as the original
+spaghetti.24
 
 **Strategies to Avoid Ravioli Code:**
 
@@ -783,11 +783,10 @@ applied judiciously, always prioritizing genuine improvements in clarity and
 maintainability over adherence to a pattern for its own sake, to avoid pitfalls
 like Ravioli Code.
 
-A proactive and disciplined approach, where these principles and techniques are
-integrated into daily development practices, is essential. This includes
-regular code reviews, monitoring complexity metrics, and fostering a team
-culture that values code quality and continuous improvement. The oft-quoted
-wisdom, "Good programmers write code that humans can understand" 1, remains the
-guiding principle. By striving for this ideal, development teams can build
-systems that are not only powerful and efficient but also a pleasure to evolve
-and maintain.
+Integrate these principles and techniques into daily development practices
+through a proactive and disciplined approach. This includes regular code
+reviews, monitoring complexity metrics, and fostering a team culture that
+values code quality and continuous improvement. The oft-quoted wisdom, "Good
+programmers write code that humans can understand"1, remains the guiding
+principle. Strive for this ideal to build systems that are not only powerful
+and efficient, but also a pleasure to evolve and maintain.

--- a/docs/complexity-antipatterns-and-refactoring-strategies.md
+++ b/docs/complexity-antipatterns-and-refactoring-strategies.md
@@ -456,11 +456,12 @@ together.
 CQRS promotes a clear separation that can prevent the kind of tangled logic
 that forms Bumpy Roads. By isolating write operations (commands) from read
 operations (queries), and by encouraging task-based commands, the system
-naturally tends towards smaller, more cohesive units of behavior, thus reducing
-overall cognitive complexity within individual components.18 The separation
-allows for independent optimization and scaling of read and write sides, but
-more importantly for this discussion, it enforces a structural discipline that
-discourages methods from accumulating diverse responsibilities.18
+naturally tends towards smaller, more cohesive units of behaviour, thus
+reducing overall cognitive complexity within individual components.18 The
+separation allows for independent optimization and scaling of read and write
+sides, but more importantly for this discussion, it enforces a structural
+discipline that discourages methods from accumulating diverse
+responsibilities.18
 
 ### B. Avoiding Spaghetti Code Turning into Ravioli Code
 
@@ -479,7 +480,7 @@ spaghetti.24
    ensure that the extracted code is functionally cohesive. Elements within a
    module (function or class) should be closely related and work together to
    achieve a single, well-defined purpose. Don't break down code arbitrarily
-   based on length alone; base it on behavior and meaningful abstractions.10
+   based on length alone; base it on behaviour and meaningful abstractions.10
 
 2. **Balance Abstraction Levels:** Abstraction is about hiding unnecessary
    details and exposing essential features.27
@@ -523,9 +524,8 @@ spaghetti.24
 7. **Focus on System Flow:** While individual components in Ravioli code might
    be simple, the difficulty lies in tracing the overall execution flow. Ensure
    that the interactions and dependencies between components are clear and easy
-   to follow. Sometimes, a slightly larger, more cohesive component is
-   preferable to many tiny ones if it improves the clarity of the overall
-   system behavior.
+   to follow. A slightly larger, more cohesive component often proves superior
+   to many tiny ones when it improves overall system behaviour clarity.
 
 The goal is not to have the fewest classes or methods, but to have a structure
 where each component is easy to understand in isolation, and the interactions
@@ -632,27 +632,25 @@ When developers write declarative code, they operate at a higher level of
 abstraction, allowing them to reason about the program's intent more
 directly.34 This often leads to more concise, readable, and maintainable code
 because the "noise" of explicit iteration, temporary variables, and manual
-state updates is minimized.34 Many declarative approaches also inherently favor
-immutability and reduce side effects, which are common culprits for bugs and
-increased cognitive load in imperative code.35
+state updates is minimized.34 Many declarative approaches also inherently
+favour immutability and reduce side effects, which are common culprits for bugs
+and increased cognitive load in imperative code.35
 
-Examples include using SQL for database queries (specifying the desired
-dataset, not the retrieval algorithm) 34, or employing functional programming
-constructs like
-
-`map`, `filter`, and `reduce` on collections instead of writing explicit loops.
-Refactoring imperative code to a declarative style can start small, perhaps by
-converting a loop that filters and transforms a list into a chain of `filter`
-and `map` operations.35 The broader adoption of declarative approaches in areas
-like UI development (e.g., React) and data querying signifies an industry trend
-towards managing complexity by raising abstraction levels. However, the
-effectiveness of declarative programming relies on well-designed underlying
-abstractions; a poorly designed declarative layer might not successfully hide
-complexity or could introduce its own.41
+Examples include using SQL for database queries (specifying the desired dataset
+rather than the retrieval algorithm)34, or employing functional programming
+constructs like `map`, `filter`, and `reduce` on collections instead of writing
+explicit loops. Refactoring imperative code to a declarative style can start
+small, perhaps by converting a loop that filters and transforms a list into a
+chain of `filter` and `map` operations.35 The broader adoption of declarative
+approaches in areas like UI development (e.g., React) and data querying
+signifies an industry trend towards managing complexity by raising abstraction
+levels. However, the effectiveness of declarative programming relies on
+well-designed underlying abstractions; a poorly designed declarative layer
+might not successfully hide complexity or could introduce its own.41
 
 3\. Employing Dispatcher and Command Patterns
 
-For managing complex conditional logic that selects different behaviors (often
+For managing complex conditional logic that selects different behaviours (often
 found in Bumpy Roads or large switch statements), the Command and Dispatcher
 patterns offer a structured and extensible alternative.
 
@@ -740,10 +738,10 @@ itself remains clear and that the proliferation of small classes doesn't lead
 to Ravioli Code, where the overall system flow becomes obscured.24 Clear naming
 conventions and logical organization are vital.42
 
-The **State pattern** is a related behavioral pattern useful when an object's
-behavior changes depending on its internal state.45 Instead of using large
+The **State pattern** is a related behavioural pattern useful when an object's
+behaviour changes depending on its internal state.45 Instead of using large
 conditionals based on state variables, each state is encapsulated in its own
-object. The context object delegates behavior to its current state object.
+object. The context object delegates behaviour to its current state object.
 Transitions involve changing the context's state object. This is particularly
 effective for refactoring state machines implemented with complex
 

--- a/docs/complexity-antipatterns-and-refactoring-strategies.md
+++ b/docs/complexity-antipatterns-and-refactoring-strategies.md
@@ -264,8 +264,7 @@ engineering principles from the outset.
 
 6. **Return Early / Guard Clauses:** To avoid deep nesting for validation or
    pre-condition checks, process exceptional cases first and return early.8
-   This flattens the main logic path. For example, instead of:
-
+   This approach flattens the main logic path and reduces nesting. For example, instead of:
    ```cpp
    void process(Data d) {
        if (d.isValid()) { // +1 (if)

--- a/docs/complexity-antipatterns-and-refactoring-strategies.md
+++ b/docs/complexity-antipatterns-and-refactoring-strategies.md
@@ -1,4 +1,4 @@
-# Navigating Code Complexity: A Guide for Implementers and Maintainers
+# Navigating code complexity: a guide for implementers and maintainers
 
 ## I. Introduction: The Challenge of Software Complexity
 
@@ -28,21 +28,21 @@ robust, maintainable, and understandable for the long haul.
 
 To effectively manage complexity, it is essential to measure it. Two prominent
 metrics in software engineering are Cyclomatic Complexity and Cognitive
-Complexity, each offering a distinct perspective on the challenges inherent in a
-codebase.
+Complexity, each offering a distinct perspective on the challenges inherent in
+a codebase.
 
 ### A. Cyclomatic Complexity: Measuring Testability
 
 Cyclomatic Complexity (CC), developed by Thomas J. McCabe, Sr. in 1976, is a
 quantitative measure of the number of linearly independent paths through a
-program's source code.3 It essentially quantifies the structural complexity of a
-program by counting decision points that can affect the execution flow.4 This
+program's source code.3 It essentially quantifies the structural complexity of
+a program by counting decision points that can affect the execution flow.4 This
 metric is computed using the control-flow graph of the program, where nodes
-represent indivisible groups of commands and directed edges connect nodes if one
-command can immediately follow another.3
+represent indivisible groups of commands and directed edges connect nodes if
+one command can immediately follow another.3
 
-The formula for Cyclomatic Complexity is often given as M=E−N+2P, where E is the
-number of edges, N is the number of nodes, and P is the number of connected
+The formula for Cyclomatic Complexity is often given as M=E−N+2P, where E is
+the number of edges, N is the number of nodes, and P is the number of connected
 components (typically 1 for a single program or method).3 A simpler formulation
 for a single subroutine is
 
@@ -73,8 +73,8 @@ risk categorization based on CC scores 3:
 
 Cognitive Complexity, a metric notably championed by SonarSource, addresses a
 different facet of code complexity: how difficult a piece of code is to
-intuitively read and understand by a human.1 Unlike Cyclomatic Complexity, which
-is rooted in mathematical graph theory, Cognitive Complexity aims to more
+intuitively read and understand by a human.1 Unlike Cyclomatic Complexity,
+which is rooted in mathematical graph theory, Cognitive Complexity aims to more
 accurately reflect the mental effort required to comprehend the control flow of
 a unit of code.7 It acknowledges that developers spend more time reading and
 understanding code than writing it.8
@@ -95,9 +95,9 @@ Cognitive Complexity is incremented based on three main rules 8:
 3. **Shorthand Discount:** Structures that allow multiple statements to be read
    as a single unit (e.g., a well-named method call) do not incur the same
    penalties as the raw statements they encapsulate. Method calls are generally
-   "free" in terms of cognitive complexity, as a well-chosen name summarizes the
-   underlying logic, allowing readers to grasp the high-level view before diving
-   into details. Recursive calls, however, do increment the score.8
+   "free" in terms of cognitive complexity, as a well-chosen name summarizes
+   the underlying logic, allowing readers to grasp the high-level view before
+   diving into details. Recursive calls, however, do increment the score.8
 
 For instance, a `switch` statement with multiple cases might have a high
 Cyclomatic Complexity because each case represents a distinct path for testing.
@@ -110,10 +110,10 @@ Thresholds and Implications:
 
 Code with high Cognitive Complexity is harder to read, understand, test, and
 modify.8 SonarQube, for example, raises issues when a function's Cognitive
-Complexity exceeds a certain threshold, signaling that the code should likely be
-refactored into smaller, more manageable pieces.8 The primary impact of high
-Cognitive Complexity is a slowdown in development and an increase in maintenance
-costs.8
+Complexity exceeds a certain threshold, signaling that the code should likely
+be refactored into smaller, more manageable pieces.8 The primary impact of high
+Cognitive Complexity is a slowdown in development and an increase in
+maintenance costs.8
 
 ### Table 1: Cyclomatic vs. Cognitive Complexity
 
@@ -189,18 +189,18 @@ The severity of a Bumpy Road can be assessed by 6:
   model).
 
 Fundamentally, a Bumpy Road signifies a function that is trying to do too many
-things, violating the Single Responsibility Principle. It acts as an obstacle to
-comprehension, forcing developers to slow down and pay meticulous attention,
+things, violating the Single Responsibility Principle. It acts as an obstacle
+to comprehension, forcing developers to slow down and pay meticulous attention,
 much like a physical bumpy road slows down driving.6
 
 ### B. How It Forms and Its Impact
 
 The Bumpy Road antipattern, like many software antipatterns, often emerges from
-development practices that prioritize short-term speed over long-term structural
-integrity.2 Rushed development cycles, lack of clear design, or cutting corners
-on maintenance can lead to the gradual accumulation of conditional logic within
-a single function.2 As new requirements or edge cases are handled, developers
-might add more
+development practices that prioritize short-term speed over long-term
+structural integrity.2 Rushed development cycles, lack of clear design, or
+cutting corners on maintenance can lead to the gradual accumulation of
+conditional logic within a single function.2 As new requirements or edge cases
+are handled, developers might add more
 
 `if` statements or loops to an existing method rather than stepping back to
 refactor and create appropriate abstractions.
@@ -227,8 +227,9 @@ The impact of this antipattern is significant:
   such code can be frustrating and demotivating.2
 
 The Bumpy Road is a strong predictor of code that is expensive to maintain and
-risky to evolve.6 It's a clear signal that the code is not well-aligned with how
-human brains process information, making it a prime candidate for refactoring.
+risky to evolve.6 It's a clear signal that the code is not well-aligned with
+how human brains process information, making it a prime candidate for
+refactoring.
 
 ## IV. Navigating and Rectifying the Bumpy Road
 
@@ -238,13 +239,13 @@ code. Identifying early warning signs is also crucial.
 
 ### A. Avoiding the Antipattern: Proactive Strategies
 
-Preventing the Bumpy Road begins with a commitment to sound software engineering
-principles from the outset.
+Preventing the Bumpy Road begins with a commitment to sound software
+engineering principles from the outset.
 
 1. **Adherence to Single Responsibility Principle (SRP):** Ensure that each
-   function or method has one clear, well-defined responsibility.8 If a function
-   starts handling multiple distinct logical blocks, it's a sign that it needs
-   to be decomposed.
+   function or method has one clear, well-defined responsibility.8 If a
+   function starts handling multiple distinct logical blocks, it's a sign that
+   it needs to be decomposed.
 
 2. **Incremental Refactoring:** Don't wait for complexity to accumulate.
    Refactor code regularly as part of the development process, not as a
@@ -263,8 +264,8 @@ principles from the outset.
    using tools like SonarQube.1 Set thresholds and address violations promptly.
 
 6. **Return Early / Guard Clauses:** To avoid deep nesting for validation or
-   pre-condition checks, process exceptional cases first and return early.8 This
-   flattens the main logic path. For example, instead of:
+   pre-condition checks, process exceptional cases first and return early.8
+   This flattens the main logic path. For example, instead of:
 
    ```cpp
    void process(Data d) {
@@ -337,8 +338,8 @@ perform auto-refactoring for certain languages.6
 
 ### C. Red Flags Portending the Bumpy Road
 
-Being vigilant for early warning signs can help prevent a minor complexity issue
-from escalating into a full-blown Bumpy Road.
+Being vigilant for early warning signs can help prevent a minor complexity
+issue from escalating into a full-blown Bumpy Road.
 
 1. **Increasing Cognitive Complexity Scores:** A rising Cognitive Complexity
    score for a method in static analysis tools is a direct indicator.8
@@ -369,46 +370,46 @@ from escalating into a full-blown Bumpy Road.
 7. **Declining Code Health Metrics:** Tools like CodeScene provide "Code Health"
    metrics which can degrade if Bumpy Roads are introduced.6
 
-By proactively addressing these red flags through disciplined refactoring, teams
-can maintain a smoother, more navigable codebase.
+By proactively addressing these red flags through disciplined refactoring,
+teams can maintain a smoother, more navigable codebase.
 
 ## V. Broader Implications and Clean Refactoring Approaches
 
-The challenges posed by high complexity and antipatterns like the Bumpy Road are
-deeply intertwined with fundamental software design principles. Understanding
-these connections and employing sophisticated refactoring techniques are key to
-building truly maintainable systems.
+The challenges posed by high complexity and antipatterns like the Bumpy Road
+are deeply intertwined with fundamental software design principles.
+Understanding these connections and employing sophisticated refactoring
+techniques are key to building truly maintainable systems.
 
 ### A. Relation to Separation of Concerns and CQRS
 
 1\. Separation of Concerns (SoC)
 
 Separation of Concerns is a design principle that advocates for dividing a
-computer program into distinct sections, where each section addresses a separate
-concern.17 A "concern" is a set of information that affects the code of a
-computer program. Modularity is achieved by encapsulating information within a
-section of code that has a well-defined interface.17
+computer program into distinct sections, where each section addresses a
+separate concern.17 A "concern" is a set of information that affects the code
+of a computer program. Modularity is achieved by encapsulating information
+within a section of code that has a well-defined interface.17
 
-The Bumpy Road antipattern is a direct violation of SoC. Each "bump" in the code
-often represents a distinct concern or responsibility that has been improperly
-co-located within a single method.6 For example, a single method might handle
-input validation, business logic processing for different cases, data
-transformation, and error handling for each case, all intermingled. Refactoring
-a Bumpy Road by extracting methods inherently applies SoC, as each extracted
-method ideally handles a single, well-defined concern.10 This leads to increased
-freedom for simplification, maintenance, module upgrade, reuse, and independent
-development.17 While SoC might introduce more interfaces and potentially more
-code to execute, the benefits in clarity and maintainability often outweigh
-these costs, especially as systems grow.17
+The Bumpy Road antipattern is a direct violation of SoC. Each "bump" in the
+code often represents a distinct concern or responsibility that has been
+improperly co-located within a single method.6 For example, a single method
+might handle input validation, business logic processing for different cases,
+data transformation, and error handling for each case, all intermingled.
+Refactoring a Bumpy Road by extracting methods inherently applies SoC, as each
+extracted method ideally handles a single, well-defined concern.10 This leads
+to increased freedom for simplification, maintenance, module upgrade, reuse,
+and independent development.17 While SoC might introduce more interfaces and
+potentially more code to execute, the benefits in clarity and maintainability
+often outweigh these costs, especially as systems grow.17
 
 Consider a function that processes different types of user commands. A Bumpy
 Road approach might have a large `if-else if-else` structure, with each block
 handling a command type and its associated logic. This mixes the concern of
-"dispatching" or "routing" based on command type with the concern of "executing"
-each specific command. Applying SoC would involve separating these: perhaps one
-component decides which command to execute, and separate components (functions
-or classes) handle the execution of each command. This separation makes the
-system easier to understand, test, and extend with new commands.
+"dispatching" or "routing" based on command type with the concern of
+"executing" each specific command. Applying SoC would involve separating these:
+perhaps one component decides which command to execute, and separate components
+(functions or classes) handle the execution of each command. This separation
+makes the system easier to understand, test, and extend with new commands.
 
 2\. Command Query Responsibility Segregation (CQRS)
 
@@ -416,8 +417,8 @@ CQRS is an architectural pattern that segregates operations that modify state
 (Commands) from operations that read state (Queries).18 Commands are task-based
 and should represent specific business intentions (e.g.,
 
-`BookHotelRoomCommand` rather than `SetReservationStatusCommand`).18 Queries, on
-the other hand, never alter data and return Data Transfer Objects (DTOs)
+`BookHotelRoomCommand` rather than `SetReservationStatusCommand`).18 Queries,
+on the other hand, never alter data and return Data Transfer Objects (DTOs)
 optimized for display needs.18
 
 While CQRS operates at a higher architectural level than a single Bumpy Road
@@ -447,27 +448,27 @@ together.
   methods within that class becoming Bumpy Roads. CQRS can help decompose God
   Objects by separating their command-handling responsibilities from their
   query-handling responsibilities, potentially leading to smaller, more focused
-  classes (e.g., one class for command processing, another for query processing,
-  or even finer-grained handlers).21 This separation simplifies each part,
-  making them easier to manage and reducing the cognitive load associated with
-  the original monolithic structure.
+  classes (e.g., one class for command processing, another for query
+  processing, or even finer-grained handlers).21 This separation simplifies
+  each part, making them easier to manage and reducing the cognitive load
+  associated with the original monolithic structure.
 
-CQRS promotes a clear separation that can prevent the kind of tangled logic that
-forms Bumpy Roads. By isolating write operations (commands) from read operations
-(queries), and by encouraging task-based commands, the system naturally tends
-towards smaller, more cohesive units of behavior, thus reducing overall
-cognitive complexity within individual components.18 The separation allows for
-independent optimization and scaling of read and write sides, but more
-importantly for this discussion, it enforces a structural discipline that
+CQRS promotes a clear separation that can prevent the kind of tangled logic
+that forms Bumpy Roads. By isolating write operations (commands) from read
+operations (queries), and by encouraging task-based commands, the system
+naturally tends towards smaller, more cohesive units of behavior, thus reducing
+overall cognitive complexity within individual components.18 The separation
+allows for independent optimization and scaling of read and write sides, but
+more importantly for this discussion, it enforces a structural discipline that
 discourages methods from accumulating diverse responsibilities.18
 
 ### B. Avoiding Spaghetti Code Turning into Ravioli Code
 
 When refactoring complex, tangled code (often called "Spaghetti Code" 2), a
 common approach is to break it down into smaller pieces, such as functions or
-classes. However, if this is done without careful consideration for cohesion and
-appropriate levels of abstraction, it can lead to "Ravioli Code".24 Ravioli Code
-is characterized by a multitude of small, often overly granular classes or
+classes. However, if this is done without careful consideration for cohesion
+and appropriate levels of abstraction, it can lead to "Ravioli Code".24 Ravioli
+Code is characterized by a multitude of small, often overly granular classes or
 functions, where understanding the overall program flow requires navigating
 through numerous tiny, disconnected pieces, making it as hard to follow as the
 original spaghetti.24
@@ -523,8 +524,8 @@ original spaghetti.24
    be simple, the difficulty lies in tracing the overall execution flow. Ensure
    that the interactions and dependencies between components are clear and easy
    to follow. Sometimes, a slightly larger, more cohesive component is
-   preferable to many tiny ones if it improves the clarity of the overall system
-   behavior.
+   preferable to many tiny ones if it improves the clarity of the overall
+   system behavior.
 
 The goal is not to have the fewest classes or methods, but to have a structure
 where each component is easy to understand in isolation, and the interactions
@@ -559,18 +560,18 @@ and method structure.
 
 1\. Structural Pattern Matching
 
-Structural pattern matching, available in languages like Python (since 3.10 with
-match-case) and C#, offers a declarative and expressive way to handle complex
-conditional logic, often replacing verbose if-elif-else chains or switch
-statements.31
+Structural pattern matching, available in languages like Python (since 3.10
+with match-case) and C#, offers a declarative and expressive way to handle
+complex conditional logic, often replacing verbose if-elif-else chains or
+switch statements.31
 
 It works by allowing code to match against the *structure* of data—such as its
 type, shape, or specific values within sequences (lists, tuples) or mappings
 (dictionaries)—and simultaneously destructure this data, binding parts of it to
 variables.32 This approach can significantly reduce cognitive load. The clarity
-comes from the direct mapping of data shapes to code blocks, making it easier to
-understand the conditions under which a piece of code executes.31 For instance,
-instead of multiple
+comes from the direct mapping of data shapes to code blocks, making it easier
+to understand the conditions under which a piece of code executes.31 For
+instance, instead of multiple
 
 `isinstance` checks followed by key lookups and value comparisons in a nested
 `if` structure to parse a JSON object, a single `case` statement with a mapping
@@ -578,8 +579,8 @@ pattern can define the expected structure and extract the necessary values
 concisely.32 This shifts the focus from an imperative sequence of checks to a
 declarative description of data shapes, which is often more intuitive. The
 destructuring capability is particularly powerful, as it eliminates the manual
-code otherwise needed to extract values after a condition has been met, reducing
-boilerplate and the number of mental steps a developer must follow.32
+code otherwise needed to extract values after a condition has been met,
+reducing boilerplate and the number of mental steps a developer must follow.32
 
 Consider processing different event types from a UI framework, where events are
 represented as dictionaries.39
@@ -624,20 +625,20 @@ further enhancing its power.32
 
 Declarative programming focuses on describing what result is desired, rather
 than detailing how to achieve it step-by-step, as is typical in imperative
-programming.34 This paradigm shift can significantly reduce cognitive complexity
-by abstracting away low-level control flow and state management.
+programming.34 This paradigm shift can significantly reduce cognitive
+complexity by abstracting away low-level control flow and state management.
 
 When developers write declarative code, they operate at a higher level of
-abstraction, allowing them to reason about the program's intent more directly.34
-This often leads to more concise, readable, and maintainable code because the
-"noise" of explicit iteration, temporary variables, and manual state updates is
-minimized.34 Many declarative approaches also inherently favor immutability and
-reduce side effects, which are common culprits for bugs and increased cognitive
-load in imperative code.35
+abstraction, allowing them to reason about the program's intent more
+directly.34 This often leads to more concise, readable, and maintainable code
+because the "noise" of explicit iteration, temporary variables, and manual
+state updates is minimized.34 Many declarative approaches also inherently favor
+immutability and reduce side effects, which are common culprits for bugs and
+increased cognitive load in imperative code.35
 
-Examples include using SQL for database queries (specifying the desired dataset,
-not the retrieval algorithm) 34, or employing functional programming constructs
-like
+Examples include using SQL for database queries (specifying the desired
+dataset, not the retrieval algorithm) 34, or employing functional programming
+constructs like
 
 `map`, `filter`, and `reduce` on collections instead of writing explicit loops.
 Refactoring imperative code to a declarative style can start small, perhaps by
@@ -655,15 +656,15 @@ For managing complex conditional logic that selects different behaviors (often
 found in Bumpy Roads or large switch statements), the Command and Dispatcher
 patterns offer a structured and extensible alternative.
 
-The **Command pattern** encapsulates a request or an action as an object.36 Each
-command object implements a common interface (e.g., with an
+The **Command pattern** encapsulates a request or an action as an object.36
+Each command object implements a common interface (e.g., with an
 
-`execute()` method). This decouples the object that invokes the command from the
-object that knows how to perform it. Instead of a large conditional checking a
-type and then executing logic, different command objects can be instantiated
-based on the type, and then their `execute()` method is called. This promotes
-SRP, as each command class handles a single action, making the system easier to
-test and extend.37
+`execute()` method). This decouples the object that invokes the command from
+the object that knows how to perform it. Instead of a large conditional
+checking a type and then executing logic, different command objects can be
+instantiated based on the type, and then their `execute()` method is called.
+This promotes SRP, as each command class handles a single action, making the
+system easier to test and extend.37
 
 The **Dispatcher pattern** often works in conjunction with the Command pattern.
 A dispatcher is a central component that receives requests (which could be
@@ -734,9 +735,9 @@ This approach not only simplifies the original `handleMessage` method but also
 makes the system more extensible, as new message types can be supported by
 adding new handler classes and registering them with the dispatcher, often
 without modifying existing dispatcher code (aligning with the Open/Closed
-Principle). However, it's important to ensure that the dispatch mechanism itself
-remains clear and that the proliferation of small classes doesn't lead to
-Ravioli Code, where the overall system flow becomes obscured.24 Clear naming
+Principle). However, it's important to ensure that the dispatch mechanism
+itself remains clear and that the proliferation of small classes doesn't lead
+to Ravioli Code, where the overall system flow becomes obscured.24 Clear naming
 conventions and logical organization are vital.42
 
 The **State pattern** is a related behavioral pattern useful when an object's
@@ -749,19 +750,20 @@ effective for refactoring state machines implemented with complex
 `if/else` or `switch` statements.45
 
 By thoughtfully applying these refactoring strategies, developers can
-significantly reduce cognitive complexity, making codebases more understandable,
-maintainable, and adaptable to future changes.
+significantly reduce cognitive complexity, making codebases more
+understandable, maintainable, and adaptable to future changes.
 
 ## VI. Conclusion: Towards a More Maintainable and Understandable Codebase
 
 Managing software complexity, particularly the cognitive load it imposes on
 developers, is not a one-time task but a continuous discipline crucial for the
-long-term health and success of any software project.12 This report has explored
-Cyclomatic and Cognitive Complexity as vital metrics for quantifying different
-aspects of this challenge, with Cognitive Complexity offering a more nuanced
-view of human understandability. The Bumpy Road antipattern serves as a clear
-indicator of localized, excessive complexity, often stemming from violations of
-the Single Responsibility Principle and a lack of timely refactoring.
+long-term health and success of any software project.12 This report has
+explored Cyclomatic and Cognitive Complexity as vital metrics for quantifying
+different aspects of this challenge, with Cognitive Complexity offering a more
+nuanced view of human understandability. The Bumpy Road antipattern serves as a
+clear indicator of localized, excessive complexity, often stemming from
+violations of the Single Responsibility Principle and a lack of timely
+refactoring.
 
 The journey towards a more maintainable codebase involves recognizing such
 antipatterns and understanding their connection to fundamental principles like
@@ -782,9 +784,10 @@ maintainability over adherence to a pattern for its own sake, to avoid pitfalls
 like Ravioli Code.
 
 A proactive and disciplined approach, where these principles and techniques are
-integrated into daily development practices, is essential. This includes regular
-code reviews, monitoring complexity metrics, and fostering a team culture that
-values code quality and continuous improvement. The oft-quoted wisdom, "Good
-programmers write code that humans can understand" 1, remains the guiding
-principle. By striving for this ideal, development teams can build systems that
-are not only powerful and efficient but also a pleasure to evolve and maintain.
+integrated into daily development practices, is essential. This includes
+regular code reviews, monitoring complexity metrics, and fostering a team
+culture that values code quality and continuous improvement. The oft-quoted
+wisdom, "Good programmers write code that humans can understand" 1, remains the
+guiding principle. By striving for this ideal, development teams can build
+systems that are not only powerful and efficient but also a pleasure to evolve
+and maintain.

--- a/docs/complexity-antipatterns-and-refactoring-strategies.md
+++ b/docs/complexity-antipatterns-and-refactoring-strategies.md
@@ -28,8 +28,8 @@ robust, maintainable, and understandable for the long haul.
 
 To effectively manage complexity, it is essential to measure it. Two prominent
 metrics in software engineering are Cyclomatic Complexity and Cognitive
-Complexity, each offering a distinct perspective on the challenges inherent in
-a codebase.
+Complexity, each offering a distinct perspective on codebase complexity
+challenges.
 
 ### A. Cyclomatic Complexity: Measuring Testability
 
@@ -74,7 +74,7 @@ risk categorization based on CC scores 3:
 Cognitive Complexity, a metric notably championed by SonarSource, addresses a
 different facet of code complexity: how difficult a piece of code is to
 intuitively read and understand by a human.1 Unlike Cyclomatic Complexity,
-which is rooted in mathematical graph theory, Cognitive Complexity aims to more
+which relies on mathematical graph theory, Cognitive Complexity aims to more
 accurately reflect the mental effort required to comprehend the control flow of
 a unit of code.7 It acknowledges that developers spend more time reading and
 understanding code than writing it.8
@@ -95,9 +95,9 @@ Cognitive Complexity is incremented based on three main rules 8:
 3. **Shorthand Discount:** Structures that allow multiple statements to be read
    as a single unit (e.g., a well-named method call) do not incur the same
    penalties as the raw statements they encapsulate. Method calls are generally
-   "free" in terms of cognitive complexity, as a well-chosen name summarizes
+   "free" in terms of cognitive complexity, as a well-chosen name summarises
    the underlying logic, allowing readers to grasp the high-level view before
-   diving into details. Recursive calls, however, do increment the score.8
+   diving into details. However, recursive calls do increment the score.8
 
 For instance, a `switch` statement with multiple cases might have a high
 Cyclomatic Complexity because each case represents a distinct path for testing.
@@ -749,9 +749,9 @@ effective for refactoring state machines implemented with complex
 
 `if/else` or `switch` statements.45
 
-By thoughtfully applying these refactoring strategies, developers can
-significantly reduce cognitive complexity, making codebases more
-understandable, maintainable, and adaptable to future changes.
+Thoughtfully apply these refactoring strategies to significantly reduce
+cognitive complexity and create codebases that are more understandable,
+maintainable, and adaptable to future changes.
 
 ## VI. Conclusion: towards a more maintainable and understandable codebase
 

--- a/docs/ddlint-design-and-road-map.md
+++ b/docs/ddlint-design-and-road-map.md
@@ -76,7 +76,7 @@ the team to leverage proven patterns and focus on implementing DDlog-specific
 logic.
 
 The heart of this adapted engine will be a set of core traits that define the
-structure and behavior of every lint rule:
+structure and behaviour of every lint rule:
 
 - `trait Rule`: This will be the base trait for all rules, containing shared
   metadata. It will expose methods such as `name()`, which returns a unique,
@@ -515,7 +515,7 @@ Key command-line arguments and flags will include:
 - `--no-ignore`: Disables the default ignore patterns (e.g., for `.git` or
   `target` directories), allowing all files to be processed.
 
-The behavior of this CLI—including its arguments, exit codes, `stdout`, and
+The behaviour of this CLI—including its arguments, exit codes, `stdout`, and
 `stderr`—will be subject to rigorous integration testing. The `assert_cmd`
 crate is purpose-built for this task, providing a fluent API to run the
 compiled binary as a child process and assert on its results.15 Tests will
@@ -558,7 +558,7 @@ be simple and extensible. The following table specifies the initial schema.
 | [rules.consistent-casing] | Table            | { level = "allow", relation_style = "PascalCase" } | An example of a rule with options. The level is set alongside rule-specific configuration keys.                                                                     |
 
 This schema provides a clear and powerful way for users to tailor the linter's
-behavior to their project's specific needs, from disabling entire classes of
+behaviour to their project's specific needs, from disabling entire classes of
 rules to fine-tuning the parameters of stylistic checks.
 
 ### 4.4. Logging
@@ -768,7 +768,7 @@ diagnostic tests manageable and robust.
 ### 6.3. Integration testing the CLI with `assert_cmd`
 
 The final layer of testing involves treating the compiled `ddlint` binary as a
-black box and testing its end-to-end behavior from the command line. This
+black box and testing its end-to-end behaviour from the command line. This
 ensures that all components—argument parsing, configuration file loading, file
 discovery, linting, and output formatting—work together correctly.
 
@@ -796,13 +796,13 @@ These integration tests will cover a wide range of scenarios:
 - Verifying that configuration files (`ddlint.toml`) are correctly located and
   that their settings properly override the defaults.
 
-- Testing file system interactions, such as the behavior of the `--fix` flag,
+- Testing file system interactions, such as the behaviour of the `--fix` flag,
   likely in combination with a crate like `assert_fs` for creating temporary
   file fixtures.15
 
 This comprehensive, three-tiered testing strategy ensures that every aspect of
 the linter is validated, from the micro-level logic of a single rule to the
-macro-level behavior of the final executable.
+macro-level behaviour of the final executable.
 
 ## VII. Phased implementation roadmap and future work
 

--- a/docs/ddlint-design-and-road-map.md
+++ b/docs/ddlint-design-and-road-map.md
@@ -181,6 +181,9 @@ system consumes. The quality and resilience of this parsing stage directly
 determine the linter's ability to provide value, especially when analysing
 real‑world code that is often in a syntactically incomplete or incorrect state.
 
+Short description: the following sequence diagram outlines the parsing pipeline
+from source to syntax tree.
+
 ```mermaid
 sequenceDiagram
     participant User
@@ -561,7 +564,7 @@ rules to fine-tuning the parameters of stylistic checks.
 ### 4.4. Logging
 
 The parser emits warnings using the [`log`](https://docs.rs/log/) crate. No
-logger is initialised by default. A consuming binary should call a logger setup
+logger is initialized by default. A consuming binary should call a logger setup
 routine early in `main` to surface these messages. One convenient option is
 [`env_logger`](https://docs.rs/env_logger/):
 

--- a/docs/ddlint-design-and-road-map.md
+++ b/docs/ddlint-design-and-road-map.md
@@ -1,4 +1,4 @@
-# A design document and implementation roadmap for the Differential datalog linter
+# A design document and implementation roadmap for the Differential Datalog linter
 
 ## Introduction
 
@@ -70,7 +70,7 @@ Rather than designing a linter engine from first principles, this project will
 adapt the mature and performant model pioneered by `rslint_core`.4 The
 
 `rslint` project demonstrates a highly effective architecture for a CST-based
-linter, featuring parallelized rule execution and a clean separation of
+linter, featuring parallelised rule execution and a clean separation of
 concerns that makes it both fast and maintainable.6 Adopting this model allows
 the team to leverage proven patterns and focus on implementing DDlog-specific
 logic.
@@ -142,7 +142,7 @@ industry-standard, production-grade solution for this problem.1
 Once `rowan` is chosen, the next logical step is to select a linter engine
 model that is designed to work with it. The `rslint_core` architecture, which
 is explicitly built to run rules over a CST, becomes the ideal candidate,
-providing a proven template for a performant, parallelized engine.4
+providing a proven template for a performant, parallelised engine.4
 
 The choice of a CST has further downstream effects, particularly on diagnostics
 and testing. To display the kind of rich, annotated error messages seen in
@@ -637,7 +637,7 @@ be able to not only report the problem but also apply a suggested fix
 automatically when run with the `--fix` flag.
 
 The implementation of this feature must be carefully designed to work with the
-immutable `rowan` tree and the parallelized rule runner. The core data
+immutable `rowan` tree and the parallelised rule runner. The core data
 structure for a fix will be a "suggestion," which consists of a `TextRange`
 (the slice of the original source text to be replaced) and a `String` (the new
 text to insert).
@@ -849,7 +849,7 @@ scalable linter engine, the rule management system, and the user-facing CLI.
 
   1. Implement the full linter engine inspired by `rslint_core`, including the
      `Rule` and `CstRule` traits, the `RuleCtx` struct, the `CstRuleStore`, and
-     the parallelized rule runner.4
+     the parallelised rule runner.4
 
   2. Implement the `declare_lint!` macro to streamline rule creation.6
 

--- a/docs/ddlint-design-and-road-map.md
+++ b/docs/ddlint-design-and-road-map.md
@@ -19,7 +19,7 @@ goal of creating a tool that is both powerful in its analysis and intuitive in
 its use. This document serves as the definitive technical blueprint for the
 implementation team.
 
-## I. Architectural Blueprint: A CST-First Linter Engine
+## I. Architectural blueprint: a CST-first linter engine
 
 The foundation of any modern static analysis tool is its internal
 representation of source code. The choice of this representation dictates the
@@ -28,7 +28,7 @@ experience for those building rules. For `ddlint`, the architecture will be
 built upon a Concrete Syntax Tree (CST), a decision that enables a new class of
 powerful, user-centric features.
 
-### 1.1. The Rationale for a Concrete Syntax Tree (CST) Architecture
+### 1.1. The rationale for a concrete syntax tree (CST) architecture
 
 The core of the linter will be a lossless Concrete Syntax Tree. Unlike a
 traditional Abstract Syntax Tree (AST), which represents the semantic structure
@@ -62,9 +62,9 @@ across threads. Layered on top of this is the "Red Tree," a typed, parent-aware
 API that provides ergonomic, safe access to the syntax tree for analysis.3 This
 separation provides the best of both worlds: the performance and memory
 efficiency of a compact, immutable data structure and the safety and
-convenience of a strongly-typed API.
+convenience of a strongly typed API.
 
-### 1.2. The Linter Core: Adapting the `rslint_core` Model
+### 1.2. The linter core: adapting the `rslint_core` model
 
 Rather than designing a linter engine from first principles, this project will
 adapt the mature and performant model pioneered by `rslint_core`.4 The
@@ -122,7 +122,7 @@ as follows:
    be checked against multiple nodes concurrently, a pattern proven effective
    by `rslint`.6
 
-### 1.3. The CST-Centric Toolchain
+### 1.3. The CST-centric toolchain
 
 The selection of `rowan` and a CST-based architecture is not an isolated
 decision but the cornerstone of a cohesive and deeply interconnected
@@ -173,7 +173,7 @@ methodology (`insta`). This transforms the component list from a simple
 "shopping list" of libraries into a coherent, interdependent architectural
 strategy where each part reinforces the others.
 
-## II. The Parsing Pipeline: From Source Text to Syntax Tree
+## II. The parsing pipeline: from source text to syntax tree
 
 The first and most critical step in the linting process is the transformation
 of raw DDlog source text into the structured `rowan` CST that the rest of the
@@ -217,7 +217,7 @@ with `#[repr(u16)]` and derive the `FromPrimitive` and `ToPrimitive` traits
 from the `num-derive` crate. This is because `rowan`'s internal `GreenNode`s
 are untyped and use a `rowan::SyntaxKind`, which is a newtype wrapper around a
 `u16`, for their type tags. These derivations provide a safe and efficient
-mechanism to convert between our strongly-typed `SyntaxKind` enum and `rowan`'s
+mechanism to convert between our strongly typed `SyntaxKind` enum and `rowan`'s
 generic `u16` representation.3 A special
 
 `N_ERROR` variant will also be included to represent locations in the tree
@@ -271,7 +271,7 @@ bridge, with its `kind_from_raw` and `kind_to_raw` methods using the
 `FromPrimitive` and `ToPrimitive` implementations to connect our specific DDlog
 grammar to the generic `rowan` machinery.3
 
-### 2.2. Parser Implementation Strategy: Leveraging `chumsky`
+### 2.2. Parser implementation strategy: leveraging `chumsky`
 
 Assuming a pre-existing, lossless, error-recovering DDlog parser is not readily
 available, one will be implemented using the `chumsky` parser-combinator
@@ -311,7 +311,7 @@ is the precise input required by the linter's core engine. This direct-to-CST
 parsing avoids an intermediate allocation and translation step, further
 improving performance.
 
-### 2.3. The Symbiotic Relationship Between Parser and Linter
+### 2.3. The symbiotic relationship between parser and linter
 
 The utility of a linter is directly proportional to the quality of its parser's
 error recovery. This creates a powerful, symbiotic relationship between the
@@ -360,7 +360,7 @@ investment in the core usability and value proposition of the entire linting
 tool. It enables the linter to function as a helpful "co-pilot" during
 development, rather than a rigid "gatekeeper" that only runs after the fact.
 
-## III. The Rule Ecosystem: Definition, Configuration, and Management
+## III. The rule ecosystem: definition, configuration, and management
 
 The true power and utility of a linter are derived from its set of rules. A
 well-designed rule ecosystem is one that is easy for contributors to extend,
@@ -368,7 +368,7 @@ simple for users to configure, and logically organized. This section details
 the anatomy of a lint rule, the tools for its creation, and the initial catalog
 of rules to be implemented.
 
-### 3.1. Anatomy of a Lint Rule
+### 3.1. Anatomy of a lint rule
 
 Each lint rule in `ddlint` will be a self-contained unit, implemented as a Rust
 `struct`. This `struct` will be responsible for its own logic and metadata by
@@ -378,7 +378,7 @@ The `Rule` trait serves as the metadata provider. Every rule must implement it
 to provide essential, self-describing information that the linter engine uses
 for organization, configuration, and documentation. The required methods are
 `name()`, `group()`, and `docs()`.7 This ensures that every rule is
-programmatically identifiable and its purpose is discoverable without needing
+programmatically identifiable, and its purpose is discoverable without needing
 to read its source code.
 
 The `CstRule` trait contains the analytical logic. Its methods, such as
@@ -389,7 +389,7 @@ or configuration, and report any discovered issues by creating and returning
 `Diagnostic` objects. This design keeps the logic for each rule encapsulated
 and testable in isolation.
 
-### 3.2. A Declarative Macro for Rule Creation (`declare_lint!`)
+### 3.2. A declarative macro for rule creation (`declare_lint!`)
 
 To streamline the development of new rules, reduce boilerplate, and improve the
 overall developer experience for linter contributors, the project will
@@ -445,7 +445,7 @@ It allows developers to focus on the interesting part—the analysis logic—rat
 than the ceremony of trait implementations. This encourages community
 involvement and accelerates the growth of the linter's rule set.
 
-### 3.3. Initial Lint Rule Catalog
+### 3.3. Initial lint rule catalog
 
 To provide clear scope for the initial implementation phases and to deliver
 immediate value to users, the following catalog of rules is proposed. This list
@@ -467,7 +467,7 @@ This table serves as a concrete work breakdown for the engineering team and
 clearly communicates the linter's initial capabilities and priorities to early
 adopters.
 
-## IV. User Interface and Configuration Layer
+## IV. User interface and configuration layer
 
 The success of a developer tool depends heavily on its user interface. A
 powerful analysis engine is of little use if it is difficult to configure or
@@ -475,7 +475,7 @@ its output is hard to understand. This section defines the command-line
 interface (CLI) and configuration system for `ddlint`, designed to be intuitive
 for new users while remaining powerful for advanced use cases.
 
-### 4.1. CLI Design
+### 4.1. CLI design
 
 The primary user interaction with the linter will be through its command-line
 binary, `ddlint`. The CLI will be built using the `clap` crate, the standard
@@ -521,7 +521,7 @@ cover successful runs, failure on
 `error`-level diagnostics, and the exact content of the output for various
 scenarios.17
 
-### 4.2. The Configuration File (`ddlint.toml`)
+### 4.2. The configuration file (`ddlint.toml`)
 
 To provide persistent and project-specific configuration, `ddlint` will support
 a configuration file named `ddlint.toml`. The `config-rs` crate will be used to
@@ -540,7 +540,7 @@ working directory and then traverse up through parent directories, allowing for
 a single configuration file at the root of a project to apply to all its
 subdirectories.
 
-### 4.3. Configuration File Schema (`ddlint.toml`)
+### 4.3. Configuration file schema (`ddlint.toml`)
 
 A clearly defined schema is essential for user documentation and for enabling
 features like IDE autocompletion. The `ddlint.toml` file will be structured to
@@ -576,7 +576,7 @@ fn main() {
 Set the `RUST_LOG` environment variable to control verbosity. For example, you
 can set `RUST_LOG=warn` to display warnings while suppressing debug output.
 
-## V. Advanced Features: Diagnostics and Automated Fixes
+## V. Advanced features: diagnostics and automated fixes
 
 The core value of a linter is delivered through its diagnostics and its ability
 to help the user fix the identified problems. This section details the
@@ -584,7 +584,7 @@ implementation of a state-of-the-art diagnostic system and a safe, reliable
 autofixing mechanism, which together form the linter's primary user-facing
 features.
 
-### 5.1. Implementing Rich Diagnostics with `miette`
+### 5.1. Implementing rich diagnostics with `miette`
 
 All user-facing diagnostic output will be generated using the `miette` library.9
 
@@ -627,7 +627,7 @@ to be easily and losslessly convertible into a `miette::Diagnostic`. The
 `SourceCode` (the full text of the file) and the `SourceSpan` for any node or
 token in the CST.
 
-### 5.2. The Autofixing Mechanism
+### 5.2. The autofixing mechanism
 
 For rules that are marked as `Autofixable` in the rule catalog, the linter will
 be able to not only report the problem but also apply a suggested fix
@@ -666,7 +666,7 @@ The autofixing workflow will proceed as follows:
 6. Finally, the modified text buffer is written back to the original file on
    disk.
 
-### 5.3. The "Trust but Verify" Principle of Autofixing
+### 5.3. The "trust but verify" principle of autofixing
 
 Autofixing is an immensely powerful feature, but it is also inherently
 dangerous. A bug in the fixing logic can silently corrupt a user's source code,
@@ -711,7 +711,7 @@ and refactor complex code transformations with a high degree of confidence,
 knowing that any deviation from the verified, correct output will be caught
 automatically by the CI system.
 
-## VI. A Comprehensive Testing and Validation Strategy
+## VI. A comprehensive testing and validation strategy
 
 A linter is a compiler-like tool, and its correctness, reliability, and
 performance are paramount. A bug in a linter can lead to incorrect warnings,
@@ -720,7 +720,7 @@ autofixes. To ensure the highest level of quality, a multi-layered testing
 strategy will be employed, covering every component of the system from
 individual rule logic to the final command-line binary.
 
-### 6.1. Unit Testing Individual Rules
+### 6.1. Unit testing individual rules
 
 The foundation of the testing pyramid is the unit test. Each lint rule's logic
 will be tested in isolation to verify its correctness. A testing harness will
@@ -737,7 +737,7 @@ relations are used, which asserts that no diagnostics are produced. This
 granular level of testing ensures that the core logic of each rule is sound
 before it is integrated into the larger system.
 
-### 6.2. Snapshot Testing Diagnostic Output with `insta`
+### 6.2. Snapshot testing diagnostic output with `insta`
 
 To ensure that the user-facing output of the linter is correct, consistent, and
 does not degrade over time, snapshot testing will be used extensively. This is
@@ -762,7 +762,7 @@ can approve it with a single keystroke, updating the snapshot file for future
 test runs.10 This workflow makes maintaining a large suite of complex
 diagnostic tests manageable and robust.
 
-### 6.3. Integration Testing the CLI with `assert_cmd`
+### 6.3. Integration testing the CLI with `assert_cmd`
 
 The final layer of testing involves treating the compiled `ddlint` binary as a
 black box and testing its end-to-end behavior from the command line. This
@@ -801,14 +801,14 @@ This comprehensive, three-tiered testing strategy ensures that every aspect of
 the linter is validated, from the micro-level logic of a single rule to the
 macro-level behavior of the final executable.
 
-## VII. Phased Implementation Roadmap and Future Work
+## VII. Phased implementation roadmap and future work
 
 This design is translated into an actionable, multi-phase project plan. Each
 phase is designed to deliver concrete, demonstrable value and build upon the
 foundations laid by the previous one. This iterative approach mitigates risk
 and allows for feedback to be incorporated throughout the development cycle.
 
-### Phase 1: The Foundation (Target: 1-2 Sprints)
+### Phase 1: The foundation (target: 1–2 sprints)
 
 The goal of this initial phase is to establish the core project structure and
 validate the fundamental architectural choices. It is a proof-of-concept phase
@@ -837,7 +837,7 @@ focused on getting a minimal end-to-end pipeline working.
   DDlog file and print a basic warning message to the console. This deliverable
   validates the `chumsky`-to-`rowan` pipeline.
 
-### Phase 2: The Engine (Target: 3-4 Sprints)
+### Phase 2: The engine (target: 3–4 sprints)
 
 With the foundation in place, this phase focuses on building out the robust,
 scalable linter engine, the rule management system, and the user-facing CLI.
@@ -869,7 +869,7 @@ scalable linter engine, the rule management system, and the user-facing CLI.
   `ddlint.toml` file, and it reports a useful set of correctness-related
   diagnostics.
 
-### Phase 3: Polish and Expansion (Target: 3-4 Sprints)
+### Phase 3: Polish and expansion (target: 3–4 sprints)
 
 This phase is dedicated to enhancing the user experience and expanding the
 linter's analytical capabilities to cover the full language and a wider range
@@ -897,7 +897,7 @@ of issues.
 - **Deliverable:** A feature-complete, polished, and well-documented linter
   ready for a stable 1.0 release.
 
-### Phase 4 (Future): IDE Integration via LSP
+### Phase 4 (future): IDE integration via LSP
 
 The architecture designed in the preceding phases explicitly paves the way for
 future extension into an IDE language server. The decoupling of the core

--- a/docs/documentation-style-guide.md
+++ b/docs/documentation-style-guide.md
@@ -97,7 +97,7 @@ pub fn add(a: i32, b: i32) -> i32 {
 Where it adds clarity, include [Mermaid](https://mermaid.js.org/) diagrams.
 When embedding figures, use `![alt text](path/to/image)` and provide concise
 alt text describing the content. Add a short description before each Mermaid
-diagram so screen readers can understand it.
+diagram, so screen readers can understand it.
 
 ```mermaid
 flowchart TD

--- a/docs/documentation-style-guide.md
+++ b/docs/documentation-style-guide.md
@@ -58,8 +58,8 @@ fn add(a: i32, b: i32) -> i32 {
 
 ## API doc comments (Rust)
 
-Use doc comments to document public APIs. Keep them consistent with the contents
-of the manual.
+Use doc comments to document public APIs. Keep them consistent with the
+contents of the manual.
 
 - Begin each block with `///`.
 - Keep the summary line short, followed by further detail.
@@ -94,10 +94,10 @@ pub fn add(a: i32, b: i32) -> i32 {
 
 ## Diagrams and images
 
-Where it adds clarity, include [Mermaid](https://mermaid.js.org/) diagrams. When
-embedding figures, use `![alt text](path/to/image)` and provide concise alt text
-describing the content. Add a short description before each Mermaid diagram so
-screen readers can understand it.
+Where it adds clarity, include [Mermaid](https://mermaid.js.org/) diagrams.
+When embedding figures, use `![alt text](path/to/image)` and provide concise
+alt text describing the content. Add a short description before each Mermaid
+diagram so screen readers can understand it.
 
 ```mermaid
 flowchart TD

--- a/docs/documentation-style-guide.md
+++ b/docs/documentation-style-guide.md
@@ -95,9 +95,11 @@ pub fn add(a: i32, b: i32) -> i32 {
 ## Diagrams and images
 
 Where it adds clarity, include [Mermaid](https://mermaid.js.org/) diagrams.
-When embedding figures, use `![alt text](path/to/image)` and provide concise
-alt text describing the content. Add a short description before each Mermaid
-diagram, so screen readers can understand it.
+When embedding figures, use `![alt text](path/to/image)` and provide brief alt
+text describing the content. Add a short description before each Mermaid
+diagram so screen readers can understand it.
+
+For screen readers: The following flowchart outlines the documentation workflow.
 
 ```mermaid
 flowchart TD

--- a/docs/function-parsing-design.md
+++ b/docs/function-parsing-design.md
@@ -56,8 +56,8 @@ balance delimiters (e.g., `extract_parenthesized` in
 likewise report the opening token’s span.
 
 A hierarchy of error types supports rich diagnostics when delimiters do not
-match or names and types are missing. The following diagram shows delimiter
-tracking and error types during parsing.
+match or names and types are missing. Short description: the following diagram
+shows delimiter tracking and related error types.
 
 ```mermaid
 classDiagram

--- a/docs/function-parsing-design.md
+++ b/docs/function-parsing-design.md
@@ -41,7 +41,8 @@ Empty names and types are reported with `ParseError::MissingName` and
 `ParseError::MissingType`. `parse_type_expr` skips whitespace and comment nodes
 and reports mismatched delimiters with a `ParseError::Delimiter` that records
 the expected and actual tokens. Unclosed delimiters produce
-`ParseError::UnclosedDelimiter` once parsing stops.
+`ParseError::UnclosedDelimiter` once parsing stops, highlighting the position
+of the opening delimiter.
 
 A hierarchy of error types supports rich diagnostics when delimiters do not
 match or names and types are missing. The following diagram shows the

--- a/docs/function-parsing-design.md
+++ b/docs/function-parsing-design.md
@@ -39,8 +39,8 @@ itself to read the matching closing delimiter. This means nested types such as\
 Parameters end when a comma or the closing `)` of the list is reached.
 
 Missing colons between a parameter name and type trigger
-`ParseError::MissingColon`. The span of the terminating comma or parenthesis is\
-attached, so diagnostics point at the error. Helper functions\
+`ParseError::MissingColon`. The span of the terminating comma or parenthesis is
+attached, so diagnostics point at the error. Helper functions
 `collect_parameter_name` and `finalise_parameter` keep the main loop small.
 
 Empty names and types are reported with `ParseError::MissingName` and

--- a/docs/function-parsing-design.md
+++ b/docs/function-parsing-design.md
@@ -4,8 +4,9 @@ This document outlines the strategy for parsing `function` definitions and
 declarations within `ddlint`. The parser relies on small helpers to interpret
 parameter lists and optional return types. These helpers now live in the
 `parser::ast::parse_utils` module so that both `Function` and `Relation` AST
-nodes can reuse them. The following diagram shows how helper functions compose
-during parsing.
+nodes can reuse them. A span-aware helper, `open_delimiter`, pushes the
+delimiter kind and token span onto `DelimStack`. The following diagram shows
+how helper functions compose during parsing.
 
 ```mermaid
 classDiagram
@@ -18,10 +19,14 @@ classDiagram
     class parse_type_after_colon {
         <<function>>
     }
+    class open_delimiter {
+        <<function>>
+    }
     Function ..> parse_name_type_pairs : uses
     parse_name_type_pairs ..> parse_type_expr : uses
     Function ..> parse_type_after_colon : uses
     Relation ..> parse_name_type_pairs : uses
+    parse_type_expr ..> open_delimiter : uses
 ```
 
 ## Parameter list parsing
@@ -87,3 +92,7 @@ classDiagram
     DelimiterError *-- Delim
     ParseError *-- DelimiterError
 ```
+
+The `count` argument on `open` and `close` represents how many delimiter units
+are encoded in a single token. When the lexer emits combined delimiters such as
+`<<`, it calls `open` with `count` set to two so nesting remains accurate.

--- a/docs/haskell-parser-analysis.md
+++ b/docs/haskell-parser-analysis.md
@@ -1,4 +1,4 @@
-# Haskell Parser Analysis
+# Haskell parser analysis
 
 This document summarizes the design of the parser implemented in
 `Language.DifferentialDatalog.Parse`. The original code is written in Haskell
@@ -109,8 +109,8 @@ exprGrammar    = removeTabs *> ((optional whiteSpace) *> expr <* eof)
 isolated expression. Both delegate to individual rules described below.
 
 `parseDatalogString` wraps the Parsec `parse` function in `ExceptT`. This
-ensures the caller receives a clear error message when parsing fails and that IO
-exceptions remain separated from parse errors.
+ensures the caller receives a clear error message when parsing fails and that
+IO exceptions remain separated from parse errors.
 
 ## Grammar Productions and AST Mapping
 
@@ -145,10 +145,10 @@ spec = do
 
 ### Declarations
 
-`decl` recognizes one of several declaration forms, each constructing a specific
-AST node (`Import`, `TypeDef`, `Relation`, `Index`, `Function`, `Transformer`,
-`Rule` or `Apply`). Attributes encountered before the item are attached to the
-resulting node when applicable.
+`decl` recognizes one of several declaration forms, each constructing a
+specific AST node (`Import`, `TypeDef`, `Relation`, `Index`, `Function`,
+`Transformer`, `Rule` or `Apply`). Attributes encountered before the item are
+attached to the resulting node when applicable.
 
 ```haskell
 decl =  do attrs <- attributes
@@ -250,9 +250,9 @@ term' = withPos $
 
 【F:Parse.hs†L566-L611】
 
-The table `etable` defines operator precedence, including assignment and logical
-connectives. Complex features such as group-by extraction are handled in helper
-functions like `extractGroupBy`.
+The table `etable` defines operator precedence, including assignment and
+logical connectives. Complex features such as group-by extraction are handled
+in helper functions like `extractGroupBy`.
 
 ### Supporting Utilities
 
@@ -305,9 +305,9 @@ in the Rust implementation.
 When porting to Rust, the constructs above can be expressed with `chumsky`
 combinators and a `rowan` CST. The `expr` grammar maps well to
 `chumsky::recursive`, while the statement parsers become small combinators that
-emit both AST nodes and CST events. Group-by extraction can be implemented using
-a post-processing step mirroring `extractGroupBy`. Patterns for `match` and
-`for` loops translate to nested `chumsky` parsers building structured nodes.
+emit both AST nodes and CST events. Group-by extraction can be implemented
+using a post-processing step mirroring `extractGroupBy`. Patterns for `match`
+and `for` loops translate to nested `chumsky` parsers building structured nodes.
 
 Keep this file in lockstep with `Parse.hs` when changes land so that the Rust
 implementation remains accurate.

--- a/docs/parser-plan.md
+++ b/docs/parser-plan.md
@@ -124,11 +124,11 @@ preserving associativity.
 
 To catch regressions, add micro-benchmarks that parse representative DDlog
 files and measure throughput and memory allocations. Compare these results with
-the existing Haskell parser using similar inputs. Benchmarks should run in CI
+the existing Haskell parser using similar inputs. Benchmarks should run in CI,
 so performance changes are visible in pull requests.
 
 ## 10. Modelling Trivia Tokens
 
 Whitespace and comments are tokenised as `T_WHITESPACE` and `T_COMMENT`
-variants so the CST preserves them. AST wrappers skip over these trivia nodes,
+variants, so the CST preserves them. AST wrappers skip over these trivia nodes,
 ensuring that semantic analyses operate on significant tokens only.

--- a/docs/parser-plan.md
+++ b/docs/parser-plan.md
@@ -1,10 +1,10 @@
-# Parser Porting Plan
+# Parser porting plan
 
 This document outlines how to port the Haskell parser found in
-`differential-datalog-1.2.3/src/Language/DifferentialDatalog/Parse.hs` to a Rust
-implementation that leverages the `chumsky` parser combinator library and builds
-a `rowan`-based Concrete Syntax Tree (CST) alongside the Abstract Syntax Tree
-(AST).
+`differential-datalog-1.2.3/src/Language/DifferentialDatalog/Parse.hs` to a
+Rust implementation that leverages the `chumsky` parser combinator library and
+builds a `rowan`-based Concrete Syntax Tree (CST) alongside the Abstract Syntax
+Tree (AST).
 
 ## 1. Review the Existing Haskell Parser
 
@@ -24,9 +24,9 @@ Follow the guidance in the design document:
   ([design document](docs/ddlint-design-and-road-map.md#L71-L122)).
 - Include an `N_ERROR` variant for error recovery.
 
-Implement `rowan::Language` for a `DdlogLanguage` newtype, using the conversions
-provided by `num-derive`. This allows `rowan` to store `SyntaxKind` tags
-transparently.
+Implement `rowan::Language` for a `DdlogLanguage` newtype, using the
+conversions provided by `num-derive`. This allows `rowan` to store `SyntaxKind`
+tags transparently.
 
 ## 3. Build a Tokenizer
 
@@ -34,9 +34,10 @@ Use `chumsky`'s text utilities (or integrate a `logos` lexer if preferred) to
 convert the source text into a stream of `(SyntaxKind, Span)` pairs. Each span
 records byte offsets so that the resulting CST can precisely mirror the input.
 Whitespace and comments should produce tokens so they can be preserved. The
-current implementation opts for a small `logos` lexer because it keeps the token
-definitions declarative while still interoperating smoothly with `chumsky`
-parsers. Keyword lookups use a `phf::Map` for zero-cost perfect hashing.
+current implementation opts for a small `logos` lexer because it keeps the
+token definitions declarative while still interoperating smoothly with
+`chumsky` parsers. Keyword lookups use a `phf::Map` for zero-cost perfect
+hashing.
 
 ```mermaid
 sequenceDiagram
@@ -61,8 +62,8 @@ sequenceDiagram
 2. Wrap every recognized token into its `SyntaxKind` and push it into a
    `GreenNodeBuilder` from `rowan`.
 3. For syntactic errors, emit an `N_ERROR` node and recover by skipping to a
-   known synchronisation point, as recommended by the design document
-   ([design document](docs/ddlint-design-and-road-map.md#L124-L139)).
+   known synchronisation point, as recommended by the design document ([design
+   document](docs/ddlint-design-and-road-map.md#L124-L139)).
 
 The parser's final output is the AST root together with a `GreenNode` that
 contains the full CST.
@@ -94,8 +95,8 @@ still providing ergonomic typed access for semantic processing.
 ## 6. Testing Strategy
 
 1. Reuse examples from the Haskell project as fixtures. Ensure the new parser
-   produces equivalent AST structures and that the CST round-trips to the source
-   text.
+   produces equivalent AST structures and that the CST round-trips to the
+   source text.
 2. Write unit tests for individual grammar constructs and integration tests for
    whole files.
 
@@ -112,21 +113,22 @@ construction happen in one efficient pass.
 
 ## 8. Handling Left-Recursive Grammar
 
-Chumsky does not support left recursion directly. Any left-recursive productions
-from the Haskell parser must be refactored into right-recursive or iterative
-forms before translation. For example, left-associative expression chains can be
-parsed using `foldl`-style helpers that combine a list of operands and operators
-after parsing. This avoids infinite recursion while preserving associativity.
+Chumsky does not support left recursion directly. Any left-recursive
+productions from the Haskell parser must be refactored into right-recursive or
+iterative forms before translation. For example, left-associative expression
+chains can be parsed using `foldl`-style helpers that combine a list of
+operands and operators after parsing. This avoids infinite recursion while
+preserving associativity.
 
 ## 9. Performance Benchmarks
 
-To catch regressions, add micro-benchmarks that parse representative DDlog files
-and measure throughput and memory allocations. Compare these results with the
-existing Haskell parser using similar inputs. Benchmarks should run in CI so
-performance changes are visible in pull requests.
+To catch regressions, add micro-benchmarks that parse representative DDlog
+files and measure throughput and memory allocations. Compare these results with
+the existing Haskell parser using similar inputs. Benchmarks should run in CI
+so performance changes are visible in pull requests.
 
 ## 10. Modelling Trivia Tokens
 
-Whitespace and comments are tokenised as `T_WHITESPACE` and `T_COMMENT` variants
-so the CST preserves them. AST wrappers skip over these trivia nodes, ensuring
-that semantic analyses operate on significant tokens only.
+Whitespace and comments are tokenised as `T_WHITESPACE` and `T_COMMENT`
+variants so the CST preserves them. AST wrappers skip over these trivia nodes,
+ensuring that semantic analyses operate on significant tokens only.

--- a/docs/pratt-parser-for-ddlog-expressions.md
+++ b/docs/pratt-parser-for-ddlog-expressions.md
@@ -8,7 +8,7 @@ the current parsing pipeline.
 
 ______________________________________________________________________
 
-## **1. Core Concepts and Integration Strategy**
+## 1. Core concepts and integration strategy
 
 The parser will be implemented as a `chumsky` parser combinator that consumes
 the token stream produced by the existing `logos`-based tokenizer. It will
@@ -33,7 +33,7 @@ The key steps are:
 
 ______________________________________________________________________
 
-## **2. Expression AST Definition**
+## 2. Expression AST definition
 
 First, we need a data structure to represent the parsed expressions. This will
 live alongside the other AST definitions in `src/parser/ast/`.
@@ -94,7 +94,7 @@ pub enum BinaryOp {
 
 ______________________________________________________________________
 
-## **3. Pratt Parser Implementation with `chumsky`**
+## 3. Pratt parser implementation with `chumsky`
 
 The heart of the implementation uses `chumsky::pratt`. This requires defining
 the atoms (the simplest parts of an expression, like literals or variables) and
@@ -267,7 +267,7 @@ parser analysis (`docs/haskell-parser-analysis.md`).
 
 ______________________________________________________________________
 
-## **4. CST Integration**
+## 4. CST integration
 
 The `chumsky` expression parser produces a structured `ast::Expr`. However, the
 core of `ddlint` is the `rowan` CST, which must remain lossless. The expression
@@ -335,7 +335,7 @@ project roadmap.
 
 ______________________________________________________________________
 
-## 5. Implementation Notes
+## 5. Implementation notes
 
 The first working parser lives in `src/parser/expression.rs` and is invoked by
 the unit tests. Although the design assumed the availability of

--- a/docs/pratt-parser-for-ddlog-expressions.md
+++ b/docs/pratt-parser-for-ddlog-expressions.md
@@ -1,4 +1,4 @@
-# Pratt Parser Design for DDlog Expressions
+# Pratt parser design for DDlog expressions
 
 This design leverages the `chumsky` crate's built-in Pratt parsing
 capabilities, which is the ideal approach given its existing use in the project
@@ -357,7 +357,7 @@ consistent binding power definitions across the codebase.
 
 Variable references are parsed by interpreting identifier tokens as
 `Expr::Variable`. When an identifier is immediately followed by a left
-parenthesis, the parser treats it as a function call, parsing a
-comma-separated list of argument expressions and producing
-`Expr::Call { name, args }`. This postfix form naturally binds tighter than
-infix operators, so no additional precedence entries are required.
+parenthesis, the parser treats it as a function call, parsing a comma-separated
+list of argument expressions and producing `Expr::Call { name, args }`. This
+postfix form naturally binds tighter than infix operators, so no additional
+precedence entries are required.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,4 +1,4 @@
-# Project Roadmap: `ddlint`
+# Project roadmap: `ddlint`
 
 This roadmap breaks down the work into logical phases, from the foundational
 parsing layer to the implementation of the linter engine and user-facing

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -146,7 +146,7 @@ envisioned in `ddlint-design-and-road-map.md`.
   - [ ] Create the `CstRuleStore` to register and manage all available lint
     rules.
 
-  - [ ] Build the visitor-based, parallelized Rule Runner (using `rayon`) that
+  - [ ] Build the visitor-based, parallelised Rule Runner (using `rayon`) that
     traverses the CST and invokes the appropriate rules for each node.
 
   - [ ] Implement the `declare_lint!` macro to simplify rule creation.

--- a/docs/rust-parser-testing-comprehensive-guide.md
+++ b/docs/rust-parser-testing-comprehensive-guide.md
@@ -1,6 +1,6 @@
 # A comprehensive guide to testing logos, chumsky, and rowan parsers in Rust
 
-## Executive Summary
+## Executive summary
 
 The construction of robust language tooling—compilers, interpreters, static
 analyzers, and formatters—is a formidable engineering challenge. At the core of
@@ -25,7 +25,7 @@ implementers. The intended audience is the experienced Rust developer, already
 conversant with the language's idioms and the `rstest` testing framework, who
 seeks to build a truly resilient and maintainable parsing pipeline.
 
-## Section 1: Foundational Testing Paradigms for Rust Parsers
+## Section 1: Foundational testing paradigms for Rust parsers
 
 Before delving into the specifics of testing each component, it is crucial to
 establish a conceptual framework. A robust testing strategy for a parser is not
@@ -34,7 +34,7 @@ validate different aspects of the system. This section outlines this framework,
 adapting classic testing models to the domain of language engineering and
 defining the roles of the key testing libraries used throughout this guide.
 
-### 1.1 The Testing Pyramid in Language Engineering
+### 1.1 The testing pyramid in language engineering
 
 The traditional testing pyramid advocates for a large base of fast, isolated
 unit tests, a smaller layer of integration tests, and a very small number of
@@ -68,7 +68,7 @@ comprehensive snapshot and property-based testing early in the development
 lifecycle yields a disproportionately high return on investment for ensuring
 the parser's long-term correctness and maintainability.
 
-### 1.2 Structuring the Test Suite
+### 1.2 Structuring the test suite
 
 A well-organized test suite is critical for maintainability. Rust's standard
 testing conventions provide a solid foundation.4
@@ -111,7 +111,7 @@ This structured approach, combining conventional file organization with a clear
 understanding of each testing paradigm's purpose, lays the groundwork for the
 robust and maintainable test suite detailed in the following sections.
 
-## Section 2: Rigorous Testing of the `logos` Lexer
+## Section 2: Rigorous testing of the `logos` lexer
 
 The lexer, or tokenizer, is the first stage of the parsing pipeline. Its
 responsibility is to transform a raw stream of characters into a structured
@@ -124,7 +124,7 @@ deterministic state machine.15 Testing a
 `logos`-based lexer, therefore, involves verifying the correctness of this
 generated state machine across a wide range of inputs.
 
-### 2.1 Core Token Validation with `rstest`
+### 2.1 Core token validation with `rstest`
 
 The most fundamental lexer tests verify that simple, unambiguous inputs produce
 the correct tokens. The `rstest` crate is exceptionally well-suited for this
@@ -182,7 +182,7 @@ mod tests {
 }
 ```
 
-### 2.2 Asserting Spans and Slices
+### 2.2 Asserting spans and slices
 
 While verifying the token's kind is essential, it is insufficient. The
 downstream components, `chumsky` and `rowan`, critically depend on accurate
@@ -231,7 +231,7 @@ fn test_token_spans_and_slices(
 
 This pattern of testing a `(Token, Slice, Span)` tuple should be the default.
 
-### 2.3 Handling Ambiguity and Precedence
+### 2.3 Handling ambiguity and precedence
 
 A common source of subtle lexer bugs arises from ambiguous token definitions
 where one token is a prefix of another. A classic example is the set of tokens
@@ -288,7 +288,7 @@ mod tests {
 }
 ```
 
-### 2.4 Testing Callbacks and State-Driven Lexing
+### 2.4 Testing callbacks and state-driven lexing
 
 For more complex tokens, `logos` supports callbacks—Rust functions that are
 executed when a token pattern is matched. These callbacks can inspect the
@@ -354,7 +354,7 @@ mod tests {
 }
 ```
 
-### 2.5 A Reusable Lexer Test Harness
+### 2.5 A reusable lexer test harness
 
 To reduce boilerplate and ensure consistency across tests, it is highly
 beneficial to create a reusable test harness. This can be a function or macro
@@ -423,7 +423,7 @@ This harness provides a robust foundation for the lexer test suite, ensuring
 that every aspect of the token—its kind, its text, and its position—is
 validated with every test run.
 
-## Section 3: Comprehensive Validation of `chumsky` Parsers
+## Section 3: Comprehensive validation of `chumsky` parsers
 
 With a correctly tokenized stream from `logos`, the next stage is the `chumsky`
 parser. `chumsky` is a parser combinator library designed for expressiveness,
@@ -433,7 +433,7 @@ performance, and, most notably, high-quality error recovery.23 Testing a
 input into an AST but also that it gracefully handles invalid input, reports
 meaningful errors, and recovers to parse the rest of the file.
 
-### 3.1 Unit Testing Individual Parser Rules
+### 3.1 Unit testing individual parser rules
 
 The combinator-based nature of `chumsky` encourages a bottom-up approach to
 parser construction. Complex parsers are built by combining smaller, simpler
@@ -509,7 +509,7 @@ mod tests {
 }
 ```
 
-### 3.2 Snapshot Testing: The Key to Taming ASTs and Errors
+### 3.2 Snapshot testing: the key to taming ASTs and errors
 
 While `assert_eq!` is suitable for simple AST nodes, it quickly becomes
 unwieldy for complex, nested structures. Manually writing out expected ASTs in
@@ -566,7 +566,7 @@ When this test is run for the first time, `insta` will create a file like
 `tests/snapshots/parser_snapshots__snapshot_simple_function.snap` containing
 the formatted AST and error output.
 
-### 3.3 Mastering Error Recovery Testing
+### 3.3 Mastering error recovery testing
 
 `chumsky`'s most powerful feature is its support for flexible error recovery
 strategies.23 A robust parser should not stop at the first error; it should
@@ -609,7 +609,7 @@ strategies (e.g., `recover_with(skip_then_retry_until(...))`) and snapshotting
 the results is the most effective way to fine-tune the parser's behavior on
 invalid input.23
 
-### 3.4 Validating Pratt Parsers (Expression Parsing)
+### 3.4 Validating Pratt parsers (expression parsing)
 
 Parsing expressions with operator precedence and associativity is a classic
 parsing problem. `chumsky` provides a built-in `pratt` parser that simplifies
@@ -649,7 +649,7 @@ fn test_pratt_parser_expressions(#[case] input: &str, #[case] expected: &str) {
 This suite of tests ensures that the core expression parsing logic, a
 notoriously tricky part of any language, is behaving exactly as specified.
 
-## Section 4: Ensuring the Integrity of `rowan` Lossless Syntax Trees
+## Section 4: Ensuring the integrity of `rowan` lossless syntax trees
 
 The final output of the `logos` and `chumsky` pipeline is often a `rowan` tree.
 `rowan` provides data structures for creating a Concrete Syntax Tree (CST).
@@ -659,7 +659,7 @@ whitespace, comments, and even syntax errors.21 This makes it an ideal data
 structure for tooling that needs to analyze or modify source code without
 losing formatting, such as IDEs, formatters, and refactoring engines.29
 
-### 4.1 The `rowan` Philosophy: Losslessness and its Testing Implications
+### 4.1 The `rowan` philosophy: losslessness and its testing implications
 
 The core design of `rowan` separates the tree's structure (the "green tree,"
 which is immutable and untyped) from the view or cursor into it (the "red
@@ -678,7 +678,7 @@ testing a
 pipeline. The CST represents the final, complete, and observable output of the
 lexer and parser working in concert.
 
-### 4.2 The Golden Test: Verifying Losslessness via Pretty-Printing
+### 4.2 The golden test: verifying losslessness via pretty-printing
 
 The most fundamental property of a lossless syntax tree is that it can be
 perfectly "unparsed" or "pretty-printed" back to the original source text. This
@@ -776,7 +776,7 @@ fn test_cst_snapshots(input: &Path) {
 }
 ```
 
-### 4.4 Typed AST Layer and Navigational Tests
+### 4.4 Typed AST layer and navigational tests
 
 While the raw `SyntaxNode` API is powerful, it is untyped. For semantic
 analysis, it is conventional to build a typed AST layer on top of the CST. This
@@ -824,7 +824,7 @@ fn test_typed_ast_navigation_on_malformed_input() {
 These tests ensure that the "view" into the syntax tree is as robust as the
 tree itself, providing a safe and ergonomic API for later compiler stages.
 
-## Section 5: Advanced Strategies with Property-Based Testing (`proptest`)
+## Section 5: Advanced strategies with property-based testing (`proptest`)
 
 The testing strategies discussed so far—example-based and snapshot—are
 excellent for verifying known behaviors and preventing regressions. However,
@@ -838,7 +838,7 @@ found,
 `proptest` automatically "shrinks" it to the smallest possible test case that
 still reproduces the failure, making debugging far easier.2
 
-### 5.1 Introduction to Property-Based Testing
+### 5.1 Introduction to property-based testing
 
 The core workflow of property-based testing is:
 
@@ -858,7 +858,7 @@ The core workflow of property-based testing is:
 For parsers, this approach is invaluable for uncovering obscure bugs that would
 be nearly impossible to find with handwritten tests.
 
-### 5.2 Fuzzing the Lexer and Parser for Panics
+### 5.2 Fuzzing the lexer and parser for panics
 
 The simplest and most fundamental property of any robust program is "it does
 not crash." Applying this to a parser means that no matter what garbage input
@@ -892,7 +892,7 @@ persistence feature of
 regression file and re-run on every subsequent test execution, effectively
 turning a discovered bug into a permanent regression test.13
 
-### 5.3 The Ultimate Property: AST Round-Trip Testing
+### 5.3 The ultimate property: AST round-trip testing
 
 The most powerful property for a parser is round-trip correctness: for any
 valid AST, pretty-printing it to a string and parsing that string back should
@@ -904,7 +904,7 @@ highly effective strategy used in production-grade systems.2
 
 Implementing this test involves three steps:
 
-#### 5.3.1 Step 1: Implementing `Arbitrary` for the AST
+#### 5.3.1 Step 1: implementing `Arbitrary` for the AST
 
 `proptest` needs to know how to generate random, valid instances of the AST.
 This is achieved by implementing the `proptest::arbitrary::Arbitrary` trait for
@@ -961,7 +961,7 @@ impl Arbitrary for Expr {
 }
 ```
 
-#### 5.3.2 Step 2: Implementing the Pretty-Printer
+#### 5.3.2 Step 2: implementing the pretty-printer
 
 A deterministic pretty-printer (or "unparser") is required to convert the
 generated AST back into a source string. This function must correctly handle
@@ -990,7 +990,7 @@ fn pretty_print_expr(expr: &Expr) -> String {
 }
 ```
 
-#### 5.3.3 Step 3: Writing the Property Test
+#### 5.3.3 Step 3: writing the property test
 
 With the `Arbitrary` implementation and the pretty-printer in place, the final
 property test is remarkably concise.
@@ -1024,7 +1024,7 @@ quality and correctness of the language implementation. This symbiotic
 relationship elevates the pretty-printer from a simple utility to a critical
 component of the testing infrastructure.
 
-## Section 6: Conclusion: A Holistic Testing Philosophy for Language Engineering
+## Section 6: Conclusion: a holistic testing philosophy for language engineering
 
 The development of a robust parser is a complex endeavor that demands a testing
 strategy as sophisticated as the parser itself. This guide has detailed a

--- a/docs/rust-parser-testing-comprehensive-guide.md
+++ b/docs/rust-parser-testing-comprehensive-guide.md
@@ -1,4 +1,4 @@
-# A Comprehensive Guide to Testing logos, chumsky, and rowan Parsers in Rust
+# A comprehensive guide to testing logos, chumsky, and rowan parsers in Rust
 
 ## Executive Summary
 
@@ -17,13 +17,13 @@ built with this modern Rust stack. It moves beyond rudimentary examples to
 establish a holistic testing philosophy tailored to the unique demands of
 language engineering. The methodologies detailed herein treat testing not as a
 post-development chore but as an integral part of the design and implementation
-process, essential for ensuring correctness, enabling confident refactoring, and
-delivering a high-quality experience for the language's users. The strategies
-are organized in a progressive manner, from foundational unit tests to advanced
-generative techniques, providing a complete roadmap for implementers. The
-intended audience is the experienced Rust developer, already conversant with the
-language's idioms and the `rstest` testing framework, who seeks to build a truly
-resilient and maintainable parsing pipeline.
+process, essential for ensuring correctness, enabling confident refactoring,
+and delivering a high-quality experience for the language's users. The
+strategies are organized in a progressive manner, from foundational unit tests
+to advanced generative techniques, providing a complete roadmap for
+implementers. The intended audience is the experienced Rust developer, already
+conversant with the language's idioms and the `rstest` testing framework, who
+seeks to build a truly resilient and maintainable parsing pipeline.
 
 ## Section 1: Foundational Testing Paradigms for Rust Parsers
 
@@ -45,16 +45,17 @@ independent units but stages in a data transformation pipeline. A subtle change
 in a token definition within the lexer can have cascading effects, altering the
 structure of the final syntax tree or the quality of error messages.1
 
-This interconnectedness suggests that while unit tests for individual components
-are valuable, the highest leverage often comes from tests that validate the
-integration of these components. A single, well-designed test that verifies the
-entire process from source text to final Abstract Syntax Tree (AST) can provide
-more assurance than hundreds of isolated unit tests. Consequently, the ideal
-testing structure for a parser often resembles a "diamond" or an "inverted
-pyramid" more than a classic one. The base is still composed of unit tests for
-specific edge cases, but the most significant investment is in the middle layer
-of integration and snapshot tests, and at the peak with powerful property-based
-tests that verify universal invariants of the system.
+This interconnectedness suggests that while unit tests for individual
+components are valuable, the highest leverage often comes from tests that
+validate the integration of these components. A single, well-designed test that
+verifies the entire process from source text to final Abstract Syntax Tree
+(AST) can provide more assurance than hundreds of isolated unit tests.
+Consequently, the ideal testing structure for a parser often resembles a
+"diamond" or an "inverted pyramid" more than a classic one. The base is still
+composed of unit tests for specific edge cases, but the most significant
+investment is in the middle layer of integration and snapshot tests, and at the
+peak with powerful property-based tests that verify universal invariants of the
+system.
 
 This approach challenges the conventional wisdom of "many unit tests, few
 integration tests." The parser's correctness is an emergent property of its
@@ -64,8 +65,8 @@ that parsing the output of a pretty-printer yields the original AST
 definition, every parser rule, and the structural integrity of the AST in a
 single, powerful check.2 Therefore, establishing the infrastructure for
 comprehensive snapshot and property-based testing early in the development
-lifecycle yields a disproportionately high return on investment for ensuring the
-parser's long-term correctness and maintainability.
+lifecycle yields a disproportionately high return on investment for ensuring
+the parser's long-term correctness and maintainability.
 
 ### 1.2 Structuring the Test Suite
 
@@ -191,15 +192,16 @@ each token.19
 `chumsky` uses spans to generate precise, user-friendly error messages that
 point to the exact location of a syntax error.19
 
-`rowan` uses the token's text and length to construct a lossless Concrete Syntax
-Tree (CST) that can be perfectly pretty-printed back to the original source.21
+`rowan` uses the token's text and length to construct a lossless Concrete
+Syntax Tree (CST) that can be perfectly pretty-printed back to the original
+source.21
 
-Therefore, a bug in a token's span is not merely a lexer issue; it is a critical
-flaw that will manifest as misleading error diagnostics or a corrupted syntax
-tree. Testing spans and slices must be treated as a first-class concern, on par
-with testing the token kind itself. The `logos::Lexer` provides the `span()` and
-`slice()` methods to access this information, and these should be asserted in
-every relevant test.15
+Therefore, a bug in a token's span is not merely a lexer issue; it is a
+critical flaw that will manifest as misleading error diagnostics or a corrupted
+syntax tree. Testing spans and slices must be treated as a first-class concern,
+on par with testing the token kind itself. The `logos::Lexer` provides the
+`span()` and `slice()` methods to access this information, and these should be
+asserted in every relevant test.15
 
 ```rust
 // Continuing in #[cfg(test)] mod tests
@@ -295,8 +297,8 @@ state. This is essential for handling constructs like C-style block comments,
 strings with escape sequences, or nested delimiters.
 
 Testing callbacks involves verifying that the logic within the callback is
-correct. This includes testing successful transformations, error conditions, and
-special lexer actions like `logos::Skip`. The `logos` repository's own test
+correct. This includes testing successful transformations, error conditions,
+and special lexer actions like `logos::Skip`. The `logos` repository's own test
 suite provides excellent examples of these patterns.22
 
 Consider a callback for parsing hexadecimal integer literals that can fail if
@@ -418,8 +420,8 @@ mod tests {
 ```
 
 This harness provides a robust foundation for the lexer test suite, ensuring
-that every aspect of the token—its kind, its text, and its position—is validated
-with every test run.
+that every aspect of the token—its kind, its text, and its position—is
+validated with every test run.
 
 ## Section 3: Comprehensive Validation of `chumsky` Parsers
 
@@ -435,15 +437,15 @@ meaningful errors, and recovers to parse the rest of the file.
 
 The combinator-based nature of `chumsky` encourages a bottom-up approach to
 parser construction. Complex parsers are built by combining smaller, simpler
-parsers.23 This modularity is a significant advantage for testing, as each small
-parser can be tested in isolation.
+parsers.23 This modularity is a significant advantage for testing, as each
+small parser can be tested in isolation.
 
 To unit test a specific parser rule, one should feed it a pre-tokenized slice
 (`&`) rather than a raw string. This isolates the parser logic from the lexer,
-ensuring that the test is focused solely on the behavior of the combinators. The
-parser's `parse` method returns a `ParseResult`, which contains either the
-output AST and a vector of non-fatal errors, or just a vector of fatal errors.27
-Tests should assert against both the output and the error vector.
+ensuring that the test is focused solely on the behavior of the combinators.
+The parser's `parse` method returns a `ParseResult`, which contains either the
+output AST and a vector of non-fatal errors, or just a vector of fatal
+errors.27 Tests should assert against both the output and the error vector.
 
 ```rust
 // Assuming an AST definition like this:
@@ -509,24 +511,25 @@ mod tests {
 
 ### 3.2 Snapshot Testing: The Key to Taming ASTs and Errors
 
-While `assert_eq!` is suitable for simple AST nodes, it quickly becomes unwieldy
-for complex, nested structures. Manually writing out expected ASTs in test code
-is tedious, error-prone, and makes refactoring the grammar a nightmare. This is
-where snapshot testing with the `insta` crate becomes indispensable.11
+While `assert_eq!` is suitable for simple AST nodes, it quickly becomes
+unwieldy for complex, nested structures. Manually writing out expected ASTs in
+test code is tedious, error-prone, and makes refactoring the grammar a
+nightmare. This is where snapshot testing with the `insta` crate becomes
+indispensable.11
 
 `insta` allows you to assert that a complex value matches a "snapshot"—a
 reference representation stored in a separate file. On the first run, the
-snapshot is created. On subsequent runs, the test output is compared against the
-stored snapshot. If they differ, the test fails, and a rich diff is presented.
-The developer can then either fix the code or, if the change was intentional,
-update the snapshot with a simple command (`cargo insta review`).11
+snapshot is created. On subsequent runs, the test output is compared against
+the stored snapshot. If they differ, the test fails, and a rich diff is
+presented. The developer can then either fix the code or, if the change was
+intentional, update the snapshot with a simple command (`cargo insta review`).11
 
-This workflow is transformative for parser development. When the language syntax
-evolves, the AST structure necessarily changes. Instead of manually updating
-dozens of `assert_eq!` calls, a developer can simply update the parser logic,
-run the tests, and interactively review and accept the new AST structures as the
-new "golden" standard. This dramatically accelerates iteration and
-refactoring.12
+This workflow is transformative for parser development. When the language
+syntax evolves, the AST structure necessarily changes. Instead of manually
+updating dozens of `assert_eq!` calls, a developer can simply update the parser
+logic, run the tests, and interactively review and accept the new AST
+structures as the new "golden" standard. This dramatically accelerates
+iteration and refactoring.12
 
 The best practice is to snapshot the entire `ParseResult`, which includes both
 the (potentially partial) AST and the list of errors. This provides a complete
@@ -560,8 +563,8 @@ fn snapshot_simple_function() {
 ```
 
 When this test is run for the first time, `insta` will create a file like
-`tests/snapshots/parser_snapshots__snapshot_simple_function.snap` containing the
-formatted AST and error output.
+`tests/snapshots/parser_snapshots__snapshot_simple_function.snap` containing
+the formatted AST and error output.
 
 ### 3.3 Mastering Error Recovery Testing
 
@@ -580,8 +583,8 @@ inputs. For each invalid input, the test must verify two critical properties:
    produce a useful partial AST for the valid parts of the code.
 
 Snapshot testing is the perfect tool for this. By snapshotting both the error
-vector and the resulting partial AST, we can validate the entire behavior of the
-error recovery mechanism.
+vector and the resulting partial AST, we can validate the entire behavior of
+the error recovery mechanism.
 
 ```rust
 // In tests/parser_error_recovery.rs
@@ -616,8 +619,8 @@ it respects the defined precedence and associativity rules.
 `rstest` is again an excellent choice for creating a table of expression inputs
 and their expected AST representations.
 
-To make assertions easier, it's common to represent the expected expression tree
-in a simple, readable format like S-expressions.
+To make assertions easier, it's common to represent the expected expression
+tree in a simple, readable format like S-expressions.
 
 ```rust
 // A helper to pretty-print an expression AST as an S-expression.
@@ -653,24 +656,25 @@ The final output of the `logos` and `chumsky` pipeline is often a `rowan` tree.
 Unlike a traditional Abstract Syntax Tree (AST), a `rowan` CST is "lossless" or
 "full-fidelity," meaning it represents the source text exactly, including all
 whitespace, comments, and even syntax errors.21 This makes it an ideal data
-structure for tooling that needs to analyze or modify source code without losing
-formatting, such as IDEs, formatters, and refactoring engines.29
+structure for tooling that needs to analyze or modify source code without
+losing formatting, such as IDEs, formatters, and refactoring engines.29
 
 ### 4.1 The `rowan` Philosophy: Losslessness and its Testing Implications
 
 The core design of `rowan` separates the tree's structure (the "green tree,"
-which is immutable and untyped) from the view or cursor into it (the "red tree,"
-which provides a typed, parent-aware API).21 The library itself provides the
-generic tree data structures (
+which is immutable and untyped) from the view or cursor into it (the "red
+tree," which provides a typed, parent-aware API).21 The library itself provides
+the generic tree data structures (
 
 `GreenNode`, `SyntaxNode`); the user's parser is responsible for correctly
 constructing the tree using a `GreenNodeBuilder`.31
 
 This architecture has a profound implication for testing: a bug found in a
-`rowan` CST is almost never a bug in the `rowan` library itself. Rather, it is a
-bug in the parser logic that called `builder.start_node()`, `builder.token()`,
-or `builder.finish_node()` in the wrong sequence. `rowan` is extensively tested
-within its primary use case, `rust-analyzer`.29 Therefore, testing a
+`rowan` CST is almost never a bug in the `rowan` library itself. Rather, it is
+a bug in the parser logic that called `builder.start_node()`,
+`builder.token()`, or `builder.finish_node()` in the wrong sequence. `rowan` is
+extensively tested within its primary use case, `rust-analyzer`.29 Therefore,
+testing a
 
 `rowan` tree is the ultimate end-to-end integration test of the entire parsing
 pipeline. The CST represents the final, complete, and observable output of the
@@ -738,8 +742,8 @@ testing with
 
 `insta`.
 
-By snapshotting the CST, developers gain a human-readable "golden" record of the
-entire parse result for a given input. This is invaluable for debugging the
+By snapshotting the CST, developers gain a human-readable "golden" record of
+the entire parse result for a given input. This is invaluable for debugging the
 parser's logic and for reviewing the impact of grammar changes.
 
 Combining this with `rstest`'s `#[files]` attribute provides a powerful
@@ -779,15 +783,15 @@ fn test_cst_snapshots(input: &Path) {
 While the raw `SyntaxNode` API is powerful, it is untyped. For semantic
 analysis, it is conventional to build a typed AST layer on top of the CST. This
 involves creating structs that wrap `SyntaxNode` and provide typed accessor
-methods for navigating the tree, as demonstrated in `rowan`'s `s_expressions.rs`
-example.31
+methods for navigating the tree, as demonstrated in `rowan`'s
+`s_expressions.rs` example.31
 
 For example, a `FunctionDef` struct might wrap a `SyntaxNode` of kind `FN_DEF`
 and provide methods like `name() -> Option<SyntaxToken>` and
 `body() -> Option<BlockExpr>`. Tests for this layer should verify that these
-navigational methods work correctly. They should check that the accessors return
-the expected node types (`Some` for well-formed input, `None` for malformed
-input) and that the returned nodes are themselves correct.
+navigational methods work correctly. They should check that the accessors
+return the expected node types (`Some` for well-formed input, `None` for
+malformed input) and that the returned nodes are themselves correct.
 
 ```rust
 // Assuming a typed AST layer exists
@@ -819,14 +823,14 @@ fn test_typed_ast_navigation_on_malformed_input() {
 }
 ```
 
-These tests ensure that the "view" into the syntax tree is as robust as the tree
-itself, providing a safe and ergonomic API for later compiler stages.
+These tests ensure that the "view" into the syntax tree is as robust as the
+tree itself, providing a safe and ergonomic API for later compiler stages.
 
 ## Section 5: Advanced Strategies with Property-Based Testing (`proptest`)
 
-The testing strategies discussed so far—example-based and snapshot—are excellent
-for verifying known behaviors and preventing regressions. However, they are
-limited by the developer's ability to imagine all possible edge cases.
+The testing strategies discussed so far—example-based and snapshot—are
+excellent for verifying known behaviors and preventing regressions. However,
+they are limited by the developer's ability to imagine all possible edge cases.
 Property-based testing, implemented in Rust by crates like `proptest`, offers a
 powerful solution to this problem. Instead of testing against specific inputs,
 it tests that certain *properties* or *invariants* of the code hold true for a
@@ -849,19 +853,19 @@ The core workflow of property-based testing is:
    matching a regex, or complex, custom data structures).
 
 3. **Test and Shrink:** The test runner executes the property function hundreds
-   or thousands of times with different generated inputs. If an assertion fails,
-   `proptest` begins a shrinking process, iteratively simplifying the failing
-   input to find a minimal counterexample.
+   or thousands of times with different generated inputs. If an assertion
+   fails, `proptest` begins a shrinking process, iteratively simplifying the
+   failing input to find a minimal counterexample.
 
 For parsers, this approach is invaluable for uncovering obscure bugs that would
 be nearly impossible to find with hand-written tests.
 
 ### 5.2 Fuzzing the Lexer and Parser for Panics
 
-The simplest and most fundamental property of any robust program is "it does not
-crash." Applying this to a parser means that no matter what garbage input it
-receives, it should never panic. It should either parse successfully or return a
-structured error.
+The simplest and most fundamental property of any robust program is "it does
+not crash." Applying this to a parser means that no matter what garbage input
+it receives, it should never panic. It should either parse successfully or
+return a structured error.
 
 A `proptest` test can be written to generate arbitrary strings and feed them
 into the full lexer-parser pipeline. This acts as a "fuzz test," probing the
@@ -892,9 +896,9 @@ turning a discovered bug into a permanent regression test.13
 
 ### 5.3 The Ultimate Property: AST Round-Trip Testing
 
-The most powerful property for a parser is round-trip correctness: for any valid
-AST, pretty-printing it to a string and parsing that string back should result
-in an identical AST. This can be expressed as
+The most powerful property for a parser is round-trip correctness: for any
+valid AST, pretty-printing it to a string and parsing that string back should
+result in an identical AST. This can be expressed as
 `parse(pretty_print(ast)) == Ok(ast)`. If this property holds, it provides
 exceptionally strong evidence that the parser can correctly handle any valid
 program construct that the AST is capable of representing. This is a common and
@@ -912,10 +916,10 @@ automatically.35
 
 For a recursive type like an expression tree, manual implementation or careful
 use of derive attributes is necessary to prevent infinite recursion during
-generation. This typically involves defining a "leaf" strategy for non-recursive
-expressions (like literals) and a recursive strategy that combines existing
-expressions. The `prop_oneof!` macro is useful for choosing between different
-expression variants.
+generation. This typically involves defining a "leaf" strategy for
+non-recursive expressions (like literals) and a recursive strategy that
+combines existing expressions. The `prop_oneof!` macro is useful for choosing
+between different expression variants.
 
 ```rust
 use proptest::prelude::*;
@@ -1010,8 +1014,8 @@ proptest! {
 }
 ```
 
-This test establishes a powerful feedback loop. A failure does not just indicate
-a bug; it points to a fundamental inconsistency between the parser's
+This test establishes a powerful feedback loop. A failure does not just
+indicate a bug; it points to a fundamental inconsistency between the parser's
 understanding of the grammar and the pretty-printer's representation of it. For
 example, if the pretty-printer fails to add necessary parentheses around a
 lower-precedence operation, the `parse` function will correctly interpret the
@@ -1044,9 +1048,9 @@ philosophy:
 2. **Prioritize High-Leverage Tests:** In the context of parsing, the most
    powerful tests are often those that verify the integration of the entire
    pipeline. The AST round-trip property test and the CST losslessness test are
-   paramount. Investing in the infrastructure for these tests (i.e., `Arbitrary`
-   implementations and a pretty-printer) early in the development process yields
-   the highest return.
+   paramount. Investing in the infrastructure for these tests (i.e.,
+   `Arbitrary` implementations and a pretty-printer) early in the development
+   process yields the highest return.
 
 3. **Treat Spans and Errors as First-Class Citizens:** A parser is not merely a
    validator; it is a critical component of the developer experience. The
@@ -1064,8 +1068,8 @@ philosophy:
 
 For integration into a Continuous Integration/Continuous Deployment (CI/CD)
 pipeline, a tiered approach is recommended. The fast-running unit tests and
-snapshot tests should be executed on every commit to provide rapid feedback. The
-more computationally expensive `proptest` suites, particularly the AST
+snapshot tests should be executed on every commit to provide rapid feedback.
+The more computationally expensive `proptest` suites, particularly the AST
 round-trip test, can be run nightly or as a mandatory check before a release,
 ensuring that deeper, more subtle bugs are caught without slowing down the
 primary development loop.
@@ -1073,5 +1077,5 @@ primary development loop.
 Ultimately, building a language is an iterative process.23 The syntax,
 semantics, and tooling will evolve. A robust, multi-faceted test suite is the
 single most important asset for managing this evolution. It provides the
-confidence needed to refactor, experiment, and extend the language, ensuring the
-long-term health, correctness, and maintainability of the entire project.
+confidence needed to refactor, experiment, and extend the language, ensuring
+the long-term health, correctness, and maintainability of the entire project.

--- a/docs/rust-parser-testing-comprehensive-guide.md
+++ b/docs/rust-parser-testing-comprehensive-guide.md
@@ -19,11 +19,11 @@ language engineering. The methodologies detailed herein treat testing not as a
 post-development chore but as an integral part of the design and implementation
 process, essential for ensuring correctness, enabling confident refactoring,
 and delivering a high-quality experience for the language's users. The
-strategies progress from foundational unit tests to advanced generative
-techniques, providing a complete roadmap for implementers. The intended
-audience is the experienced Rust developer, already conversant with the
-language's idioms and the `rstest` testing framework, who seeks to build a
-truly resilient and maintainable parsing pipeline.
+strategies are organised progressively, from foundational unit tests to
+advanced generative techniques, providing a complete roadmap for implementers.
+The intended audience is the experienced Rust developer, already conversant
+with the language's idioms and the `rstest` testing framework, who seeks to
+build a truly resilient and maintainable parsing pipeline.
 
 ## Section 1: Foundational testing paradigms for Rust parsers
 

--- a/docs/rust-parser-testing-comprehensive-guide.md
+++ b/docs/rust-parser-testing-comprehensive-guide.md
@@ -19,11 +19,11 @@ language engineering. The methodologies detailed herein treat testing not as a
 post-development chore but as an integral part of the design and implementation
 process, essential for ensuring correctness, enabling confident refactoring,
 and delivering a high-quality experience for the language's users. The
-strategies are organized in a progressive manner, from foundational unit tests
-to advanced generative techniques, providing a complete roadmap for
-implementers. The intended audience is the experienced Rust developer, already
-conversant with the language's idioms and the `rstest` testing framework, who
-seeks to build a truly resilient and maintainable parsing pipeline.
+strategies progress from foundational unit tests to advanced generative
+techniques, providing a complete roadmap for implementers. The intended
+audience is the experienced Rust developer, already conversant with the
+language's idioms and the `rstest` testing framework, who seeks to build a
+truly resilient and maintainable parsing pipeline.
 
 ## Section 1: Foundational testing paradigms for Rust parsers
 
@@ -632,7 +632,7 @@ fn pretty_print_expr(expr: &Expr) -> String {
 #[rstest]
 // input, expected s-expression
 #[case("1 + 2 * 3", "(+ 1 (* 2 3))")] // Precedence
-#[case("1 * 2 + 3", "(+ (* 1 2) 3))")] // Precedence
+#[case("1 * 2 + 3", "(+ (* 1 2) 3)")] // Precedence
 #[case("8 - 4 - 2", "(- (- 8 4) 2)")] // Left-associativity
 #[case("-5 + 2", "(+ (- 5) 2)")]      // Unary operator
 #[case("-(5 + 2)", "(- (+ 5 2))")]    // Parentheses
@@ -668,11 +668,10 @@ the generic tree data structures (`GreenNode`, `SyntaxNode`); the user's parser
 is responsible for correctly constructing the tree using a `GreenNodeBuilder`.31
 
 This architecture has a profound implication for testing: a bug found in a
-`rowan` CST is almost never a bug in the `rowan` library itself. Rather, it is
-a bug in the parser logic that called `builder.start_node()`,
-`builder.token()`, or `builder.finish_node()` in the wrong sequence. `rowan` is
-extensively tested within its primary use case, `rust-analyzer`.29 Therefore,
-testing a
+`rowan` CST is rarely a bug in the `rowan` library itself. Rather, it is a bug
+in the parser logic that called `builder.start_node()`, `builder.token()`, or
+`builder.finish_node()` in the wrong sequence. `rowan` is extensively tested
+within its primary use case, `rust-analyzer`.29 Therefore, testing a
 
 `rowan` tree is the ultimate end-to-end integration test of the entire parsing
 pipeline. The CST represents the final, complete, and observable output of the
@@ -861,9 +860,9 @@ be nearly impossible to find with handwritten tests.
 ### 5.2 Fuzzing the lexer and parser for panics
 
 The simplest and most fundamental property of any robust program is "it does
-not crash." Applying this to a parser means that no matter what garbage input
-it receives, it should never panic. It should either parse successfully or
-return a structured error.
+not crash." Applying this to a parser means that, regardless of the input
+quality, it should never panic. It should either parse successfully or return a
+structured error.
 
 A `proptest` test can be written to generate arbitrary strings and feed them
 into the full lexer-parser pipeline. This acts as a "fuzz test," probing the

--- a/docs/rust-parser-testing-comprehensive-guide.md
+++ b/docs/rust-parser-testing-comprehensive-guide.md
@@ -19,7 +19,7 @@ language engineering. The methodologies detailed herein treat testing not as a
 post-development chore but as an integral part of the design and implementation
 process, essential for ensuring correctness, enabling confident refactoring,
 and delivering a high-quality experience for the language's users. The
-strategies are organised progressively, from foundational unit tests to
+strategies are organized progressively, from foundational unit tests to
 advanced generative techniques, providing a complete roadmap for implementers.
 The intended audience is the experienced Rust developer, already conversant
 with the language's idioms and the `rstest` testing framework, who seeks to
@@ -111,7 +111,7 @@ This structured approach, combining conventional file organization with a clear
 understanding of each testing paradigm's purpose, lays the groundwork for the
 robust and maintainable test suite detailed in the following sections.
 
-## Section 2: Rigorous testing of the `logos` lexer
+## Section 2: rigorous testing of the `logos` lexer
 
 The lexer, or tokenizer, is the first stage of the parsing pipeline. Its
 responsibility is to transform a raw stream of characters into a structured
@@ -423,7 +423,7 @@ This harness provides a robust foundation for the lexer test suite, ensuring
 that every aspect of the token—its kind, its text, and its position—is
 validated with every test run.
 
-## Section 3: Comprehensive validation of `chumsky` parsers
+## Section 3: comprehensive validation of `chumsky` parsers
 
 With a correctly tokenized stream from `logos`, the next stage is the `chumsky`
 parser. `chumsky` is a parser combinator library designed for expressiveness,
@@ -517,12 +517,12 @@ test code is tedious, error-prone, and makes refactoring the grammar a
 nightmare. This is where snapshot testing with the `insta` crate becomes
 indispensable.11
 
-`insta` allows you to assert that a complex value matches a "snapshot"—a
-reference representation stored in a separate file. On the first run, the
-snapshot is created. On subsequent runs, the test output is compared against
-the stored snapshot. If they differ, the test fails, and a rich diff is
-presented. The developer can then either fix the code or, if the change was
-intentional, update the snapshot with a simple command (`cargo insta review`).11
+`insta` enables asserting that a complex value matches a “snapshot”—a reference
+representation stored in a separate file. On the first run, the snapshot is
+created. On subsequent runs, the test output is compared against the stored
+snapshot. If they differ, the test fails, and a rich diff is presented. The
+developer can then either fix the code or, if the change was intentional,
+update the snapshot with `cargo insta review`.11
 
 This workflow is transformative for parser development. When the language
 syntax evolves, the AST structure necessarily changes. Instead of manually
@@ -823,7 +823,7 @@ fn test_typed_ast_navigation_on_malformed_input() {
 These tests ensure that the "view" into the syntax tree is as robust as the
 tree itself, providing a safe and ergonomic API for later compiler stages.
 
-## Section 5: Advanced strategies with property-based testing (`proptest`)
+## Section 5: advanced strategies with property-based testing (`proptest`)
 
 The testing strategies discussed so far—example-based and snapshot—are
 excellent for verifying known behaviors and preventing regressions. However,
@@ -1023,7 +1023,7 @@ quality and correctness of the language implementation. This symbiotic
 relationship elevates the pretty-printer from a simple utility to a critical
 component of the testing infrastructure.
 
-## Section 6: Conclusion: a holistic testing philosophy for language engineering
+## Section 6: conclusion: a holistic testing philosophy for language engineering
 
 The development of a robust parser is a complex endeavor that demands a testing
 strategy as sophisticated as the parser itself. This guide has detailed a

--- a/docs/rust-parser-testing-comprehensive-guide.md
+++ b/docs/rust-parser-testing-comprehensive-guide.md
@@ -664,10 +664,8 @@ losing formatting, such as IDEs, formatters, and refactoring engines.29
 The core design of `rowan` separates the tree's structure (the "green tree,"
 which is immutable and untyped) from the view or cursor into it (the "red
 tree," which provides a typed, parent-aware API).21 The library itself provides
-the generic tree data structures (
-
-`GreenNode`, `SyntaxNode`); the user's parser is responsible for correctly
-constructing the tree using a `GreenNodeBuilder`.31
+the generic tree data structures (`GreenNode`, `SyntaxNode`); the user's parser
+is responsible for correctly constructing the tree using a `GreenNodeBuilder`.31
 
 This architecture has a profound implication for testing: a bug found in a
 `rowan` CST is almost never a bug in the `rowan` library itself. Rather, it is
@@ -858,7 +856,7 @@ The core workflow of property-based testing is:
    failing input to find a minimal counterexample.
 
 For parsers, this approach is invaluable for uncovering obscure bugs that would
-be nearly impossible to find with hand-written tests.
+be nearly impossible to find with handwritten tests.
 
 ### 5.2 Fuzzing the Lexer and Parser for Panics
 

--- a/docs/rust-testing-with-rstest-fixtures.md
+++ b/docs/rust-testing-with-rstest-fixtures.md
@@ -6,7 +6,7 @@ built-in testing framework provides a solid foundation, managing test
 dependencies and creating parameterized tests can become verbose. The `rstest`
 crate (`github.com/la10736/rstest`) emerges as a powerful solution, offering a
 sophisticated fixture-based and parameterized testing framework that
-significantly simplifies these tasks through the use of procedural macros.1
+significantly simplifies these tasks through the use of procedural macros.[^1]
 This document provides a comprehensive exploration of `rstest`, from
 fundamental concepts to advanced techniques, enabling Rust developers to write
 cleaner, more expressive, and robust tests.
@@ -26,7 +26,7 @@ considerable boilerplate code and repetition, making tests harder to read and
 maintain.
 
 Fixtures address this by encapsulating these dependencies and their setup
-logic.1 For instance, if multiple tests require a logged-in user object or a
+logic.[^2] For instance, if multiple tests require a logged-in user object or a
 pre-populated database, instead of creating these in every test, a fixture can
 provide them. This approach allows developers to focus on the specific logic
 being tested rather than the auxiliary utilities.
@@ -1327,3 +1327,6 @@ provided by `rstest`:
 By mastering `rstest`, Rust developers can significantly elevate the quality
 and efficiency of their testing practices, leading to more reliable and
 maintainable software.
+
+[^1]: [`rstest` crate](https://github.com/la10736/rstest)
+[^2]: [Test fixture](https://en.wikipedia.org/wiki/Test_fixture)

--- a/docs/rust-testing-with-rstest-fixtures.md
+++ b/docs/rust-testing-with-rstest-fixtures.md
@@ -1,4 +1,4 @@
-# Mastering Test Fixtures in Rust with `rstest`
+# Mastering test fixtures in Rust with `rstest`
 
 Testing is an indispensable part of modern software development, ensuring code
 reliability, maintainability, and correctness. In the Rust ecosystem, while the
@@ -6,10 +6,10 @@ built-in testing framework provides a solid foundation, managing test
 dependencies and creating parameterized tests can become verbose. The `rstest`
 crate (`github.com/la10736/rstest`) emerges as a powerful solution, offering a
 sophisticated fixture-based and parameterized testing framework that
-significantly simplifies these tasks through the use of procedural macros.1 This
-document provides a comprehensive exploration of `rstest`, from fundamental
-concepts to advanced techniques, enabling Rust developers to write cleaner, more
-expressive, and robust tests.
+significantly simplifies these tasks through the use of procedural macros.1
+This document provides a comprehensive exploration of `rstest`, from
+fundamental concepts to advanced techniques, enabling Rust developers to write
+cleaner, more expressive, and robust tests.
 
 ## I. Introduction to `rstest` and Test Fixtures in Rust
 
@@ -35,9 +35,9 @@ Fundamentally, the use of fixtures promotes a crucial separation of concerns:
 the *preparation* of the test environment is decoupled from the *execution* of
 the test logic. Traditional testing approaches often intermingle setup, action,
 and assertion logic within a single test function. This can result in lengthy
-and convoluted tests that are difficult to comprehend at a glance. By extracting
-the setup logic into reusable components (fixtures), the actual test functions
-become shorter, more focused, and thus more readable and maintainable.
+and convoluted tests that are difficult to comprehend at a glance. By
+extracting the setup logic into reusable components (fixtures), the actual test
+functions become shorter, more focused, and thus more readable and maintainable.
 
 ### B. Introducing `rstest`: Simplifying Fixture-Based Testing in Rust
 
@@ -51,8 +51,9 @@ JavaScript/TypeScript framework mentioned in 5).
 The `rstest` crate utilizes Rust's procedural macros, such as `#[rstest]` and
 `#[fixture]`, to achieve its declarative and expressive syntax.2 These macros
 allow developers to define fixtures and inject them into test functions simply
-by listing them as arguments. This compile-time mechanism analyzes test function
-signatures and fixture definitions to wire up dependencies automatically.
+by listing them as arguments. This compile-time mechanism analyzes test
+function signatures and fixture definitions to wire up dependencies
+automatically.
 
 This reliance on procedural macros is a key architectural decision. It enables
 `rstest` to offer a remarkably clean and intuitive syntax at the test-writing
@@ -72,8 +73,8 @@ quality and developer productivity:
 - **Readability:** By injecting dependencies as function arguments, `rstest`
   makes the requirements of a test explicit and easy to understand.9 The test
   function's signature clearly documents what it needs to run. This allows
-  developers to "focus on the important stuff in your tests" by abstracting away
-  the setup details.1
+  developers to "focus on the important stuff in your tests" by abstracting
+  away the setup details.1
 - **Reusability:** Fixtures defined with `rstest` are reusable components. A
   single fixture, such as one setting up a database connection or creating a
   complex data structure, can be used across multiple tests, eliminating
@@ -84,12 +85,13 @@ quality and developer productivity:
   variations from a single function.
 
 The declarative nature of `rstest` is central to these benefits. Instead of
-imperatively writing setup code within each test (the *how*), developers declare
-the fixtures they need (the *what*) in the test function's signature. This
-shifts the cognitive load from managing setup details in every test to designing
-a system of well-defined, reusable fixtures. Over time, particularly in larger
-projects, this can lead to a more robust, maintainable, and understandable test
-suite as common setup patterns are centralized and managed effectively.
+imperatively writing setup code within each test (the *how*), developers
+declare the fixtures they need (the *what*) in the test function's signature.
+This shifts the cognitive load from managing setup details in every test to
+designing a system of well-defined, reusable fixtures. Over time, particularly
+in larger projects, this can lead to a more robust, maintainable, and
+understandable test suite as common setup patterns are centralized and managed
+effectively.
 
 ## II. Getting Started with `rstest`
 
@@ -137,21 +139,23 @@ pub fn answer_to_life() -> u32 {
 }
 ```
 
-In this example, `answer_to_life` is a public function marked with `#[fixture]`.
-It takes no arguments and returns a `u32` value of 42.9 The `#[fixture]` macro
-effectively registers this function with the `rstest` system, transforming it
-into a component that `rstest` can discover and utilize. The return type of the
-fixture function (here, `u32`) defines the type of the data that will be
-injected into tests requesting this fixture. Fixtures can return any valid Rust
-type, from simple primitives to complex structs or trait objects.1 Fixtures can
-also depend on other fixtures, allowing for compositional setup.12
+In this example, `answer_to_life` is a public function marked with
+`#[fixture]`. It takes no arguments and returns a `u32` value of 42.9 The
+`#[fixture]` macro effectively registers this function with the `rstest`
+system, transforming it into a component that `rstest` can discover and
+utilize. The return type of the fixture function (here, `u32`) defines the type
+of the data that will be injected into tests requesting this fixture. Fixtures
+can return any valid Rust type, from simple primitives to complex structs or
+trait objects.1 Fixtures can also depend on other fixtures, allowing for
+compositional setup.12
 
 ### C. Injecting Fixtures into Tests with `#[rstest]`
 
 Once a fixture is defined, it can be used in a test function. Test functions
 that utilize `rstest` features, including fixture injection, must be annotated
-with the `#[rstest]` attribute. The fixture is then injected by simply declaring
-an argument in the test function with the same name as the fixture function.
+with the `#[rstest]` attribute. The fixture is then injected by simply
+declaring an argument in the test function with the same name as the fixture
+function.
 
 Here’s how to use the `answer_to_life` fixture in a test:
 
@@ -170,8 +174,8 @@ fn test_with_fixture(answer_to_life: u32) {
 ```
 
 In `test_with_fixture`, the argument `answer_to_life: u32` signals to `rstest`
-that the `answer_to_life` fixture should be injected.1 `rstest` resolves this by
-name: it looks for a fixture function named `answer_to_life`, calls it, and
+that the `answer_to_life` fixture should be injected.1 `rstest` resolves this
+by name: it looks for a fixture function named `answer_to_life`, calls it, and
 passes its return value as the argument to the test function.13
 
 The argument name in the test function serves as the primary key for fixture
@@ -189,11 +193,11 @@ leveraging `rstest` effectively.
 
 ### A. Simple Fixture Examples
 
-The flexibility of `rstest` fixtures allows them to provide a wide array of data
-types and perform various setup tasks. Fixtures are not limited by the kind of
-data they can return; any valid Rust type is permissible.1 This enables fixtures
-to encapsulate diverse setup logic, providing ready-to-use dependencies for
-tests.
+The flexibility of `rstest` fixtures allows them to provide a wide array of
+data types and perform various setup tasks. Fixtures are not limited by the
+kind of data they can return; any valid Rust type is permissible.1 This enables
+fixtures to encapsulate diverse setup logic, providing ready-to-use
+dependencies for tests.
 
 Here are a few examples illustrating different kinds of fixtures:
 
@@ -287,11 +291,11 @@ Here are a few examples illustrating different kinds of fixtures:
 ### B. Understanding Fixture Scope and Lifetime (Default Behavior)
 
 By default, `rstest` calls a fixture function anew for each test that uses it.
-This means if five different tests inject the same fixture, the fixture function
-will be executed five times, and each test will receive a fresh, independent
-instance of the fixture's result. This behavior is crucial for test isolation.
-The `rstest` macro effectively desugars a test like `fn the_test(injected: i32)`
-into something conceptually similar to
+This means if five different tests inject the same fixture, the fixture
+function will be executed five times, and each test will receive a fresh,
+independent instance of the fixture's result. This behavior is crucial for test
+isolation. The `rstest` macro effectively desugars a test like
+`fn the_test(injected: i32)` into something conceptually similar to
 `#[test] fn the_test() { let injected = injected_fixture_func(); /*... */ }`
 within the test body, implying a new call each time.13
 
@@ -308,9 +312,9 @@ concern or when the cost of fixture creation is prohibitive.
 
 ## IV. Parameterized Tests with `rstest`
 
-`rstest` excels at creating parameterized tests, allowing a single test logic to
-be executed with multiple sets of input data. This is achieved primarily through
-the `#[case]` and `#[values]` attributes.
+`rstest` excels at creating parameterized tests, allowing a single test logic
+to be executed with multiple sets of input data. This is achieved primarily
+through the `#[case]` and `#[values]` attributes.
 
 ### A. Table-Driven Tests with `#[case]`: Defining Specific Scenarios
 
@@ -344,10 +348,10 @@ fn test_fibonacci(#[case] input: u32, #[case] expected: u32) {
 }
 ```
 
-For each `#[case(input_val, expected_val)]` line, `rstest` generates a separate,
-independent test. If one case fails, the others are still executed and reported
-individually by the test runner. These generated tests are often named by
-appending `::case_N` to the original test function name (e.g.,
+For each `#[case(input_val, expected_val)]` line, `rstest` generates a
+separate, independent test. If one case fails, the others are still executed
+and reported individually by the test runner. These generated tests are often
+named by appending `::case_N` to the original test function name (e.g.,
 `test_fibonacci::case_1`, `test_fibonacci::case_2`, etc.), which aids in
 identifying specific failing cases.8 This individual reporting mechanism
 provides clearer feedback than a loop within a single test, where the first
@@ -357,8 +361,9 @@ failure might obscure subsequent ones.
 
 The `#[values(...)]` attribute is used on test function arguments to generate
 tests for every possible combination of the provided values (the Cartesian
-product). This is particularly useful for testing interactions between different
-parameters or ensuring comprehensive coverage across various input states.1
+product). This is particularly useful for testing interactions between
+different parameters or ensuring comprehensive coverage across various input
+states.1
 
 Consider testing a state machine's transition logic based on current state and
 an incoming event:
@@ -414,12 +419,13 @@ representative values or using `#[case]` for more targeted scenarios.
 Fixtures can be seamlessly combined with parameterized arguments (`#[case]` or
 `#[values]`) in the same test function. This powerful combination allows for
 testing different aspects of a component (varied by parameters) within a
-consistent environment or context (provided by fixtures). The "Complete Example"
-in the `rstest` documentation hints at this synergy, stating that all features
-can be used together, mixing fixture variables, fixed cases, and value lists.9
+consistent environment or context (provided by fixtures). The "Complete
+Example" in the `rstest` documentation hints at this synergy, stating that all
+features can be used together, mixing fixture variables, fixed cases, and value
+lists.9
 
-For example, a test might use a fixture to obtain a database connection and then
-use `#[case]` arguments to test operations with different user IDs:
+For example, a test might use a fixture to obtain a database connection and
+then use `#[case]` arguments to test operations with different user IDs:
 
 ```rust
 use rstest::*;
@@ -486,8 +492,8 @@ In this example, `derived_value` depends on `base_value`, and `configured_item`
 depends on `derived_value`. When `test_composed_fixture` requests
 `configured_item`, `rstest` first calls `base_value()`, then
 `derived_value(10)`, and finally `configured_item(20, "item_".to_string())`.
-This hierarchical dependency resolution mirrors good software design principles,
-promoting modularity and maintainability in test setups.
+This hierarchical dependency resolution mirrors good software design
+principles, promoting modularity and maintainability in test setups.
 
 ### B. Controlling Fixture Initialization: `#[once]` for Shared State
 
@@ -542,10 +548,11 @@ consideration for resource management.
 
 ### C. Renaming Fixtures for Clarity: The `#[from]` Attribute
 
-Sometimes a fixture's function name might be long and descriptive, but a shorter
-or different name is preferred for the argument in a test or another fixture.
-The `#[from(original_fixture_name)]` attribute on an argument allows renaming.12
-This is particularly useful when destructuring the result of a fixture.
+Sometimes a fixture's function name might be long and descriptive, but a
+shorter or different name is preferred for the argument in a test or another
+fixture. The `#[from(original_fixture_name)]` attribute on an argument allows
+renaming.12 This is particularly useful when destructuring the result of a
+fixture.
 
 ```rust
 use rstest::*;
@@ -567,10 +574,10 @@ fn test_with_destructured_fixture(#[from(complex_user_data_fixture)] (name, _, _
 ```
 
 The `#[from]` attribute decouples the fixture's actual function name from the
-variable name used within the consuming function. As shown, if a fixture returns
-a tuple or struct and the test only cares about some parts or wants to use more
-idiomatic names for destructured elements, `#[from]` is essential to link the
-argument pattern to the correct source fixture.12
+variable name used within the consuming function. As shown, if a fixture
+returns a tuple or struct and the test only cares about some parts or wants to
+use more idiomatic names for destructured elements, `#[from]` is essential to
+link the argument pattern to the correct source fixture.12
 
 ### D. Partial Fixture Injection & Default Arguments
 
@@ -665,14 +672,15 @@ allowing the direct use of string representations for types that support it.
 However, if the `FromStr` conversion fails (e.g., due to a malformed string),
 the error will typically occur at test runtime, potentially leading to a panic.
 For types with complex parsing logic or many failure modes, it might be clearer
-to perform the conversion explicitly within a fixture or at the beginning of the
-test to handle errors more gracefully or provide more specific diagnostic
+to perform the conversion explicitly within a fixture or at the beginning of
+the test to handle errors more gracefully or provide more specific diagnostic
 messages.
 
 ## VI. Asynchronous Testing with `rstest`
 
-`rstest` provides robust support for testing asynchronous Rust code, integrating
-with common async runtimes and offering syntactic sugar for managing futures.
+`rstest` provides robust support for testing asynchronous Rust code,
+integrating with common async runtimes and offering syntactic sugar for
+managing futures.
 
 ### A. Defining Asynchronous Fixtures (`async fn`)
 
@@ -703,8 +711,8 @@ Test functions themselves can also be `async fn`. `rstest` will manage the
 execution of these async tests. By default, `rstest` often uses
 `#[async_std::test]` to annotate the generated async test functions.9 However,
 it is designed to be largely runtime-agnostic and can be integrated with other
-popular async runtimes like Tokio or Actix. This is typically done by adding the
-runtime's specific test attribute (e.g., `#[tokio::test]` or
+popular async runtimes like Tokio or Actix. This is typically done by adding
+the runtime's specific test attribute (e.g., `#[tokio::test]` or
 `#[actix_rt::test]`) alongside `#[rstest]`.4
 
 ```rust
@@ -730,10 +738,10 @@ The order of procedural macro attributes can sometimes matter.15 While `rstest`
 documentation and examples show flexibility (e.g., `#[rstest]` then
 `#[tokio::test]` 4, or vice versa), users should ensure their chosen async
 runtime's test macro is correctly placed to provide the necessary execution
-context for the async test body and any async fixtures. `rstest` itself does not
-bundle a runtime; it integrates with existing ones. The "Inject Test Attribute"
-feature mentioned in `rstest` documentation 10 may offer more explicit control
-over which test runner attribute is applied.
+context for the async test body and any async fixtures. `rstest` itself does
+not bundle a runtime; it integrates with existing ones. The "Inject Test
+Attribute" feature mentioned in `rstest` documentation 10 may offer more
+explicit control over which test runner attribute is applied.
 
 ### C. Managing Futures: `#[future]` and `#[awt]` Attributes
 
@@ -888,27 +896,28 @@ fn test_read_from_temp_file(temp_file_with_content: PathBuf) {
 
 By encapsulating temporary resource management within fixtures, tests become
 cleaner and less prone to errors related to resource setup or cleanup. The RAII
-(Resource Acquisition Is Initialization) pattern, common in Rust and exemplified
-by `tempfile::TempDir` (which cleans up the directory when dropped), works
-effectively with `rstest`'s fixture model. When a regular (non-`#[once]`)
-fixture returns a `TempDir` object, or an object that owns it, the resource is
-typically cleaned up after the test finishes, as the fixture's return value goes
-out of scope. This localizes resource management logic to the fixture, keeping
-the test focused on its assertions. For temporary resources, regular (per-test)
-fixtures are generally preferred over `#[once]` fixtures to ensure proper
-cleanup, as `#[once]` fixtures are never dropped.
+(Resource Acquisition Is Initialization) pattern, common in Rust and
+exemplified by `tempfile::TempDir` (which cleans up the directory when
+dropped), works effectively with `rstest`'s fixture model. When a regular
+(non-`#[once]`) fixture returns a `TempDir` object, or an object that owns it,
+the resource is typically cleaned up after the test finishes, as the fixture's
+return value goes out of scope. This localizes resource management logic to the
+fixture, keeping the test focused on its assertions. For temporary resources,
+regular (per-test) fixtures are generally preferred over `#[once]` fixtures to
+ensure proper cleanup, as `#[once]` fixtures are never dropped.
 
 ### B. Mocking External Services (e.g., Database Connections, HTTP APIs)
 
 For unit and integration tests that depend on external services like databases
 or HTTP APIs, mocking is a crucial technique. Mocks allow tests to run in
-isolation, without relying on real external systems, making them faster and more
-reliable. `rstest` fixtures are an ideal place to encapsulate the setup and
-configuration of mock objects. Crates like `mockall` can be used to create
-mocks, or they can be hand-rolled. The fixture would then provide the configured
-mock instance to the test. General testing advice also strongly recommends
-mocking external dependencies.17 The `rstest` documentation itself shows
-examples with fakes or mocks like `empty_repository` and `string_processor`.1
+isolation, without relying on real external systems, making them faster and
+more reliable. `rstest` fixtures are an ideal place to encapsulate the setup
+and configuration of mock objects. Crates like `mockall` can be used to create
+mocks, or they can be hand-rolled. The fixture would then provide the
+configured mock instance to the test. General testing advice also strongly
+recommends mocking external dependencies.17 The `rstest` documentation itself
+shows examples with fakes or mocks like `empty_repository` and
+`string_processor`.1
 
 A conceptual example using a hypothetical mocking library:
 
@@ -989,11 +998,11 @@ readable and maintainable.
 
 ### C. Using `#[files(...)]` for Test Input from Filesystem Paths
 
-For tests that need to process data from multiple input files, `rstest` provides
-the `#[files("glob_pattern")]` attribute. This attribute can be used on a test
-function argument to inject file paths that match a given glob pattern. The
-argument type is typically `PathBuf`. It can also inject file contents directly
-as `&str` or `&[u8]` by specifying a mode, e.g.,
+For tests that need to process data from multiple input files, `rstest`
+provides the `#[files("glob_pattern")]` attribute. This attribute can be used
+on a test function argument to inject file paths that match a given glob
+pattern. The argument type is typically `PathBuf`. It can also inject file
+contents directly as `&str` or `&[u8]` by specifying a mode, e.g.,
 `#[files("glob_pattern", mode = "str")]`.13 Additional attributes like
 `#[base_dir = "..."]` can specify a base directory for the glob, and
 `#[exclude("regex")]` can filter out paths matching a regular expression.10
@@ -1033,15 +1042,15 @@ significantly increase binary size if used with large data files.
 ## VIII. Reusability and Organization
 
 As test suites grow, maintaining reusability and clear organization becomes
-paramount. `rstest` and its ecosystem provide tools and encourage practices that
-support these goals.
+paramount. `rstest` and its ecosystem provide tools and encourage practices
+that support these goals.
 
 ### A. Leveraging `rstest_reuse` for Test Templates
 
 While `rstest`'s `#[case]` attribute is excellent for parameterization,
 repeating the same set of `#[case]` attributes across multiple test functions
-can lead to duplication. The `rstest_reuse` crate addresses this by allowing the
-definition of reusable test templates.9
+can lead to duplication. The `rstest_reuse` crate addresses this by allowing
+the definition of reusable test templates.9
 
 `rstest_reuse` introduces two main attributes:
 
@@ -1085,11 +1094,11 @@ fn test_multiplication_by_one(#[case] a: i32, #[case] b: i32) {
 
 `rstest_reuse` works by having `#[template]` define a macro. When
 `#[apply(template_name)]` is used, this macro is called and expands to the set
-of attributes (like `#[case]`) onto the target function.18 This meta-programming
-technique effectively avoids direct code duplication of parameter sets,
-promoting DRY principles in test case definitions. `rstest_reuse` also supports
-composing templates with additional `#[case]` or `#[values]` attributes when
-applying them.18
+of attributes (like `#[case]`) onto the target function.18 This
+meta-programming technique effectively avoids direct code duplication of
+parameter sets, promoting DRY principles in test case definitions.
+`rstest_reuse` also supports composing templates with additional `#[case]` or
+`#[values]` attributes when applying them.18
 
 ### B. Best Practices for Organizing Fixtures and Tests
 
@@ -1108,16 +1117,16 @@ for maintainability and scalability.
     `src/lib.rs` or `src/fixtures.rs` under `#[cfg(test)]`) and `use` them in
     integration tests.
 - **Naming Conventions:** Use clear, descriptive names for fixtures that
-  indicate what they provide or set up. Test function names should clearly state
-  what behavior they are verifying.
+  indicate what they provide or set up. Test function names should clearly
+  state what behavior they are verifying.
 - **Fixture Responsibility:** Aim for fixtures with a single, well-defined
   responsibility. Complex setups can be achieved by composing smaller, focused
   fixtures.12
 - **Scope Management (**`#[once]` **vs. Regular):** Make conscious decisions
   about fixture lifetimes. Use `#[once]` sparingly, only for genuinely
-  expensive, read-only, and safely static resources, being mindful of its "never
-  dropped" nature.12 Prefer regular (per-test) fixtures for test isolation and
-  proper resource management.
+  expensive, read-only, and safely static resources, being mindful of its
+  "never dropped" nature.12 Prefer regular (per-test) fixtures for test
+  isolation and proper resource management.
 - **Modularity:** Group related fixtures and tests into modules. This improves
   navigation and understanding of the test suite.
 - **Readability:** Utilize features like `#[from]` for renaming 12 and
@@ -1148,21 +1157,21 @@ become verbose for scenarios involving shared setup or parameterization.
   `#[test]` functions with slight variations. `rstest`'s `#[case]` and
   `#[values]` attributes provide a much cleaner and more powerful solution.
 - **Readability and Boilerplate:** `rstest` generally leads to less boilerplate
-  code and more readable tests because dependencies are explicit in the function
-  signature, and parameterization is handled declaratively.
+  code and more readable tests because dependencies are explicit in the
+  function signature, and parameterization is handled declaratively.
 
 The following table summarizes key differences:
 
 **Table 1:** `rstest` **vs. Standard Rust** `#[test]` **for Fixture Management
 and Parameterization**
 
-| Feature                                                       | Standard #[test] Approach                                     | rstest Approach                                                                  |
-| ------------------------------------------------------------- | ------------------------------------------------------------- | -------------------------------------------------------------------------------- |
-| Fixture Injection                                             | Manual calls to setup functions within each test.             | Fixture name as argument in #[rstest] function; fixture defined with #[fixture]. |
-| Parameterized Tests (Specific Cases)                          | Loop inside one test, or multiple distinct #[test] functions. | #[case(...)] attributes on #[rstest] function.                                   |
-| Parameterized Tests (Value Combinations)                      | Nested loops inside one test, or complex manual generation.   | #[values(...)] attributes on arguments of #[rstest] function.                    |
-| Async Fixture Setup                                           | Manual async block and .await calls inside test.              | async fn fixtures, with #[future] and #[awt] for ergonomic `.await`ing.          |
-| Reusing Parameter Sets                                        | Manual duplication of cases or custom helper macros.          | rstest_reuse crate with #[template] and #[apply] attributes.                     |
+| Feature                                  | Standard #[test] Approach                                     | rstest Approach                                                                  |
+| ---------------------------------------- | ------------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| Fixture Injection                        | Manual calls to setup functions within each test.             | Fixture name as argument in #[rstest] function; fixture defined with #[fixture]. |
+| Parameterized Tests (Specific Cases)     | Loop inside one test, or multiple distinct #[test] functions. | #[case(...)] attributes on #[rstest] function.                                   |
+| Parameterized Tests (Value Combinations) | Nested loops inside one test, or complex manual generation.   | #[values(...)] attributes on arguments of #[rstest] function.                    |
+| Async Fixture Setup                      | Manual async block and .await calls inside test.              | async fn fixtures, with #[future] and #[awt] for ergonomic `.await`ing.          |
+| Reusing Parameter Sets                   | Manual duplication of cases or custom helper macros.          | rstest_reuse crate with #[template] and #[apply] attributes.                     |
 
 This comparison highlights how `rstest`'s attribute-based, declarative approach
 streamlines common testing patterns, reducing manual effort and improving the
@@ -1199,8 +1208,8 @@ mind:
   macros expand.8
 - **Debugging Parameterized Tests:** `rstest` generates individual test
   functions for parameterized cases, often named like
-  `test_function_name::case_N`.8 Understanding this naming convention is helpful
-  for identifying and running specific failing cases with
+  `test_function_name::case_N`.8 Understanding this naming convention is
+  helpful for identifying and running specific failing cases with
   `cargo test test_function_name::case_N`. Some IDEs or debuggers might require
   specific configurations or might not fully support stepping through the
   macro-generated code as seamlessly as handwritten code, though support is
@@ -1209,8 +1218,8 @@ mind:
   `#[files]`) are defined and discovered at compile time.7 This means the
   structure of the tests is validated by the Rust compiler, which can catch
   structural errors (like type mismatches in `#[case]` arguments or references
-  to non-existent fixtures) earlier than runtime test discovery mechanisms. This
-  compile-time validation is a strength, offering a degree of static
+  to non-existent fixtures) earlier than runtime test discovery mechanisms.
+  This compile-time validation is a strength, offering a degree of static
   verification for the test suite itself. However, it also means that
   dynamically generating test cases at runtime based on external factors (not
   known at compile time) is not directly supported by `rstest`'s core model.
@@ -1231,25 +1240,26 @@ specific needs like logging and conditional test execution.
 ### A. `rstest-log`: Logging in `rstest` Tests
 
 For developers who rely on logging frameworks like `log` or `tracing` for
-debugging tests, the `rstest-log` crate can simplify integration.21 Test runners
-often capture standard output and error streams, and logging frameworks require
-proper initialization. `rstest-log` likely provides attributes or wrappers to
-ensure that logging is correctly set up before each `rstest`-generated test case
-runs, making it easier to get consistent log output from tests.
+debugging tests, the `rstest-log` crate can simplify integration.21 Test
+runners often capture standard output and error streams, and logging frameworks
+require proper initialization. `rstest-log` likely provides attributes or
+wrappers to ensure that logging is correctly set up before each
+`rstest`-generated test case runs, making it easier to get consistent log
+output from tests.
 
 ### B. `test-with`: Conditional Testing with `rstest`
 
-The `test-with` crate allows for conditional execution of tests based on various
-runtime conditions, such as the presence of environment variables, the existence
-of specific files or folders, or the availability of network services.22 It can
-be used with `rstest`. For example, an `rstest` test could be further annotated
-with `test-with` attributes to ensure it only runs if a particular database
-configuration file exists or if a dependent web service is reachable. The order
-of macros is important: `rstest` should typically generate the test cases first,
-and then `test-with` can apply its conditional execution logic to these
-generated tests.22 This allows `rstest` to focus on test structure and data
-provision, while `test-with` provides an orthogonal layer of control over test
-execution conditions.
+The `test-with` crate allows for conditional execution of tests based on
+various runtime conditions, such as the presence of environment variables, the
+existence of specific files or folders, or the availability of network
+services.22 It can be used with `rstest`. For example, an `rstest` test could
+be further annotated with `test-with` attributes to ensure it only runs if a
+particular database configuration file exists or if a dependent web service is
+reachable. The order of macros is important: `rstest` should typically generate
+the test cases first, and then `test-with` can apply its conditional execution
+logic to these generated tests.22 This allows `rstest` to focus on test
+structure and data provision, while `test-with` provides an orthogonal layer of
+control over test execution conditions.
 
 ## XI. Conclusion and Further Resources
 
@@ -1263,9 +1273,9 @@ equips developers with the tools to build comprehensive and maintainable test
 suites.
 
 While considerations such as compile-time impact and the learning curve for
-advanced features exist, the benefits in terms of cleaner, more robust, and more
-expressive tests often outweigh these for projects with non-trivial testing
-requirements.
+advanced features exist, the benefits in terms of cleaner, more robust, and
+more expressive tests often outweigh these for projects with non-trivial
+testing requirements.
 
 ### A. Recap of `rstest`'s Power for Fixture-Based Testing
 
@@ -1314,6 +1324,6 @@ provided by `rstest`:
 | #[timeout(...)]              | Sets a timeout for an asynchronous test.                                                     |
 | #[files("glob_pattern",...)] | Injects file paths (or contents, with mode=) matching a glob pattern as test arguments.      |
 
-By mastering `rstest`, Rust developers can significantly elevate the quality and
-efficiency of their testing practices, leading to more reliable and maintainable
-software.
+By mastering `rstest`, Rust developers can significantly elevate the quality
+and efficiency of their testing practices, leading to more reliable and
+maintainable software.

--- a/src/parser/ast/parse_utils/errors.rs
+++ b/src/parser/ast/parse_utils/errors.rs
@@ -20,6 +20,11 @@ pub(crate) enum Delim {
     Brace,
 }
 
+/// Records an opened delimiter and the span of its token.
+///
+/// Persisting the span lets the parser report `UnclosedDelimiter`
+/// errors at the original opening site rather than at the end of
+/// input, which makes diagnostics actionable.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct OpenDelimiter {
     kind: Delim,
@@ -124,7 +129,13 @@ impl DelimStack {
         closed
     }
 
-    /// Returns an iterator over any remaining unclosed delimiters.
+    /// Returns an iterator over remaining unclosed delimiters, draining the stack.
+    ///
+    /// # Side effects
+    ///
+    /// The internal stack is cleared, preventing the same delimiters from
+    /// being reported twice. Subsequent calls yield no items unless new
+    /// delimiters are opened.
     pub(crate) fn unclosed(&mut self) -> impl Iterator<Item = (Delim, TextRange)> + '_ {
         self.0.drain(..).map(|d| (d.kind, d.span))
     }

--- a/src/parser/ast/parse_utils/errors.rs
+++ b/src/parser/ast/parse_utils/errors.rs
@@ -20,8 +20,14 @@ pub(crate) enum Delim {
     Brace,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct OpenDelimiter {
+    kind: Delim,
+    span: TextRange,
+}
+
 #[derive(Default, Debug)]
-pub(crate) struct DelimStack(Vec<Delim>);
+pub(crate) struct DelimStack(Vec<OpenDelimiter>);
 
 /// An error emitted when a closing token does not match the expected delimiter.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -92,11 +98,11 @@ impl std::error::Error for DelimiterError {}
 impl DelimStack {
     /// Opens one or more delimiters of the same type.
     ///
-    /// Pushes `count` instances of `delim` onto the stack so they can be
-    /// matched with closing tokens later.
-    pub(super) fn open(&mut self, delim: Delim, count: usize) {
+    /// Pushes `count` instances of `delim` onto the stack, each recording the
+    /// `span` of the opening token so it can be reported if left unclosed.
+    pub(super) fn open(&mut self, delim: Delim, span: TextRange, count: usize) {
         for _ in 0..count {
-            self.0.push(delim);
+            self.0.push(OpenDelimiter { kind: delim, span });
         }
     }
 
@@ -108,7 +114,7 @@ impl DelimStack {
     pub(super) fn close(&mut self, delim: Delim, count: usize) -> usize {
         let mut closed = 0;
         for _ in 0..count {
-            if matches!(self.0.last(), Some(d) if *d == delim) {
+            if matches!(self.0.last(), Some(d) if d.kind == delim) {
                 self.0.pop();
                 closed += 1;
             } else {
@@ -119,8 +125,8 @@ impl DelimStack {
     }
 
     /// Returns an iterator over any remaining unclosed delimiters.
-    pub(crate) fn unclosed(&mut self) -> impl Iterator<Item = Delim> + '_ {
-        self.0.drain(..)
+    pub(crate) fn unclosed(&mut self) -> impl Iterator<Item = (Delim, TextRange)> + '_ {
+        self.0.drain(..).map(|d| (d.kind, d.span))
     }
 
     /// Checks whether the delimiter stack contains no open delimiters.

--- a/src/parser/ast/parse_utils/token_utils.rs
+++ b/src/parser/ast/parse_utils/token_utils.rs
@@ -5,6 +5,7 @@
 //! reported via `ParseError`.
 
 use crate::DdlogLanguage;
+use rowan::TextRange;
 
 use super::errors::{Delim, DelimStack, DelimiterError, ParseError};
 
@@ -23,22 +24,24 @@ impl<'a> TokenParseContext<'a> {
 
 /// Records an opening delimiter on the provided stack.
 ///
-/// Pushes `count` instances of `delim` so that matching closing
-/// tokens can be validated later. The token text itself is not
-/// appended to the buffer by this helper.
+/// Pushes `count` instances of `delim`, each tagged with the provided `span`, so
+/// that matching closing tokens can be validated later. The token text itself is
+/// not appended to the buffer by this helper.
 ///
 /// # Examples
 ///
 /// ```
 /// use ddlint::parser::ast::parse_utils::errors::{Delim, DelimStack};
 /// use ddlint::parser::ast::parse_utils::token_utils::open_delimiter;
+/// use rowan::{TextRange, TextSize};
 ///
 /// let mut stack = DelimStack::default();
-/// open_delimiter(&mut stack, Delim::Paren, 2);
+/// let span = TextRange::empty(TextSize::from(0));
+/// open_delimiter(&mut stack, Delim::Paren, span, 2);
 /// assert_eq!(stack.unclosed().count(), 2);
 /// ```
-pub(crate) fn open_delimiter(stack: &mut DelimStack, delim: Delim, count: usize) {
-    stack.open(delim, count);
+pub(crate) fn open_delimiter(stack: &mut DelimStack, delim: Delim, span: TextRange, count: usize) {
+    stack.open(delim, span, count);
 }
 
 /// Attempts to close `count` delimiters of the specified type.
@@ -52,9 +55,11 @@ pub(crate) fn open_delimiter(stack: &mut DelimStack, delim: Delim, count: usize)
 /// ```
 /// use ddlint::parser::ast::parse_utils::errors::{Delim, DelimStack};
 /// use ddlint::parser::ast::parse_utils::token_utils::{open_delimiter, close_delimiter};
+/// use rowan::{TextRange, TextSize};
 ///
 /// let mut stack = DelimStack::default();
-/// open_delimiter(&mut stack, Delim::Angle, 1);
+/// let span = TextRange::empty(TextSize::from(0));
+/// open_delimiter(&mut stack, Delim::Angle, span, 1);
 /// assert_eq!(close_delimiter(&mut stack, Delim::Angle, 1), 1);
 /// ```
 pub(crate) fn close_delimiter(stack: &mut DelimStack, delim: Delim, count: usize) -> usize {

--- a/src/parser/ast/parse_utils/token_utils.rs
+++ b/src/parser/ast/parse_utils/token_utils.rs
@@ -30,7 +30,7 @@ impl<'a> TokenParseContext<'a> {
 ///
 /// # Examples
 ///
-/// ```
+/// ```rust
 /// use ddlint::parser::ast::parse_utils::errors::{Delim, DelimStack};
 /// use ddlint::parser::ast::parse_utils::token_utils::open_delimiter;
 /// use rowan::{TextRange, TextSize};
@@ -52,7 +52,7 @@ pub(crate) fn open_delimiter(stack: &mut DelimStack, delim: Delim, span: TextRan
 ///
 /// # Examples
 ///
-/// ```
+/// ```rust
 /// use ddlint::parser::ast::parse_utils::errors::{Delim, DelimStack};
 /// use ddlint::parser::ast::parse_utils::token_utils::{open_delimiter, close_delimiter};
 /// use rowan::{TextRange, TextSize};

--- a/src/parser/ast/parse_utils/type_parsing.rs
+++ b/src/parser/ast/parse_utils/type_parsing.rs
@@ -196,26 +196,21 @@ fn handle_opening_delimiter(
     token: &rowan::SyntaxToken<DdlogLanguage>,
     ctx: &mut TokenParseContext<'_>,
 ) -> bool {
-    match token.kind() {
-        SyntaxKind::T_LPAREN => {
-            open_delimiter(&mut *ctx.stack, Delim::Paren, token.text_range(), 1);
-        }
-        SyntaxKind::T_LT => {
-            open_delimiter(&mut *ctx.stack, Delim::Angle, token.text_range(), 1);
-        }
-        SyntaxKind::T_SHL => {
-            open_delimiter(&mut *ctx.stack, Delim::Angle, token.text_range(), 2);
-        }
-        SyntaxKind::T_LBRACKET => {
-            open_delimiter(&mut *ctx.stack, Delim::Bracket, token.text_range(), 1);
-        }
-        SyntaxKind::T_LBRACE => {
-            open_delimiter(&mut *ctx.stack, Delim::Brace, token.text_range(), 1);
-        }
-        _ => return false,
+    let mapping = match token.kind() {
+        SyntaxKind::T_LPAREN => Some((Delim::Paren, 1)),
+        SyntaxKind::T_LT => Some((Delim::Angle, 1)),
+        SyntaxKind::T_SHL => Some((Delim::Angle, 2)),
+        SyntaxKind::T_LBRACKET => Some((Delim::Bracket, 1)),
+        SyntaxKind::T_LBRACE => Some((Delim::Brace, 1)),
+        _ => None,
+    };
+    if let Some((delim, count)) = mapping {
+        open_delimiter(&mut *ctx.stack, delim, token.text_range(), count);
+        push(token, ctx);
+        true
+    } else {
+        false
     }
-    push(token, ctx);
-    true
 }
 
 /// Handles a closing delimiter token.


### PR DESCRIPTION
## Summary
- record spans when opening delimiters and surface them in `ParseError::UnclosedDelimiter`
- expose span-aware `open_delimiter` helper
- document that unclosed delimiter errors point to the opening token

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make markdownlint`


------
https://chatgpt.com/codex/tasks/task_e_689553fd1f5083229549543ef2561574

## Summary by Sourcery

Track and report the spans of opening delimiters in the parser to improve UnclosedDelimiter diagnostics and expose a span-aware open_delimiter helper.

New Features:
- Expose a span-aware open_delimiter helper for recording opening token ranges

Enhancements:
- Record opening delimiter spans in DelimStack entries and return them in unclosed error reporting
- Surface the correct opening token span in ParseError::UnclosedDelimiter
- Refactor handle_opening_delimiter to pass token text ranges to the delimiter stack

Documentation:
- Document that unclosed delimiter errors highlight the opening delimiter’s position

Tests:
- Update unclosed_angle_error test to assert the reported span matches the opening token