### PR TITLE
Add test for unclosed delimiter span

### DIFF
--- a/src/parser/ast/parse_utils/type_parsing.rs
+++ b/src/parser/ast/parse_utils/type_parsing.rs
@@ -633,19 +633,19 @@ mod tests {
         }
     }
 
-    #[test]
-    fn type_expr_unclosed_delimiter_span() {
-        let src = "function bad(x: Vec<u32) {}";
-        let elements = tokens_for(src);
+    #[rstest]
+    fn type_expr_unclosed_delimiter_span(
+        #[with("function bad(x: Vec<u32) {}")] tokens_for: Vec<SyntaxElement<DdlogLanguage>>,
+    ) {
         #[expect(clippy::expect_used, reason = "Using expect for clearer test failures")]
-        let lt_span = elements
+        let lt_span = tokens_for
             .iter()
             .find_map(|e| match e {
                 SyntaxElement::Token(t) if t.text() == "<" => Some(t.text_range()),
                 _ => None,
             })
             .expect("angle token missing");
-        let mut iter = elements.into_iter().peekable();
+        let mut iter = tokens_for.into_iter().peekable();
         for e in iter.by_ref() {
             if e.kind() == SyntaxKind::T_COLON {
                 break;

--- a/src/parser/ast/parse_utils/type_parsing.rs
+++ b/src/parser/ast/parse_utils/type_parsing.rs
@@ -634,6 +634,37 @@ mod tests {
     }
 
     #[test]
+    fn type_expr_unclosed_delimiter_span() {
+        let src = "function bad(x: Vec<u32) {}";
+        let elements = tokens_for(src);
+        #[expect(clippy::expect_used, reason = "Using expect for clearer test failures")]
+        let lt_span = elements
+            .iter()
+            .find_map(|e| match e {
+                SyntaxElement::Token(t) if t.text() == "<" => Some(t.text_range()),
+                _ => None,
+            })
+            .expect("angle token missing");
+        let mut iter = elements.into_iter().peekable();
+        for e in iter.by_ref() {
+            if e.kind() == SyntaxKind::T_COLON {
+                break;
+            }
+        }
+        let (_ty, errors) = parse_type_expr(&mut iter);
+        assert_eq!(errors.len(), 1);
+        match errors.first() {
+            Some(ParseError::UnclosedDelimiter {
+                delimiter: '>',
+                span,
+            }) => {
+                assert_eq!(*span, lt_span);
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    #[test]
     fn empty_name_error() {
         let src = "function bad(: u32) {}";
         let elements = tokens_for(src);


### PR DESCRIPTION
## Summary
- test that `parse_type_expr` reports the span of the opening delimiter when the closing token is missing

## Testing
- `make fmt`
- `make lint`
- `make test`

closes #59

------
https://chatgpt.com/codex/tasks/task_e_689ef907cfc48322832ce49d43ee89a2

## Summary by Sourcery

Tests:
- Add test for UnclosedDelimiter error to assert the opening '<' span is returned when '>' is missing