### PR TITLE
Organize output parsing tests into dedicated module

### DIFF
--- a/src/parser/ast/parse_utils/outputs.rs
+++ b/src/parser/ast/parse_utils/outputs.rs
@@ -75,23 +75,4 @@ where
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::parser::ast::AstNode;
-    use crate::parser::parse;
-
-    #[test]
-    fn collects_output_names() {
-        let src = "extern transformer t(a: X): Out1, Out2";
-        let parsed = parse(src);
-        #[expect(clippy::expect_used, reason = "Using expect for clearer test failures")]
-        let tr = parsed
-            .root()
-            .transformers()
-            .first()
-            .cloned()
-            .expect("transformer missing");
-        let names = parse_output_list(tr.syntax().children_with_tokens());
-        assert_eq!(names, vec!["Out1".to_string(), "Out2".to_string()]);
-    }
-}
+mod tests;

--- a/src/parser/ast/parse_utils/outputs/tests.rs
+++ b/src/parser/ast/parse_utils/outputs/tests.rs
@@ -1,0 +1,20 @@
+//! Tests for output list parsing utilities.
+
+use super::*;
+use crate::parser::ast::AstNode;
+use crate::parser::parse;
+
+#[test]
+fn collects_output_names() {
+    let src = "extern transformer t(a: X): Out1, Out2";
+    let parsed = parse(src);
+    #[expect(clippy::expect_used, reason = "Using expect for clearer test failures")]
+    let tr = parsed
+        .root()
+        .transformers()
+        .first()
+        .cloned()
+        .expect("transformer missing");
+    let names = parse_output_list(tr.syntax().children_with_tokens());
+    assert_eq!(names, vec!["Out1".to_string(), "Out2".to_string()]);
+}


### PR DESCRIPTION
## Summary
- move output list parsing tests into their own `outputs::tests` module
- keep `outputs.rs` focused on parsing logic and gate tests behind `cfg(test)`

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a3ac3ec2c88322b67dc36ee6eecd2a

## Summary by Sourcery

Tests:
- Move output parsing tests from outputs.rs into a new outputs/tests.rs module