### PR TITLE
Refactor root collection assertions

### DIFF
--- a/src/parser/tests/parser.rs
+++ b/src/parser/tests/parser.rs
@@ -79,14 +79,35 @@ fn assert_index_count(parsed: &crate::Parsed, expected: usize) {
     assert_eq!(parsed.root().indexes().len(), expected);
 }
 
-/// Assert that all root collections are empty.
-fn assert_empty_collections(parsed: &crate::Parsed) {
+/// Assert that no declaration items are present.
+///
+/// This covers imports and type definitions.
+fn assert_no_declarations(parsed: &crate::Parsed) {
     assert!(parsed.root().imports().is_empty());
     assert!(parsed.root().type_defs().is_empty());
+}
+
+/// Assert that no executable items are present.
+///
+/// Executable items include relations, functions, and rules.
+fn assert_no_executables(parsed: &crate::Parsed) {
     assert!(parsed.root().relations().is_empty());
     assert!(parsed.root().functions().is_empty());
-    assert!(parsed.root().indexes().is_empty());
     assert!(parsed.root().rules().is_empty());
+}
+
+/// Assert that no indexes are present.
+fn assert_no_indexes(parsed: &crate::Parsed) {
+    assert!(parsed.root().indexes().is_empty());
+}
+
+/// Assert that all root collections are empty.
+///
+/// This delegates to the specialised helpers above.
+fn assert_empty_collections(parsed: &crate::Parsed) {
+    assert_no_declarations(parsed);
+    assert_no_executables(parsed);
+    assert_no_indexes(parsed);
 }
 
 /// Assert that the root node contains the expected number of children.


### PR DESCRIPTION
## Summary
- split root collection checks into specific helpers for declarations, executables, and indexes
- keep `assert_empty_collections` as a thin wrapper over the new helpers

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a992907d308322b13966e52390d953

## Summary by Sourcery

Refactor root collection assertions in parser tests by splitting generic empty checks into dedicated helpers for declarations, executables, and indexes, and update assert_empty_collections to wrap these.

Enhancements:
- Introduce assert_no_declarations to check for empty imports and type definitions
- Introduce assert_no_executables to check for empty relations, functions, and rules
- Introduce assert_no_indexes to check for empty indexes
- Refactor assert_empty_collections to delegate to the new specialized helpers

Tests:
- Update parser.rs test helpers to use the new assertion functions