### PR TITLE
Refactor parser tests to use typed programs

### DIFF
--- a/src/parser/tests/parser.rs
+++ b/src/parser/tests/parser.rs
@@ -3,132 +3,23 @@
 //! These tests verify that the parser builds a correct CST and that source
 //! round-trips through `pretty_print` unchanged.
 
-use crate::{
-    SyntaxKind,
-    ast::{AstNode, Function, Import, Index, Relation, Transformer, TypeDef},
-    parse,
-};
+use crate::{SyntaxKind, ast::AstNode, parse};
 use rstest::rstest;
+
+mod programs;
+use programs::{
+    BasicProgram,
+    FunctionProgram,
+    IndexProgram,
+    RelationProgram,
+    RuleProgram,
+    TransformerProgram,
+};
+mod specs;
+use specs::{FnSpec, IndexSpec, RelationSpec, TransformerSpec};
 
 const USER_ID: &str = "user_id";
 const USERNAME: &str = "username";
-
-enum TestProgram {
-    SimpleProg,
-    ComplexProg,
-    EmptyProg,
-    InputRelationPk,
-    OutputRelationNoPk,
-    InternalRelationCompoundPk,
-    MultilineRelation,
-    IndexSingleColumn,
-    IndexMultiColumn,
-    IndexInvalidMissingOn,
-    IndexNestedFunction,
-    IndexUnbalancedParentheses,
-    RelationUnbalancedParentheses,
-    RelationEmptyColumns,
-    RelationWhitespaceColumns,
-    RelationInvalidPk,
-    RelationPkEmpty,
-    RelationPkTrailingComma,
-    IndexWhitespaceVariations,
-    SimpleRule,
-    MultiLiteralRule,
-    FactRule,
-    ExternFunction,
-    FunctionWithBody,
-    FunctionNoReturn,
-    ExternFunctionMissingColon,
-    FunctionUnterminatedBody,
-    FunctionNoParams,
-    FunctionMultiParams,
-    FunctionComplexParams,
-    FunctionWsComments,
-    FunctionUnclosedParams,
-    FunctionGenericParams,
-    FunctionNestedGenerics,
-    FunctionShiftParam,
-    TransformerSingleIo,
-    TransformerMultiIo,
-    TransformerInvalid,
-    TransformerNoInputs,
-    TransformerNoOutputs,
-    TransformerExtraWs,
-    TransformerDupInputs,
-    TransformerReservedNames,
-}
-
-impl TestProgram {
-    fn source(&self) -> &'static str {
-        use TestProgram::*;
-        match self {
-            SimpleProg => "input relation R(x: u32);",
-            ComplexProg => "input relation R(x: u32);\noutput relation S(y: string);",
-            EmptyProg => "",
-            InputRelationPk => {
-                "input relation User(user_id: u32, username: string) primary key (user_id)"
-            }
-            OutputRelationNoPk => "output relation Alert(message: string, timestamp: u64)",
-            InternalRelationCompoundPk => {
-                "relation UserSession(user_id: u32, session_id: string, start_time: u64) primary key (user_id, session_id)"
-            }
-            MultilineRelation => {
-                "input relation Log(\n    id: u32,\n    message: string\n) primary key (id)\n"
-            }
-            IndexSingleColumn => "index Idx_User_username on User(username)",
-            IndexMultiColumn => "index Idx_Session_user_time on UserSession(user_id, start_time)",
-            IndexInvalidMissingOn => "index Idx_Invalid User(username)",
-            IndexNestedFunction => "index Idx_lower_username on User(lower(username))",
-            IndexUnbalancedParentheses => "index Idx_Unbalanced on User(lower(username)",
-            RelationUnbalancedParentheses => "relation Foo(x: u32",
-            RelationEmptyColumns => "relation Foo()",
-            RelationWhitespaceColumns => "relation Foo(   )",
-            RelationInvalidPk => "relation Foo(x: u32) primary key x",
-            RelationPkEmpty => "relation Foo(x: u32) primary key ()",
-            RelationPkTrailingComma => "relation Foo(x: u32) primary key (x,)",
-            IndexWhitespaceVariations => "  index  Idx_User_ws \t on\n  User (\n    username  )  ",
-            SimpleRule => "ActiveUser(user_id) :- User(user_id, _, true).",
-            MultiLiteralRule => {
-                "UserLogin(username, session_id) :- User(user_id, username, _), UserSession(user_id, session_id, _)."
-            }
-            FactRule => "SystemAlert(\"System is now online.\").",
-            ExternFunction => "extern function hash(data: string): u64\n",
-            FunctionWithBody => "function to_uppercase(s: string): string {\n}\n",
-            FunctionNoReturn => "function log_message(msg: string) {\n}\n",
-            ExternFunctionMissingColon => "extern function missing_colon u32\n",
-            FunctionUnterminatedBody => "function foo() {",
-            FunctionNoParams => "function greet(): string {\n}\n",
-            FunctionMultiParams => "function concat(a: string, b: string): string {\n}\n",
-            FunctionComplexParams => "function complex(p: (u32,(u8,string))): bool {\n}\n",
-            FunctionWsComments => "function  spaced  (  x : string )  :  u8 { /*empty*/ }\n",
-            FunctionUnclosedParams => "function bad(a: string { }\n",
-            FunctionGenericParams => {
-                "function example(arg: Vec<(u32,string)>, map: Map<string,u64>): bool {\n}\n"
-            }
-            FunctionNestedGenerics => {
-                "function test(p: Vec<Map<string,Vec<u8>>>, arr: [Vec<u32>]): bool {}\n"
-            }
-            FunctionShiftParam => "function shift(x: Vec<<u8>>): bool {}\n",
-            TransformerSingleIo => {
-                "extern transformer normalize(input: UnnormalizedData): NormalizedData"
-            }
-            TransformerMultiIo => {
-                "extern transformer correlate(users: User, sessions: UserSession): UserActivity, SessionAlerts"
-            }
-            TransformerInvalid => "extern transformer incomplete_transformer(input: SomeData):",
-            TransformerNoInputs => "extern transformer no_inputs(): OutputType",
-            TransformerNoOutputs => "extern transformer no_outputs(input: InputType):",
-            TransformerExtraWs => {
-                " extern   transformer   spaced  (  foo  :  Bar  ,  baz : Qux )  :  Out1 , Out2 "
-            }
-            TransformerDupInputs => "extern transformer dup_inputs(foo: Bar, foo: Baz): Out",
-            TransformerReservedNames => {
-                "extern transformer reserved(transformer: Type, extern: Type): out"
-            }
-        }
-    }
-}
 
 type SyntaxNode = rowan::SyntaxNode<crate::DdlogLanguage>;
 type SyntaxElement = rowan::SyntaxElement<crate::DdlogLanguage>;
@@ -159,235 +50,74 @@ fn assert_parse_has_errors(parsed: &crate::Parsed) {
     assert!(!parsed.errors().is_empty());
 }
 
-struct RelationSpec<'a> {
-    name: &'a str,
-    input: bool,
-    output: bool,
-    columns: Vec<(&'a str, &'a str)>,
-    pk: Option<Vec<&'a str>>,
-}
-impl<'a> RelationSpec<'a> {
-    fn new(name: &'a str) -> Self {
-        Self {
-            name,
-            input: false,
-            output: false,
-            columns: vec![],
-            pk: None,
-        }
-    }
-    fn input(mut self) -> Self {
-        self.input = true;
-        self
-    }
-    fn output(mut self) -> Self {
-        self.output = true;
-        self
-    }
-    fn column(mut self, name: &'a str, ty: &'a str) -> Self {
-        self.columns.push((name, ty));
-        self
-    }
-    fn pk(mut self, cols: Vec<&'a str>) -> Self {
-        self.pk = Some(cols);
-        self
-    }
-    fn assert(self, r: &Relation) {
-        assert_eq!(r.name(), Some(self.name.into()));
-        assert_eq!(r.is_input(), self.input);
-        assert_eq!(r.is_output(), self.output);
-        assert_eq!(
-            r.columns(),
-            self.columns
-                .iter()
-                .map(|(n, t)| ((*n).into(), (*t).into()))
-                .collect::<Vec<_>>()
-        );
-        assert_eq!(
-            r.primary_key(),
-            self.pk.map(|v| v.into_iter().map(String::from).collect())
-        );
-    }
-}
-
-struct IndexSpec<'a> {
-    name: &'a str,
-    relation: &'a str,
-    columns: Vec<&'a str>,
-}
-impl<'a> IndexSpec<'a> {
-    fn new(name: &'a str, relation: &'a str) -> Self {
-        Self {
-            name,
-            relation,
-            columns: vec![],
-        }
-    }
-    fn column(mut self, col: &'a str) -> Self {
-        self.columns.push(col);
-        self
-    }
-    fn assert(self, i: &Index) {
-        assert_eq!(i.name(), Some(self.name.into()));
-        assert_eq!(i.relation(), Some(self.relation.into()));
-        assert_eq!(
-            i.columns(),
-            self.columns
-                .iter()
-                .map(|c| (*c).to_string())
-                .collect::<Vec<_>>()
-        );
-    }
-}
-
-struct FnSpec<'a> {
-    name: &'a str,
-    ext: bool,
-    params: Vec<(&'a str, &'a str)>,
-    ret: Option<&'a str>,
-}
-impl<'a> FnSpec<'a> {
-    fn new(name: &'a str) -> Self {
-        Self {
-            name,
-            ext: false,
-            params: vec![],
-            ret: None,
-        }
-    }
-    fn extern_(mut self) -> Self {
-        self.ext = true;
-        self
-    }
-    fn param(mut self, name: &'a str, ty: &'a str) -> Self {
-        self.params.push((name, ty));
-        self
-    }
-    fn ret(mut self, ty: &'a str) -> Self {
-        self.ret = Some(ty);
-        self
-    }
-    fn assert(self, f: &Function) {
-        assert_eq!(f.name(), Some(self.name.into()));
-        assert_eq!(f.is_extern(), self.ext);
-        assert_eq!(
-            f.parameters(),
-            self.params
-                .iter()
-                .map(|(n, t)| ((*n).into(), (*t).into()))
-                .collect::<Vec<_>>()
-        );
-        assert_eq!(f.return_type(), self.ret.map(str::to_string));
-    }
-}
-
-struct TransformerSpec<'a> {
-    name: &'a str,
-    inputs: Vec<(&'a str, &'a str)>,
-    outputs: Vec<&'a str>,
-}
-impl<'a> TransformerSpec<'a> {
-    fn new(name: &'a str) -> Self {
-        Self {
-            name,
-            inputs: vec![],
-            outputs: vec![],
-        }
-    }
-    fn input(mut self, name: &'a str, ty: &'a str) -> Self {
-        self.inputs.push((name, ty));
-        self
-    }
-    fn output(mut self, ty: &'a str) -> Self {
-        self.outputs.push(ty);
-        self
-    }
-    fn assert(self, t: &Transformer) {
-        assert_eq!(t.name(), Some(self.name.into()));
-        assert_eq!(
-            t.inputs(),
-            self.inputs
-                .iter()
-                .map(|(n, ty)| ((*n).into(), (*ty).into()))
-                .collect::<Vec<_>>()
-        );
-        assert_eq!(
-            t.outputs(),
-            self.outputs
-                .iter()
-                .map(|o| (*o).to_string())
-                .collect::<Vec<_>>()
-        );
-    }
-}
 
 #[rstest]
-#[case(TestProgram::SimpleProg)]
-#[case(TestProgram::ComplexProg)]
-#[case(TestProgram::MultilineRelation)]
-fn round_trip_program(#[case] prog: TestProgram) {
+#[case(BasicProgram::Simple)]
+#[case(BasicProgram::Complex)]
+#[case(BasicProgram::MultilineRelation)]
+fn round_trip_program(#[case] prog: BasicProgram) {
     let src = prog.source();
     let parsed = parse(src);
     assert_parse_success(&parsed, src);
 }
 
 #[rstest]
-#[case(TestProgram::ComplexProg, 2)]
-#[case(TestProgram::SimpleProg, 1)]
-#[case(TestProgram::EmptyProg, 0)]
-fn relation_counts(#[case] prog: TestProgram, #[case] expected: usize) {
+#[case(BasicProgram::Complex, 2)]
+#[case(BasicProgram::Simple, 1)]
+#[case(BasicProgram::Empty, 0)]
+fn relation_counts(#[case] prog: BasicProgram, #[case] expected: usize) {
     let parsed = parse(prog.source());
     assert_eq!(parsed.root().relations().len(), expected);
 }
 
 #[rstest]
-#[case(TestProgram::InputRelationPk, RelationSpec::new("User").input().column(USER_ID, "u32").column(USERNAME, "string").pk(vec![USER_ID]))]
-#[case(TestProgram::OutputRelationNoPk, RelationSpec::new("Alert").output().column("message", "string").column("timestamp", "u64"))]
-#[case(TestProgram::InternalRelationCompoundPk, RelationSpec::new("UserSession").column(USER_ID, "u32").column("session_id", "string").column("start_time", "u64").pk(vec![USER_ID, "session_id"]))]
-fn relation_parsing(#[case] prog: TestProgram, #[case] spec: RelationSpec) {
+#[case(RelationProgram::InputRelationPk, RelationSpec::new("User").input().column(USER_ID, "u32").column(USERNAME, "string").pk(vec![USER_ID]))]
+#[case(RelationProgram::OutputRelationNoPk, RelationSpec::new("Alert").output().column("message", "string").column("timestamp", "u64"))]
+#[case(RelationProgram::InternalRelationCompoundPk, RelationSpec::new("UserSession").column(USER_ID, "u32").column("session_id", "string").column("start_time", "u64").pk(vec![USER_ID, "session_id"]))]
+fn relation_parsing(#[case] prog: RelationProgram, #[case] spec: RelationSpec) {
     let parsed = parse(prog.source());
     let rel = parsed.root().relations().first().expect("relation missing");
     spec.assert(rel);
 }
 
 #[rstest]
-#[case(TestProgram::RelationUnbalancedParentheses)]
-#[case(TestProgram::RelationEmptyColumns)]
-#[case(TestProgram::RelationWhitespaceColumns)]
-#[case(TestProgram::RelationInvalidPk)]
-#[case(TestProgram::RelationPkEmpty)]
-#[case(TestProgram::RelationPkTrailingComma)]
-fn relation_invalid(#[case] prog: TestProgram) {
+#[case(RelationProgram::RelationUnbalancedParentheses)]
+#[case(RelationProgram::RelationEmptyColumns)]
+#[case(RelationProgram::RelationWhitespaceColumns)]
+#[case(RelationProgram::RelationInvalidPk)]
+#[case(RelationProgram::RelationPkEmpty)]
+#[case(RelationProgram::RelationPkTrailingComma)]
+fn relation_invalid(#[case] prog: RelationProgram) {
     let parsed = parse(prog.source());
     assert_parse_has_errors(&parsed);
     assert!(parsed.root().relations().is_empty());
 }
 
 #[rstest]
-#[case(TestProgram::IndexSingleColumn, IndexSpec::new("Idx_User_username", "User").column(USERNAME))]
-#[case(TestProgram::IndexMultiColumn, IndexSpec::new("Idx_Session_user_time", "UserSession").column(USER_ID).column("start_time"))]
-#[case(TestProgram::IndexNestedFunction, IndexSpec::new("Idx_lower_username", "User").column("lower(username)"))]
-#[case(TestProgram::IndexWhitespaceVariations, IndexSpec::new("Idx_User_ws", "User").column(USERNAME))]
-fn index_parsing(#[case] prog: TestProgram, #[case] spec: IndexSpec) {
+#[case(IndexProgram::IndexSingleColumn, IndexSpec::new("Idx_User_username", "User").column(USERNAME))]
+#[case(IndexProgram::IndexMultiColumn, IndexSpec::new("Idx_Session_user_time", "UserSession").column(USER_ID).column("start_time"))]
+#[case(IndexProgram::IndexNestedFunction, IndexSpec::new("Idx_lower_username", "User").column("lower(username)"))]
+#[case(IndexProgram::IndexWhitespaceVariations, IndexSpec::new("Idx_User_ws", "User").column(USERNAME))]
+fn index_parsing(#[case] prog: IndexProgram, #[case] spec: IndexSpec) {
     let parsed = parse(prog.source());
     let idx = parsed.root().indexes().first().expect("index missing");
     spec.assert(idx);
 }
 
 #[rstest]
-#[case(TestProgram::IndexInvalidMissingOn)]
-#[case(TestProgram::IndexUnbalancedParentheses)]
-fn index_errors(#[case] prog: TestProgram) {
+#[case(IndexProgram::IndexInvalidMissingOn)]
+#[case(IndexProgram::IndexUnbalancedParentheses)]
+fn index_errors(#[case] prog: IndexProgram) {
     let parsed = parse(prog.source());
     assert_parse_has_errors(&parsed);
     assert!(parsed.root().indexes().is_empty());
 }
 
 #[rstest]
-#[case(TestProgram::SimpleRule)]
-#[case(TestProgram::MultiLiteralRule)]
-#[case(TestProgram::FactRule)]
-fn rule_parsing(#[case] prog: TestProgram) {
+#[case(RuleProgram::SimpleRule)]
+#[case(RuleProgram::MultiLiteralRule)]
+#[case(RuleProgram::FactRule)]
+fn rule_parsing(#[case] prog: RuleProgram) {
     let src = prog.source();
     let parsed = parse(src);
     let rule = parsed.root().rules().first().expect("rule missing");
@@ -459,40 +189,49 @@ fn typedef_parsing(#[case] src: &str, #[case] expect: (&str, bool)) {
 }
 
 #[rstest]
-#[case(TestProgram::ExternFunction, FnSpec::new("hash").extern_().param("data", "string").ret("u64"))]
-#[case(TestProgram::FunctionWithBody, FnSpec::new("to_uppercase").param("s", "string").ret("string"))]
-#[case(TestProgram::FunctionNoReturn, FnSpec::new("log_message").param("msg", "string"))]
-#[case(TestProgram::FunctionNoParams, FnSpec::new("greet").ret("string"))]
-#[case(TestProgram::FunctionMultiParams, FnSpec::new("concat").param("a", "string").param("b", "string").ret("string"))]
-#[case(TestProgram::FunctionComplexParams, FnSpec::new("complex").param("p", "(u32,(u8,string))").ret("bool"))]
-#[case(TestProgram::FunctionWsComments, FnSpec::new("spaced").param("x", "string").ret("u8"))]
-#[case(TestProgram::FunctionGenericParams, FnSpec::new("example").param("arg", "Vec<(u32,string)>").param("map", "Map<string,u64>").ret("bool"))]
-#[case(TestProgram::FunctionNestedGenerics, FnSpec::new("test").param("p", "Vec<Map<string,Vec<u8>>>").param("arr", "[Vec<u32>]").ret("bool"))]
-#[case(TestProgram::FunctionShiftParam, FnSpec::new("shift").param("x", "Vec<<u8>>").ret("bool"))]
-fn function_parsing(#[case] prog: TestProgram, #[case] spec: FnSpec) {
+#[case("typedef = string\n")]
+#[case("typedef MissingType\n")]
+fn typedef_errors(#[case] src: &str) {
+    let parsed = parse(src);
+    assert_parse_has_errors(&parsed);
+    assert!(parsed.root().type_defs().is_empty());
+}
+
+#[rstest]
+#[case(FunctionProgram::ExternFunction, FnSpec::new("hash").extern_().param("data", "string").ret("u64"))]
+#[case(FunctionProgram::FunctionWithBody, FnSpec::new("to_uppercase").param("s", "string").ret("string"))]
+#[case(FunctionProgram::FunctionNoReturn, FnSpec::new("log_message").param("msg", "string"))]
+#[case(FunctionProgram::FunctionNoParams, FnSpec::new("greet").ret("string"))]
+#[case(FunctionProgram::FunctionMultiParams, FnSpec::new("concat").param("a", "string").param("b", "string").ret("string"))]
+#[case(FunctionProgram::FunctionComplexParams, FnSpec::new("complex").param("p", "(u32,(u8,string))").ret("bool"))]
+#[case(FunctionProgram::FunctionWsComments, FnSpec::new("spaced").param("x", "string").ret("u8"))]
+#[case(FunctionProgram::FunctionGenericParams, FnSpec::new("example").param("arg", "Vec<(u32,string)>").param("map", "Map<string,u64>").ret("bool"))]
+#[case(FunctionProgram::FunctionNestedGenerics, FnSpec::new("test").param("p", "Vec<Map<string,Vec<u8>>>").param("arr", "[Vec<u32>]").ret("bool"))]
+#[case(FunctionProgram::FunctionShiftParam, FnSpec::new("shift").param("x", "Vec<<u8>>").ret("bool"))]
+fn function_parsing(#[case] prog: FunctionProgram, #[case] spec: FnSpec) {
     let parsed = parse(prog.source());
     let func = parsed.root().functions().first().expect("function missing");
     spec.assert(func);
 }
 
 #[rstest]
-#[case(TestProgram::ExternFunctionMissingColon)]
-#[case(TestProgram::FunctionUnterminatedBody)]
-#[case(TestProgram::FunctionUnclosedParams)]
-fn function_errors(#[case] prog: TestProgram) {
+#[case(FunctionProgram::ExternFunctionMissingColon)]
+#[case(FunctionProgram::FunctionUnterminatedBody)]
+#[case(FunctionProgram::FunctionUnclosedParams)]
+fn function_errors(#[case] prog: FunctionProgram) {
     let parsed = parse(prog.source());
     assert_parse_has_errors(&parsed);
     assert!(parsed.root().functions().is_empty());
 }
 
 #[rstest]
-#[case(TestProgram::TransformerSingleIo, TransformerSpec::new("normalize").input("input", "UnnormalizedData").output("NormalizedData"))]
-#[case(TestProgram::TransformerMultiIo, TransformerSpec::new("correlate").input("users", "User").input("sessions", "UserSession").output("UserActivity").output("SessionAlerts"))]
-#[case(TestProgram::TransformerNoInputs, TransformerSpec::new("no_inputs").output("OutputType"))]
-#[case(TestProgram::TransformerExtraWs, TransformerSpec::new("spaced").input("foo", "Bar").input("baz", "Qux").output("Out1").output("Out2"))]
-#[case(TestProgram::TransformerDupInputs, TransformerSpec::new("dup_inputs").input("foo", "Bar").input("foo", "Baz").output("Out"))]
-#[case(TestProgram::TransformerReservedNames, TransformerSpec::new("reserved").input("transformer", "Type").input("extern", "Type").output("out"))]
-fn transformer_parsing(#[case] prog: TestProgram, #[case] spec: TransformerSpec) {
+#[case(TransformerProgram::TransformerSingleIo, TransformerSpec::new("normalize").input("input", "UnnormalizedData").output("NormalizedData"))]
+#[case(TransformerProgram::TransformerMultiIo, TransformerSpec::new("correlate").input("users", "User").input("sessions", "UserSession").output("UserActivity").output("SessionAlerts"))]
+#[case(TransformerProgram::TransformerNoInputs, TransformerSpec::new("no_inputs").output("OutputType"))]
+#[case(TransformerProgram::TransformerExtraWs, TransformerSpec::new("spaced").input("foo", "Bar").input("baz", "Qux").output("Out1").output("Out2"))]
+#[case(TransformerProgram::TransformerDupInputs, TransformerSpec::new("dup_inputs").input("foo", "Bar").input("foo", "Baz").output("Out"))]
+#[case(TransformerProgram::TransformerReservedNames, TransformerSpec::new("reserved").input("transformer", "Type").input("extern", "Type").output("out"))]
+fn transformer_parsing(#[case] prog: TransformerProgram, #[case] spec: TransformerSpec) {
     let parsed = parse(prog.source());
     let t = parsed
         .root()
@@ -503,9 +242,9 @@ fn transformer_parsing(#[case] prog: TestProgram, #[case] spec: TransformerSpec)
 }
 
 #[rstest]
-#[case(TestProgram::TransformerInvalid)]
-#[case(TestProgram::TransformerNoOutputs)]
-fn transformer_errors(#[case] prog: TestProgram) {
+#[case(TransformerProgram::TransformerInvalid)]
+#[case(TransformerProgram::TransformerNoOutputs)]
+fn transformer_errors(#[case] prog: TransformerProgram) {
     let parsed = parse(prog.source());
     assert_parse_has_errors(&parsed);
     assert!(parsed.root().transformers().is_empty());

--- a/src/parser/tests/programs.rs
+++ b/src/parser/tests/programs.rs
@@ -1,0 +1,202 @@
+//! Predefined DDL programs used across parser tests.
+//!
+//! Each enum groups programs by domain to keep the main test file concise.
+
+#[derive(Copy, Clone)]
+pub enum BasicProgram {
+    Simple,
+    Complex,
+    Empty,
+    MultilineRelation,
+}
+
+impl BasicProgram {
+    pub fn source(self) -> &'static str {
+        match self {
+            Self::Simple => "input relation R(x: u32);",
+            Self::Complex => "input relation R(x: u32);\noutput relation S(y: string);",
+            Self::Empty => "",
+            Self::MultilineRelation => "input relation Log(\n    id: u32,\n    message: string\n) primary key (id)\n",
+        }
+    }
+}
+
+#[derive(Copy, Clone)]
+pub enum RelationProgram {
+    InputRelationPk,
+    OutputRelationNoPk,
+    InternalRelationCompoundPk,
+    RelationUnbalancedParentheses,
+    RelationEmptyColumns,
+    RelationWhitespaceColumns,
+    RelationInvalidPk,
+    RelationPkEmpty,
+    RelationPkTrailingComma,
+}
+
+impl RelationProgram {
+    pub fn source(self) -> &'static str {
+        match self {
+            Self::InputRelationPk => {
+                "input relation User(user_id: u32, username: string) primary key (user_id)"
+            }
+            Self::OutputRelationNoPk => {
+                "output relation Alert(message: string, timestamp: u64)"
+            }
+            Self::InternalRelationCompoundPk => {
+                "relation UserSession(user_id: u32, session_id: string, start_time: u64) primary key (user_id, session_id)"
+            }
+            Self::RelationUnbalancedParentheses => "relation Foo(x: u32",
+            Self::RelationEmptyColumns => "relation Foo()",
+            Self::RelationWhitespaceColumns => "relation Foo(   )",
+            Self::RelationInvalidPk => "relation Foo(x: u32) primary key x",
+            Self::RelationPkEmpty => "relation Foo(x: u32) primary key ()",
+            Self::RelationPkTrailingComma => "relation Foo(x: u32) primary key (x,)",
+        }
+    }
+}
+
+#[derive(Copy, Clone)]
+pub enum IndexProgram {
+    IndexSingleColumn,
+    IndexMultiColumn,
+    IndexInvalidMissingOn,
+    IndexNestedFunction,
+    IndexUnbalancedParentheses,
+    IndexWhitespaceVariations,
+}
+
+impl IndexProgram {
+    pub fn source(self) -> &'static str {
+        match self {
+            Self::IndexSingleColumn => "index Idx_User_username on User(username)",
+            Self::IndexMultiColumn => {
+                "index Idx_Session_user_time on UserSession(user_id, start_time)"
+            }
+            Self::IndexInvalidMissingOn => "index Idx_Invalid User(username)",
+            Self::IndexNestedFunction => {
+                "index Idx_lower_username on User(lower(username))"
+            }
+            Self::IndexUnbalancedParentheses => {
+                "index Idx_Unbalanced on User(lower(username)"
+            }
+            Self::IndexWhitespaceVariations => {
+                "  index  Idx_User_ws \t on\n  User (\n    username  )  "
+            }
+        }
+    }
+}
+
+#[derive(Copy, Clone)]
+pub enum RuleProgram {
+    SimpleRule,
+    MultiLiteralRule,
+    FactRule,
+}
+
+impl RuleProgram {
+    pub fn source(self) -> &'static str {
+        match self {
+            Self::SimpleRule => {
+                "ActiveUser(user_id) :- User(user_id, _, true)."
+            }
+            Self::MultiLiteralRule => {
+                "UserLogin(username, session_id) :- User(user_id, username, _), UserSession(user_id, session_id, _)."
+            }
+            Self::FactRule => "SystemAlert(\"System is now online.\").",
+        }
+    }
+}
+
+#[derive(Copy, Clone)]
+pub enum FunctionProgram {
+    ExternFunction,
+    FunctionWithBody,
+    FunctionNoReturn,
+    ExternFunctionMissingColon,
+    FunctionUnterminatedBody,
+    FunctionNoParams,
+    FunctionMultiParams,
+    FunctionComplexParams,
+    FunctionWsComments,
+    FunctionUnclosedParams,
+    FunctionGenericParams,
+    FunctionNestedGenerics,
+    FunctionShiftParam,
+}
+
+impl FunctionProgram {
+    pub fn source(self) -> &'static str {
+        match self {
+            Self::ExternFunction => "extern function hash(data: string): u64\n",
+            Self::FunctionWithBody => "function to_uppercase(s: string): string {\n}\n",
+            Self::FunctionNoReturn => "function log_message(msg: string) {\n}\n",
+            Self::ExternFunctionMissingColon => {
+                "extern function missing_colon u32\n"
+            }
+            Self::FunctionUnterminatedBody => "function foo() {",
+            Self::FunctionNoParams => "function greet(): string {\n}\n",
+            Self::FunctionMultiParams => {
+                "function concat(a: string, b: string): string {\n}\n"
+            }
+            Self::FunctionComplexParams => {
+                "function complex(p: (u32,(u8,string))): bool {\n}\n"
+            }
+            Self::FunctionWsComments => {
+                "function  spaced  (  x : string )  :  u8 { /*empty*/ }\n"
+            }
+            Self::FunctionUnclosedParams => "function bad(a: string { }\n",
+            Self::FunctionGenericParams => {
+                "function example(arg: Vec<(u32,string)>, map: Map<string,u64>): bool {\n}\n"
+            }
+            Self::FunctionNestedGenerics => {
+                "function test(p: Vec<Map<string,Vec<u8>>>, arr: [Vec<u32>]): bool {}\n"
+            }
+            Self::FunctionShiftParam => "function shift(x: Vec<<u8>>): bool {}\n",
+        }
+    }
+}
+
+#[derive(Copy, Clone)]
+pub enum TransformerProgram {
+    TransformerSingleIo,
+    TransformerMultiIo,
+    TransformerInvalid,
+    TransformerNoInputs,
+    TransformerNoOutputs,
+    TransformerExtraWs,
+    TransformerDupInputs,
+    TransformerReservedNames,
+}
+
+impl TransformerProgram {
+    pub fn source(self) -> &'static str {
+        match self {
+            Self::TransformerSingleIo => {
+                "extern transformer normalize(input: UnnormalizedData): NormalizedData"
+            }
+            Self::TransformerMultiIo => {
+                "extern transformer correlate(users: User, sessions: UserSession): UserActivity, SessionAlerts"
+            }
+            Self::TransformerInvalid => {
+                "extern transformer incomplete_transformer(input: SomeData):"
+            }
+            Self::TransformerNoInputs => {
+                "extern transformer no_inputs(): OutputType"
+            }
+            Self::TransformerNoOutputs => {
+                "extern transformer no_outputs(input: InputType):"
+            }
+            Self::TransformerExtraWs => {
+                " extern   transformer   spaced  (  foo  :  Bar  ,  baz : Qux )  :  Out1 , Out2 "
+            }
+            Self::TransformerDupInputs => {
+                "extern transformer dup_inputs(foo: Bar, foo: Baz): Out"
+            }
+            Self::TransformerReservedNames => {
+                "extern transformer reserved(transformer: Type, extern: Type): out"
+            }
+        }
+    }
+}
+

--- a/src/parser/tests/specs.rs
+++ b/src/parser/tests/specs.rs
@@ -1,0 +1,145 @@
+//! Assertion builders for parser tests.
+
+use crate::ast::{Function, Index, Relation, Transformer};
+
+fn pair_vec(items: &[(&str, &str)]) -> Vec<(String, String)> {
+    items
+        .iter()
+        .map(|(n, t)| ((*n).into(), (*t).into()))
+        .collect()
+}
+
+fn str_vec(items: &[&str]) -> Vec<String> {
+    items.iter().map(|s| (*s).to_string()).collect()
+}
+
+macro_rules! assert_entity {
+    ($node:expr, $spec:expr, $( $actual:expr => $expected:expr ),* $(,)?) => {{
+        assert_eq!($node.name(), Some($spec.name.into()));
+        $( assert_eq!($actual, $expected); )*
+    }};
+}
+pub(crate) use assert_entity;
+
+pub struct RelationSpec<'a> {
+    name: &'a str,
+    input: bool,
+    output: bool,
+    columns: Vec<(&'a str, &'a str)>,
+    pk: Option<Vec<&'a str>>,
+}
+impl<'a> RelationSpec<'a> {
+    pub fn new(name: &'a str) -> Self {
+        Self { name, input: false, output: false, columns: vec![], pk: None }
+    }
+    pub fn input(mut self) -> Self {
+        self.input = true;
+        self
+    }
+    pub fn output(mut self) -> Self {
+        self.output = true;
+        self
+    }
+    pub fn column(mut self, name: &'a str, ty: &'a str) -> Self {
+        self.columns.push((name, ty));
+        self
+    }
+    pub fn pk(mut self, cols: Vec<&'a str>) -> Self {
+        self.pk = Some(cols);
+        self
+    }
+    pub fn assert(self, r: &Relation) {
+        assert_entity!(
+            r,
+            self,
+            r.is_input() => self.input,
+            r.is_output() => self.output,
+            r.columns() => pair_vec(&self.columns),
+            r.primary_key() => self.pk.map(|v| str_vec(&v))
+        );
+    }
+}
+
+pub struct IndexSpec<'a> {
+    name: &'a str,
+    relation: &'a str,
+    columns: Vec<&'a str>,
+}
+impl<'a> IndexSpec<'a> {
+    pub fn new(name: &'a str, relation: &'a str) -> Self {
+        Self { name, relation, columns: vec![] }
+    }
+    pub fn column(mut self, col: &'a str) -> Self {
+        self.columns.push(col);
+        self
+    }
+    pub fn assert(self, i: &Index) {
+        assert_entity!(
+            i,
+            self,
+            i.relation() => Some(self.relation.into()),
+            i.columns() => str_vec(&self.columns)
+        );
+    }
+}
+
+pub struct FnSpec<'a> {
+    name: &'a str,
+    ext: bool,
+    params: Vec<(&'a str, &'a str)>,
+    ret: Option<&'a str>,
+}
+impl<'a> FnSpec<'a> {
+    pub fn new(name: &'a str) -> Self {
+        Self { name, ext: false, params: vec![], ret: None }
+    }
+    pub fn extern_(mut self) -> Self {
+        self.ext = true;
+        self
+    }
+    pub fn param(mut self, name: &'a str, ty: &'a str) -> Self {
+        self.params.push((name, ty));
+        self
+    }
+    pub fn ret(mut self, ty: &'a str) -> Self {
+        self.ret = Some(ty);
+        self
+    }
+    pub fn assert(self, f: &Function) {
+        assert_entity!(
+            f,
+            self,
+            f.is_extern() => self.ext,
+            f.parameters() => pair_vec(&self.params),
+            f.return_type() => self.ret.map(str::to_string)
+        );
+    }
+}
+
+pub struct TransformerSpec<'a> {
+    name: &'a str,
+    inputs: Vec<(&'a str, &'a str)>,
+    outputs: Vec<&'a str>,
+}
+impl<'a> TransformerSpec<'a> {
+    pub fn new(name: &'a str) -> Self {
+        Self { name, inputs: vec![], outputs: vec![] }
+    }
+    pub fn input(mut self, name: &'a str, ty: &'a str) -> Self {
+        self.inputs.push((name, ty));
+        self
+    }
+    pub fn output(mut self, ty: &'a str) -> Self {
+        self.outputs.push(ty);
+        self
+    }
+    pub fn assert(self, t: &Transformer) {
+        assert_entity!(
+            t,
+            self,
+            t.inputs() => pair_vec(&self.inputs),
+            t.outputs() => str_vec(&self.outputs)
+        );
+    }
+}
+


### PR DESCRIPTION
## Summary
- replace 43 string fixtures with a `TestProgram` enum and `source()` helper
- introduce builder structs for relation, index, function and transformer assertions
- consolidate duplicate tests with rstest cases and extract common string constants

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a993dbde908322991396b83f409c15

## Summary by Sourcery

Refactor the parser integration tests to improve maintainability and reduce duplication by introducing typed program fixtures, assertion builder structs, and parameterized test cases.

Enhancements:
- Replace raw string fixtures with `Program` enums and `source()` helpers in a new `programs.rs` file
- Introduce builder structs (`RelationSpec`, `IndexSpec`, `FnSpec`, `TransformerSpec`) in `specs.rs` for structured assertions
- Consolidate repetitive tests using `rstest` case parameters to cover multiple scenarios in single test functions
- Streamline test helpers by extracting common constants and simplifying `pretty_print` and whitespace normalization

Tests:
- Remove dozens of individual fixture functions and inline assertion helpers in favor of reusable enums and specs
- Parameterize tests across basic programs, relations, indexes, rules, imports, typedefs, functions, and transformers