### PR TITLE
Refactor parser tests to use shared helpers

### DIFF
--- a/src/parser/tests/common.rs
+++ b/src/parser/tests/common.rs
@@ -56,14 +56,22 @@ pub(super) fn normalise_whitespace(text: &str) -> String {
 /// let parsed = parse_program("input relation R(x: u32);");
 /// assert!(parsed.errors().is_empty());
 /// ```
+#[track_caller]
 pub(super) fn parse_program(src: &str) -> crate::Parsed {
     let parsed = parse(src);
     assert!(
         parsed.errors().is_empty(),
-        "unexpected errors: {:?}",
-        parsed.errors()
+        "parse_program: unexpected errors: {:?}\nsource: {:?}",
+        parsed.errors(),
+        src
     );
-    assert_eq!(parsed.root().kind(), SyntaxKind::N_DATALOG_PROGRAM);
+    assert_eq!(
+        parsed.root().kind(),
+        SyntaxKind::N_DATALOG_PROGRAM,
+        "parse_program: unexpected root kind; got {:?}\nsource: {:?}",
+        parsed.root().kind(),
+        src
+    );
     parsed
 }
 
@@ -79,9 +87,14 @@ pub(super) fn parse_program(src: &str) -> crate::Parsed {
 ///
 /// assert_program_round_trip("input relation R(x: u32);");
 /// ```
+#[track_caller]
 pub(super) fn assert_program_round_trip(src: &str) -> crate::Parsed {
     let parsed = parse_program(src);
-    assert_eq!(pretty_print(parsed.root().syntax()), src);
+    assert_eq!(
+        pretty_print(parsed.root().syntax()),
+        src,
+        "round_trip: printed output diverged from input",
+    );
     parsed
 }
 
@@ -95,8 +108,12 @@ pub(super) fn assert_program_round_trip(src: &str) -> crate::Parsed {
 /// let parsed = ddlint::parse("?");
 /// assert_parse_has_errors(&parsed);
 /// ```
+#[track_caller]
 pub(super) fn assert_parse_has_errors(parsed: &crate::Parsed) {
-    assert!(!parsed.errors().is_empty());
+    assert!(
+        !parsed.errors().is_empty(),
+        "assert_parse_has_errors: expected errors but none found"
+    );
 }
 
 /// Parse a program and extract the first item produced by `extractor`.

--- a/src/parser/tests/round_trip.rs
+++ b/src/parser/tests/round_trip.rs
@@ -4,10 +4,7 @@
 //! original source and that basic program structure is detected correctly.
 
 use super::common::{
-    assert_parse_has_errors,
-    assert_program_round_trip,
-    parse_program,
-    pretty_print,
+    assert_parse_has_errors, assert_program_round_trip, parse_program, pretty_print,
 };
 use crate::{SyntaxKind, parse};
 use rstest::{fixture, rstest};

--- a/src/parser/tests/round_trip.rs
+++ b/src/parser/tests/round_trip.rs
@@ -6,7 +6,9 @@
 use super::common::{
     assert_parse_has_errors, assert_program_round_trip, parse_program, pretty_print,
 };
-use crate::{SyntaxKind, parse};
+#[rustfmt::skip]
+use crate::{parse, SyntaxKind};
+use chumsky::error::SimpleReason;
 use rstest::{fixture, rstest};
 
 #[fixture]
@@ -61,6 +63,12 @@ fn error_token_produces_error_node() {
     let source = "?( relation Foo(";
     let parsed = parse(source);
     assert_parse_has_errors(&parsed);
+    let errors = parsed.errors();
+    assert_eq!(errors.len(), 1);
+    #[expect(clippy::expect_used, reason = "test asserts single error")]
+    let error = errors.first().expect("expected error");
+    assert!(matches!(error.reason(), SimpleReason::Unexpected));
+    assert!(error.found().is_none());
     let root = parsed.root().syntax();
     let has_error = root
         .children_with_tokens()

--- a/tests/expression_literals.rs
+++ b/tests/expression_literals.rs
@@ -5,10 +5,10 @@
 
 use ddlint::parser::ast::Expr;
 use ddlint::parser::expression::parse_expression;
-use ddlint::test_util::{
-    assert_parse_error, assert_unclosed_delimiter_error, lit_bool, lit_num, lit_str,
-};
+
+mod test_util;
 use rstest::rstest;
+use test_util::{assert_parse_error, assert_unclosed_delimiter_error, lit_bool, lit_num, lit_str};
 
 #[rstest]
 #[case("42", lit_num("42"))]

--- a/tests/expression_var_and_call.rs
+++ b/tests/expression_var_and_call.rs
@@ -5,10 +5,12 @@
 
 use ddlint::parser::ast::Expr;
 use ddlint::parser::expression::parse_expression;
-use ddlint::test_util::{
+
+mod test_util;
+use rstest::rstest;
+use test_util::{
     assert_delimiter_error, assert_parse_error, assert_unclosed_delimiter_error, call, lit_num, var,
 };
-use rstest::rstest;
 
 #[rstest]
 #[case("x", var("x"))]

--- a/tests/function_errors.rs
+++ b/tests/function_errors.rs
@@ -4,8 +4,10 @@
 //! that specific delimiter issues are reported with precise spans.
 
 use ddlint::parser::parse;
-use ddlint::test_util::{assert_delimiter_error, assert_unclosed_delimiter_error};
+
+mod test_util;
 use rstest::rstest;
+use test_util::{assert_delimiter_error, assert_unclosed_delimiter_error};
 
 #[rstest]
 #[case("function f(x: int {", "T_RPAREN", 0, 19, true)]

--- a/tests/test_util/mod.rs
+++ b/tests/test_util/mod.rs
@@ -1,0 +1,255 @@
+//! Shared test utilities for integration tests.
+//!
+//! These helpers construct AST nodes and assert over parser errors. They mirror
+//! a subset of the `ddlint::test_util` module without requiring the `test-util`
+//! feature, enabling integration tests to compile against the published
+//! library.
+
+#![expect(
+    dead_code,
+    reason = "helpers are reused across multiple tests so some may be unused"
+)]
+#![expect(
+    clippy::expect_used,
+    reason = "test helpers use expect for clearer failure messages"
+)]
+
+use chumsky::error::Simple;
+use ddlint::{
+    SyntaxKind,
+    parser::ast::{Expr, Literal},
+};
+use std::ops::Range;
+
+/// Typed wrapper for variable and function names.
+#[derive(Debug, Clone)]
+pub struct Name(String);
+
+impl From<&str> for Name {
+    fn from(s: &str) -> Self {
+        Self(s.to_string())
+    }
+}
+
+impl From<String> for Name {
+    fn from(s: String) -> Self {
+        Self(s)
+    }
+}
+
+/// Construct a numeric [`Expr::Literal`].
+///
+/// # Examples
+///
+/// ```
+/// use test_util::lit_num;
+/// use ddlint::parser::ast::Expr;
+///
+/// let expr = lit_num("42");
+/// assert!(matches!(expr, Expr::Literal(_)));
+/// ```
+#[must_use]
+pub fn lit_num(n: &str) -> Expr {
+    Expr::Literal(Literal::Number(n.into()))
+}
+
+/// Construct a string [`Expr::Literal`].
+///
+/// # Examples
+///
+/// ```
+/// use test_util::lit_str;
+/// use ddlint::parser::ast::Expr;
+///
+/// let expr = lit_str("hi");
+/// assert!(matches!(expr, Expr::Literal(_)));
+/// ```
+#[must_use]
+pub fn lit_str(s: &str) -> Expr {
+    Expr::Literal(Literal::String(s.into()))
+}
+
+/// Construct a boolean [`Expr::Literal`].
+///
+/// # Examples
+///
+/// ```
+/// use test_util::lit_bool;
+/// use ddlint::parser::ast::Expr;
+///
+/// let expr = lit_bool(true);
+/// assert!(matches!(expr, Expr::Literal(_)));
+/// ```
+#[must_use]
+pub fn lit_bool(b: bool) -> Expr {
+    Expr::Literal(Literal::Bool(b))
+}
+
+/// Construct a variable [`Expr::Variable`].
+///
+/// # Examples
+///
+/// ```
+/// use test_util::var;
+/// use ddlint::parser::ast::Expr;
+///
+/// let expr = var("x");
+/// assert!(matches!(expr, Expr::Variable(_)));
+/// ```
+#[must_use]
+pub fn var(name: impl Into<Name>) -> Expr {
+    let name: Name = name.into();
+    Expr::Variable(name.0)
+}
+
+/// Construct a function call [`Expr::Call`].
+///
+/// # Examples
+///
+/// ```
+/// use test_util::{call, lit_num};
+/// use ddlint::parser::ast::Expr;
+///
+/// let expr = call("f", vec![lit_num("1")]);
+/// assert!(matches!(expr, Expr::Call { .. }));
+/// ```
+#[must_use]
+pub fn call(name: impl Into<Name>, args: Vec<Expr>) -> Expr {
+    let name: Name = name.into();
+    Expr::Call { name: name.0, args }
+}
+
+/// Common error message patterns for parser assertions.
+#[derive(Debug, Clone)]
+pub enum ErrorPattern {
+    /// Custom substring to match against a rendered error.
+    Custom(String),
+    /// The parser reported an unexpected token.
+    UnexpectedToken,
+    /// The parser reported an unexpected end-of-file.
+    UnexpectedEof,
+    /// A delimiter was left unclosed.
+    UnclosedDelimiter,
+    /// A delimiter mismatch occurred.
+    MismatchedDelimiter,
+}
+
+impl ErrorPattern {
+    fn contains_message(&self, rendered: &str) -> bool {
+        match self {
+            Self::Custom(msg) => rendered.contains(msg),
+            Self::UnexpectedToken => rendered.contains("unexpected"),
+            Self::UnexpectedEof => rendered.contains("EOF") || rendered.contains("end"),
+            Self::UnclosedDelimiter => {
+                rendered.contains("unclosed") || rendered.contains("missing")
+            }
+            Self::MismatchedDelimiter => {
+                rendered.contains("expected") || rendered.contains("found")
+            }
+        }
+    }
+}
+
+impl From<&str> for ErrorPattern {
+    fn from(s: &str) -> Self {
+        Self::Custom(s.to_string())
+    }
+}
+
+#[derive(Debug, Copy, Clone)]
+enum DelimiterErrorType {
+    Mismatch,
+    Unclosed,
+}
+
+/// Assert that the parser produced exactly one error matching the expected
+/// pattern and span.
+///
+/// # Examples
+///
+/// ```
+/// use chumsky::error::Simple;
+/// use ddlint::SyntaxKind;
+/// use test_util::assert_parse_error;
+///
+/// let err: Simple<SyntaxKind> = Simple::custom(0..1, "oops");
+/// assert_parse_error(&[err], "oops", 0, 1);
+/// ```
+///
+/// # Panics
+/// Panics if `errors` is empty or the message or span do not match.
+#[track_caller]
+pub fn assert_parse_error(
+    errors: &[Simple<SyntaxKind>],
+    expected_pattern: impl Into<ErrorPattern>,
+    start: usize,
+    end: usize,
+) {
+    let pattern: ErrorPattern = expected_pattern.into();
+    assert_eq!(errors.len(), 1, "expected one error, got {errors:?}");
+    let error = errors.first().expect("error missing");
+    let rendered = format!("{error:?}");
+    assert!(
+        pattern.contains_message(&rendered),
+        "expected error to contain pattern '{pattern:?}', got '{rendered}'",
+    );
+    assert_eq!(error.span(), start..end);
+}
+
+#[track_caller]
+fn assert_delimiter_error_impl(
+    errors: &[Simple<SyntaxKind>],
+    expected_pattern: &ErrorPattern,
+    span: Range<usize>,
+    error_type: DelimiterErrorType,
+) {
+    use chumsky::error::SimpleReason;
+
+    let error = errors.first().expect("error missing");
+    let rendered = format!("{error:?}");
+    assert!(
+        expected_pattern.contains_message(&rendered),
+        "expected error to contain pattern '{expected_pattern:?}', got '{rendered}'",
+    );
+    assert_eq!(error.span(), span);
+    assert!(
+        matches!(
+            error.reason(),
+            SimpleReason::Unexpected | SimpleReason::Custom(_)
+        ),
+        "expected {:?}, got {:?}",
+        error_type,
+        error.reason()
+    );
+}
+
+/// Assert that a parser error indicates a delimiter mismatch.
+///
+/// # Panics
+/// Panics if `errors` is empty or the error kind does not indicate a mismatch.
+#[track_caller]
+pub fn assert_delimiter_error(
+    errors: &[Simple<SyntaxKind>],
+    expected_pattern: impl Into<ErrorPattern>,
+    start: usize,
+    end: usize,
+) {
+    let pattern: ErrorPattern = expected_pattern.into();
+    assert_delimiter_error_impl(errors, &pattern, start..end, DelimiterErrorType::Mismatch);
+}
+
+/// Assert that a parser error indicates an unclosed delimiter.
+///
+/// # Panics
+/// Panics if `errors` is empty or the error kind does not indicate an unclosed
+/// delimiter.
+#[track_caller]
+pub fn assert_unclosed_delimiter_error(
+    errors: &[Simple<SyntaxKind>],
+    expected_pattern: impl Into<ErrorPattern>,
+    start: usize,
+    end: usize,
+) {
+    let pattern: ErrorPattern = expected_pattern.into();
+    assert_delimiter_error_impl(errors, &pattern, start..end, DelimiterErrorType::Unclosed);
+}


### PR DESCRIPTION
## Summary
- add `parse_program` and `assert_program_round_trip` helpers
- refactor parser tests to reuse shared utilities
- clean up round-trip tests to ensure consistent assertions

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a99a358c6083229596f7272fc6a406

## Summary by Sourcery

Introduce common parser test helpers and refactor parser tests to use them for consistent round-trip and error assertions

New Features:
- Add parse_program helper to parse input and assert no errors
- Add assert_program_round_trip helper to verify pretty-print round-trip fidelity
- Add assert_parse_has_errors helper to assert parsing produces errors

Enhancements:
- Refactor parser and round-trip tests to replace bespoke parsing, printing, and assertion logic with shared utilities
- Remove duplicated pretty-print and whitespace normalization code in tests

Tests:
- Update existing parser and round-trip test suites to leverage new helpers for concise and consistent assertions