### PR TITLE
Add error tests for malformed slices and tuple indices

### DIFF
--- a/src/parser/tests/expression.rs
+++ b/src/parser/tests/expression.rs
@@ -75,6 +75,10 @@ fn parses_literals(#[case] src: &str, #[case] expected: Expr) {
 #[case("x ;", 1)]
 #[case("x =>", 1)]
 #[case("", 1)]
+#[case("e[1 0]", 1)]
+#[case("e[1,0", 1)]
+#[case("t.", 1)]
+#[case("t.-1", 1)]
 fn reports_errors(#[case] src: &str, #[case] min_errs: usize) {
     match parse_expression(src) {
         Ok(_) => panic!("expected parse error"),


### PR DESCRIPTION
## Summary
- test malformed bit slice syntax
- test invalid tuple index expressions

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68bb2c050d648322976bda276f7f8aa6