### PR TITLE
Clarify tokenize APIs with explicit names

### DIFF
--- a/docs/ddlint-design-and-road-map.md
+++ b/docs/ddlint-design-and-road-map.md
@@ -192,7 +192,7 @@ sequenceDiagram
     participant SyntaxTree
 
     User->>Parser: parse(source)
-    Parser->>Tokenizer: tokenize(source)
+    Parser->>Tokenizer: tokenize_with_trivia(source)
     Tokenizer-->>Parser: tokens
     Parser->>Parser: build token stream
     Parser->>SyntaxTree: construct green tree from tokens
@@ -411,7 +411,7 @@ lives right next to the code it describes and is never out of sync.
 An example of how a developer would define a new rule using this macro is as
 follows:
 
-````rust
+```rust
 declare_lint! {
     /// ## What it does
     /// Checks for relations that are declared but are never used as input to another rule.
@@ -441,7 +441,7 @@ declare_lint! {
     group: "correctness",
     // The default severity will also be specified here, e.g., level: "warn"
 }
-````
+```
 
 This macro dramatically lowers the barrier to entry for contributing new rules.
 It allows developers to focus on the interesting part—the analysis logic—rather

--- a/docs/parser-plan.md
+++ b/docs/parser-plan.md
@@ -45,7 +45,7 @@ sequenceDiagram
     participant Tokenizer
     participant LogosLexer
     participant SyntaxKind
-    Client->>Tokenizer: tokenize(src: &str)
+    Client->>Tokenizer: tokenize_with_trivia(src: &str)
     Tokenizer->>LogosLexer: Token::lexer(src)
     loop for each token
         LogosLexer-->>Tokenizer: next() -> Token + span

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,4 +17,4 @@ pub mod test_util;
 pub use language::{DdlogLanguage, SyntaxKind};
 pub use parser::{Parsed, ast, parse};
 pub use syntax_utils::parse_parenthesized_list;
-pub use tokenizer::{Span, tokenize, tokenize_no_trivia};
+pub use tokenizer::{Span, tokenize_with_trivia, tokenize_without_trivia};

--- a/src/parser/ast/parse_utils/relation.rs
+++ b/src/parser/ast/parse_utils/relation.rs
@@ -17,7 +17,7 @@ use crate::{Span, SyntaxKind};
 /// ```rust,ignore
 /// use chumsky::Parser as _;
 /// let src = "User(id: u32)";
-/// let tokens = crate::tokenize(src);
+/// let tokens = crate::tokenize_with_trivia(src);
 /// let stream = chumsky::Stream::from_iter(0..src.len(), tokens.into_iter());
 /// assert!(relation_columns().parse(stream).is_ok());
 /// ```
@@ -25,7 +25,7 @@ use crate::{Span, SyntaxKind};
 /// ```rust,ignore
 /// use chumsky::Parser as _;
 /// let src = "User"; // Missing column list
-/// let tokens = crate::tokenize(src);
+/// let tokens = crate::tokenize_with_trivia(src);
 /// let stream = chumsky::Stream::from_iter(0..src.len(), tokens.into_iter());
 /// assert!(relation_columns().parse(stream).is_err());
 /// ```
@@ -65,7 +65,7 @@ fn keyword<'a>(
 /// ```rust,ignore
 /// use chumsky::Parser as _;
 /// let src = "primary key(id, other)";
-/// let tokens = crate::tokenize(src);
+/// let tokens = crate::tokenize_with_trivia(src);
 /// let stream = chumsky::Stream::from_iter(0..src.len(), tokens.into_iter());
 /// let keys = primary_key_clause(src)
 ///     .parse(stream)
@@ -76,7 +76,7 @@ fn keyword<'a>(
 /// ```rust,ignore
 /// use chumsky::Parser as _;
 /// let src = "primary key"; // Missing column list
-/// let tokens = crate::tokenize(src);
+/// let tokens = crate::tokenize_with_trivia(src);
 /// let stream = chumsky::Stream::from_iter(0..src.len(), tokens.into_iter());
 /// assert!(primary_key_clause(src).parse(stream).is_err());
 /// ```

--- a/src/parser/ast/relation.rs
+++ b/src/parser/ast/relation.rs
@@ -89,7 +89,7 @@ impl Relation {
     #[must_use]
     pub fn primary_key(&self) -> Option<Vec<String>> {
         use super::parse_utils::primary_key_clause;
-        use crate::tokenize;
+        use crate::tokenize_with_trivia;
         use chumsky::Parser as _;
 
         let mut iter = self.syntax.children_with_tokens().peekable();
@@ -104,7 +104,7 @@ impl Relation {
         if rest.is_empty() {
             return None;
         }
-        let tokens = tokenize(&rest);
+        let tokens = tokenize_with_trivia(&rest);
         let stream = chumsky::Stream::from_iter(0..rest.len(), tokens.into_iter());
         let parser = primary_key_clause(&rest);
         let (res, errs) = parser.parse_recovery(stream);

--- a/src/parser/cst_builder/tree.rs
+++ b/src/parser/cst_builder/tree.rs
@@ -82,11 +82,11 @@ impl<'a> SpanCursors<'a> {
 /// # Examples
 ///
 /// ```
-/// use ddlint::tokenize;
+/// use ddlint::tokenize_with_trivia;
 /// use ddlint::parser::{cst_builder::{build_green_tree, ParsedSpans}, span_scanner::parse_tokens, ast::Root};
 ///
 /// let src = "import foo::bar;";
-/// let tokens = tokenize(src);
+/// let tokens = tokenize_with_trivia(src);
 /// let (spans, errors) = parse_tokens(&tokens, src);
 /// assert!(errors.is_empty());
 /// let green = build_green_tree(&tokens, src, &spans);
@@ -146,12 +146,12 @@ fn push_error_wrapped(builder: &mut GreenNodeBuilder, raw: rowan::SyntaxKind, te
 mod tests {
     use super::*;
     use crate::parser::span_scanner::parse_tokens;
-    use crate::tokenize;
+    use crate::tokenize_with_trivia;
 
     #[test]
     fn build_green_tree_round_trip() {
         let src = "import foo::bar;";
-        let tokens = tokenize(src);
+        let tokens = tokenize_with_trivia(src);
         let (spans, errors) = parse_tokens(&tokens, src);
         assert!(errors.is_empty());
         let green = build_green_tree(&tokens, src, &spans);

--- a/src/parser/expression/pratt.rs
+++ b/src/parser/expression/pratt.rs
@@ -7,7 +7,7 @@
 use chumsky::error::Simple;
 
 use crate::parser::ast::Expr;
-use crate::{Span, SyntaxKind, tokenize_no_trivia};
+use crate::{Span, SyntaxKind, tokenize_without_trivia};
 
 use super::token_stream::TokenStream;
 
@@ -27,7 +27,7 @@ where
 /// Returns a vector of [`Simple`] errors when parsing fails.
 #[must_use = "discarding the Result will ignore parse errors"]
 pub fn parse_expression(src: &str) -> Result<Expr, Vec<Simple<SyntaxKind>>> {
-    let mut parser = Pratt::new(tokenize_no_trivia(src).into_iter(), src);
+    let mut parser = Pratt::new(tokenize_without_trivia(src).into_iter(), src);
     let expr = parser.parse_expr(0);
     if let Some(expr_val) = expr {
         for (kind, sp) in parser.ts.drain_unexpected_tokens() {

--- a/src/parser/lexer_helpers.rs
+++ b/src/parser/lexer_helpers.rs
@@ -62,7 +62,7 @@ pub(super) fn token_display(kind: SyntaxKind) -> &'static str {
 ///     st.stream.advance();
 /// }
 ///
-/// # let tokens = ddlint::tokenize("extern type Foo;");
+/// # let tokens = ddlint::tokenize_with_trivia("extern type Foo;");
 /// # let src = "extern type Foo;";
 /// let mut st = State { stream: TokenStream::new(&tokens, src) };
 /// token_dispatch!(st, {
@@ -203,7 +203,7 @@ pub(super) fn balanced_block_nonempty(
 mod tests {
     //! Unit tests for the lexer helper utilities.
     use super::*;
-    use crate::{Span, parser::token_stream::TokenStream, tokenize};
+    use crate::{Span, parser::token_stream::TokenStream, tokenize_with_trivia};
     use chumsky::Stream;
     use rstest::rstest;
 
@@ -240,7 +240,7 @@ mod tests {
         }
 
         let src = "()";
-        let tokens = tokenize(src);
+        let tokens = tokenize_with_trivia(src);
         let mut st = State {
             stream: TokenStream::new(&tokens, src),
             out: Vec::new(),
@@ -257,7 +257,7 @@ mod tests {
     #[test]
     fn inline_ws_consumes_ws_and_comments() {
         let src = " \t//c";
-        let tokens = tokenize(src);
+        let tokens = tokenize_with_trivia(src);
         let parser = inline_ws().repeated();
         let res = parser.parse(Stream::from_iter(0..src.len(), tokens.into_iter()));
         assert!(res.is_ok());
@@ -266,7 +266,7 @@ mod tests {
     #[test]
     fn ident_parses_with_padding() {
         let src = "  foo  ";
-        let tokens = tokenize(src);
+        let tokens = tokenize_with_trivia(src);
         let res = ident().parse(Stream::from_iter(0..src.len(), tokens.into_iter()));
         assert!(res.is_ok());
     }
@@ -274,7 +274,7 @@ mod tests {
     #[test]
     fn atom_accepts_optional_args() {
         let src = "foo(bar)";
-        let tokens = tokenize(src);
+        let tokens = tokenize_with_trivia(src);
         let parser = atom();
         let res = parser.parse(Stream::from_iter(0..src.len(), tokens.into_iter()));
         assert!(res.is_ok());
@@ -283,7 +283,7 @@ mod tests {
     #[test]
     fn balanced_block_parses_nested() {
         let src = "(a(b)c)";
-        let tokens = tokenize(src);
+        let tokens = tokenize_with_trivia(src);
         let parser = balanced_block(SyntaxKind::T_LPAREN, SyntaxKind::T_RPAREN);
         let res = parser.parse(Stream::from_iter(0..src.len(), tokens.into_iter()));
         assert!(res.is_ok());
@@ -292,7 +292,7 @@ mod tests {
     #[test]
     fn balanced_block_nonempty_fails_on_empty() {
         let src = "()";
-        let tokens = tokenize(src);
+        let tokens = tokenize_with_trivia(src);
         let parser = balanced_block_nonempty(SyntaxKind::T_LPAREN, SyntaxKind::T_RPAREN);
         let res = parser.parse(Stream::from_iter(0..src.len(), tokens.into_iter()));
         assert!(res.is_err());

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -6,7 +6,7 @@
 //! and rules. It lays down the framework for integrating `chumsky` combinators
 //! and error recovery in later stages.
 
-use crate::tokenize;
+use crate::tokenize_with_trivia;
 
 #[macro_use]
 mod lexer_helpers;
@@ -25,7 +25,7 @@ pub use cst_builder::{Parsed, ParsedSpans};
 
 /// Parse the provided source string.
 ///
-/// The function tokenises the source using [`tokenize`], then uses a minimal
+/// The function tokenises the source using [`tokenize_with_trivia`], then uses a minimal
 /// `chumsky` parser to wrap those tokens into a CST. Syntactic error recovery
 /// will insert `N_ERROR` nodes when grammar rules fail once they exist.
 ///
@@ -39,7 +39,7 @@ pub use cst_builder::{Parsed, ParsedSpans};
 /// ```
 #[must_use]
 pub fn parse(src: &str) -> Parsed {
-    let tokens = tokenize(src);
+    let tokens = tokenize_with_trivia(src);
     let (spans, errors) = parse_tokens(&tokens, src);
 
     let green = build_green_tree(&tokens, src, &spans);
@@ -67,7 +67,7 @@ mod tests {
     mod transformers;
     mod types;
     use super::token_stream::TokenStream;
-    use crate::{SyntaxKind, tokenize};
+    use crate::{SyntaxKind, tokenize_with_trivia};
     use rstest::rstest;
 
     /// Tests that `skip_until` advances the token stream cursor past the specified span end.
@@ -76,7 +76,7 @@ mod tests {
     ///
     /// ```no_run
     /// let src = "import foo\n";
-    /// let tokens = tokenize(src);
+    /// let tokens = tokenize_with_trivia(src);
     /// let mut stream = TokenStream::new(&tokens, src);
     /// let end = stream.line_end(0);
     /// stream.skip_until(end);
@@ -85,7 +85,7 @@ mod tests {
     #[rstest]
     fn skip_until_advances_past_span() {
         let src = "import foo\n";
-        let tokens = tokenize(src);
+        let tokens = tokenize_with_trivia(src);
         let mut stream = TokenStream::new(&tokens, src);
         let end = stream.line_end(0);
         stream.skip_until(end);
@@ -98,7 +98,7 @@ mod tests {
     ///
     /// ```no_run
     /// let src = "typedef A = string\nnext";
-    /// let tokens = tokenize(src);
+    /// let tokens = tokenize_with_trivia(src);
     /// let stream = TokenStream::new(&tokens, src);
     /// let start = 1; // token after 'typedef'
     /// let end = stream.line_end(start);
@@ -108,7 +108,7 @@ mod tests {
     #[rstest]
     fn line_end_returns_span_end() {
         let src = "typedef A = string\nnext";
-        let tokens = tokenize(src);
+        let tokens = tokenize_with_trivia(src);
         let stream = TokenStream::new(&tokens, src);
         let start = 1; // token after 'typedef'
         let end = stream.line_end(start);
@@ -122,7 +122,7 @@ mod tests {
     ///
     /// ```no_run
     /// let src = "extern    type Foo";
-    /// let tokens = tokenize(src);
+    /// let tokens = tokenize_with_trivia(src);
     /// let mut stream = TokenStream::new(&tokens, src);
     /// stream.advance();
     /// stream.skip_ws_inline();
@@ -134,7 +134,7 @@ mod tests {
     #[rstest]
     fn skip_ws_inline_skips_spaces() {
         let src = "extern    type Foo";
-        let tokens = tokenize(src);
+        let tokens = tokenize_with_trivia(src);
         let mut stream = TokenStream::new(&tokens, src);
         stream.advance();
         stream.skip_ws_inline();
@@ -150,7 +150,7 @@ mod tests {
     ///
     /// ```no_run
     /// let src = "typedef A = string\n";
-    /// let tokens = tokenize(src);
+    /// let tokens = tokenize_with_trivia(src);
     /// let stream = TokenStream::new(&tokens, src);
     /// let start = tokens.len();
     /// assert_eq!(stream.line_end(start), src.len());
@@ -158,7 +158,7 @@ mod tests {
     #[rstest]
     fn line_end_out_of_bounds_returns_len() {
         let src = "typedef A = string\n";
-        let tokens = tokenize(src);
+        let tokens = tokenize_with_trivia(src);
         let stream = TokenStream::new(&tokens, src);
         let start = tokens.len();
         assert_eq!(stream.line_end(start), src.len());

--- a/src/parser/span_collector.rs
+++ b/src/parser/span_collector.rs
@@ -102,7 +102,7 @@ mod tests {
     #[rstest]
     fn new_initialises_state() {
         let src = "import foo";
-        let tokens = crate::tokenize(src);
+        let tokens = crate::tokenize_with_trivia(src);
         let collector = SpanCollector::new(&tokens, src, ());
         assert_eq!(collector.stream.cursor(), 0);
         assert_eq!(collector.stream.tokens(), tokens.as_slice());
@@ -113,7 +113,7 @@ mod tests {
     #[test]
     fn into_parts_returns_collected_spans_and_extra() {
         let src = "input";
-        let tokens = crate::tokenize(src);
+        let tokens = crate::tokenize_with_trivia(src);
         let mut collector = SpanCollector::new(&tokens, src, 99u8);
         collector.spans.push(0..5);
         let (spans, extra) = collector.into_parts();

--- a/src/parser/span_scanner.rs
+++ b/src/parser/span_scanner.rs
@@ -68,7 +68,7 @@ pub(super) fn parse_tokens(
 /// use crate::parser::span_collector::SpanCollector;
 ///
 /// let src = "import foo\n";
-/// let tokens = crate::tokenize(src);
+/// let tokens = crate::tokenize_with_trivia(src);
 /// let mut st = SpanCollector::new(&tokens, src, Vec::new());
 /// let ident = just(SyntaxKind::T_IDENT).map_with_span(|_, sp: Span| sp);
 /// let (span, errs) = parse_and_record(&mut st, 0, ident);
@@ -222,7 +222,7 @@ fn collect_typedef_spans(tokens: &[(SyntaxKind, Span)], src: &str) -> Vec<Span> 
 /// ```rust,ignore
 /// use chumsky::Parser as _;
 /// let src = "User(id: u32)";
-/// let tokens = crate::tokenize(src);
+/// let tokens = crate::tokenize_with_trivia(src);
 /// let stream = chumsky::Stream::from_iter(0..src.len(), tokens.into_iter());
 /// assert!(relation_columns().parse(stream).is_ok());
 /// ```
@@ -594,7 +594,7 @@ fn collect_rule_spans(
 mod tests {
     //! Tests for the span scanner helper utilities.
     use super::*;
-    use crate::tokenize;
+    use crate::tokenize_with_trivia;
     use rstest::rstest;
 
     #[rstest]
@@ -605,7 +605,7 @@ mod tests {
         #[case] expected: Vec<Span>,
         #[case] errs_empty: bool,
     ) {
-        let tokens = tokenize(src);
+        let tokens = tokenize_with_trivia(src);
         let (spans, errs) = collect_import_spans(&tokens, src);
         assert_eq!(spans, expected);
         assert_eq!(errs.is_empty(), errs_empty);

--- a/src/parser/token_stream.rs
+++ b/src/parser/token_stream.rs
@@ -4,11 +4,11 @@
 //! navigation during parsing.
 //!
 //! ```
-//! use ddlint::{tokenize, SyntaxKind};
+//! use ddlint::{tokenize_with_trivia, SyntaxKind};
 //! use ddlint::parser::token_stream::TokenStream;
 //!
 //! let src = "typedef A = string\n";
-//! let tokens = tokenize(src);
+//! let tokens = tokenize_with_trivia(src);
 //! let mut stream = TokenStream::new(&tokens, src);
 //! let end = stream.line_end(0);
 //! stream.skip_until(end);

--- a/src/syntax_utils.rs
+++ b/src/syntax_utils.rs
@@ -15,10 +15,10 @@ use rowan::SyntaxElement;
 ///
 /// ```
 /// use ddlint::syntax_utils::parse_parenthesized_list;
-/// use ddlint::tokenize;
+/// use ddlint::tokenize_with_trivia;
 ///
 /// let src = "foo(bar, baz)";
-/// let tokens = tokenize(src);
+/// let tokens = tokenize_with_trivia(src);
 /// let result = parse_parenthesized_list(tokens.into_iter());
 /// assert_eq!(result, vec!["bar".into(), "baz".into()]);
 /// ```

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -1,6 +1,7 @@
 //! Lexical analysis for `DDlog` source.
 //!
-//! This module exposes a `tokenize` function which converts raw source text into
+//! This module exposes `tokenize_with_trivia` and `tokenize_without_trivia`
+//! functions which convert raw source text into
 //! a sequence of `(SyntaxKind, Span)` pairs. It uses the `logos` crate to
 //! recognise tokens so that the CST can mirror the input exactly.
 
@@ -260,8 +261,17 @@ fn tokenize_impl(src: &str) -> Vec<(SyntaxKind, Span)> {
 /// Tokenise the source, excluding whitespace and comments.
 ///
 /// Returns only significant tokens for use in expression parsing.
+///
+/// # Examples
+///
+/// ```rust
+/// use ddlint::{tokenize_without_trivia, SyntaxKind};
+///
+/// let tokens = tokenize_without_trivia("input R(x: u32);");
+/// assert!(!tokens.iter().any(|(k, _)| *k == SyntaxKind::T_WHITESPACE));
+/// ```
 #[must_use]
-pub fn tokenize_no_trivia(src: &str) -> Vec<(SyntaxKind, Span)> {
+pub fn tokenize_without_trivia(src: &str) -> Vec<(SyntaxKind, Span)> {
     tokenize_impl(src)
         .into_iter()
         .filter(|(k, _)| !matches!(k, SyntaxKind::T_WHITESPACE | SyntaxKind::T_COMMENT))
@@ -273,15 +283,15 @@ pub fn tokenize_no_trivia(src: &str) -> Vec<(SyntaxKind, Span)> {
 /// # Examples
 ///
 /// ```rust,no_run
-/// use ddlint::{tokenize, SyntaxKind};
+/// use ddlint::{tokenize_with_trivia, SyntaxKind};
 ///
-/// let tokens = tokenize("input relation R(x: u32);");
+/// let tokens = tokenize_with_trivia("input relation R(x: u32);");
 /// assert_eq!(tokens.len(), 12);
 /// assert_eq!(tokens[0].0, SyntaxKind::K_INPUT);
 /// ```
 ///
 /// This variant retains whitespace and comment tokens.
 #[must_use]
-pub fn tokenize(src: &str) -> Vec<(SyntaxKind, Span)> {
+pub fn tokenize_with_trivia(src: &str) -> Vec<(SyntaxKind, Span)> {
     tokenize_impl(src)
 }


### PR DESCRIPTION
## Summary
- rename tokenize/tokenize_no_trivia to tokenize_with_trivia/tokenize_without_trivia
- update parser, docs and tests to use clearer names

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make markdownlint`
- `make nixie`


------
https://chatgpt.com/codex/tasks/task_e_68bb2d27e40c8322839a0ae715610e84