### PR TITLE
Add chained call and access tests

### DIFF
--- a/src/parser/tests/expression.rs
+++ b/src/parser/tests/expression.rs
@@ -42,6 +42,20 @@ use rstest::rstest;
 #[case("(f)(x)", call_expr(Expr::Group(Box::new(var("f"))), vec![var("x")]))]
 #[case("foo.bar(x)", method_call(var("foo"), "bar", vec![var("x")]))]
 #[case("foo.bar", field_access(var("foo"), "bar"))]
+#[case("foo.bar().baz(x)", method_call(
+    method_call(var("foo"), "bar", vec![]),
+    "baz",
+    vec![var("x")]
+))]
+#[case("foo.bar.baz", field_access(field_access(var("foo"), "bar"), "baz"))]
+#[case("foo.bar().baz.qux(x)", method_call(
+    field_access(
+        method_call(var("foo"), "bar", vec![]),
+        "baz"
+    ),
+    "qux",
+    vec![var("x")]
+))]
 #[case("e[1,0]", bit_slice(var("e"), lit_num("1"), lit_num("0")))]
 #[case("t.0", tuple_index(var("t"), "0"))]
 #[case("x: T", Expr::Binary { op: BinaryOp::Ascribe, lhs: Box::new(var("x")), rhs: Box::new(var("T")) })]


### PR DESCRIPTION
## Summary
- test chained method calls to ensure left-associative parsing
- test chained field accesses and mixed access/call chains

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68bb2ca31d048322908df228747629fd