### PR TITLE
Refine precedence for type and control operators

### DIFF
--- a/docs/pratt-parser-for-ddlog-expressions.md
+++ b/docs/pratt-parser-for-ddlog-expressions.md
@@ -359,6 +359,10 @@ Operator precedence is centralised in `src/parser/ast/precedence.rs`. Both the
 Pratt parser and any future grammar extensions reference this table, ensuring
 consistent binding power definitions across the codebase.
 
+The precedence for type and control operators is, from highest to lowest: `:`
+and `as`, `=`, `=>`, `;`. Ascription and cast bind more tightly than assignment
+but looser than arithmetic operators.
+
 Variable references are parsed by interpreting identifier tokens as
 `Expr::Variable`. Postfix operators such as calls, field access, method
 invocations, bit slices, and tuple indexing are handled in a loop at the

--- a/src/parser/ast/precedence.rs
+++ b/src/parser/ast/precedence.rs
@@ -25,73 +25,77 @@ const PREFIX_TABLE: &[(SyntaxKind, PrefixEntry)] = &[
     (
         SyntaxKind::T_MINUS,
         PrefixEntry {
-            bp: 60,
+            bp: 80,
             op: UnaryOp::Neg,
         },
     ),
     (
         SyntaxKind::K_NOT,
         PrefixEntry {
-            bp: 60,
+            bp: 80,
             op: UnaryOp::Not,
         },
     ),
 ];
 
 const INFIX_TABLE: &[(SyntaxKind, InfixEntry)] = &[
+    // Operator precedence rationale:
+    // Ascribe (:) and Cast (as) should bind tighter than Assign (=), but looser than arithmetic.
+    // Assign (=) should be lower than Ascribe/Cast, but higher than Seq (;).
+    // Seq (;) should be lowest, and Imply (=>) should be just above Seq.
     (
         SyntaxKind::T_COLON,
         InfixEntry {
-            l_bp: 60,
-            r_bp: 61,
+            l_bp: 50, // Ascribe binds tighter than assign, looser than arithmetic
+            r_bp: 51,
             op: BinaryOp::Ascribe,
         },
     ),
     (
         SyntaxKind::K_AS,
         InfixEntry {
-            l_bp: 60,
-            r_bp: 61,
+            l_bp: 50, // Cast matches Ascribe
+            r_bp: 51,
             op: BinaryOp::Cast,
         },
     ),
     (
         SyntaxKind::T_STAR,
         InfixEntry {
-            l_bp: 50,
-            r_bp: 51,
+            l_bp: 70,
+            r_bp: 71,
             op: BinaryOp::Mul,
         },
     ),
     (
         SyntaxKind::T_SLASH,
         InfixEntry {
-            l_bp: 50,
-            r_bp: 51,
+            l_bp: 70,
+            r_bp: 71,
             op: BinaryOp::Div,
         },
     ),
     (
         SyntaxKind::T_PERCENT,
         InfixEntry {
-            l_bp: 50,
-            r_bp: 51,
+            l_bp: 70,
+            r_bp: 71,
             op: BinaryOp::Mod,
         },
     ),
     (
         SyntaxKind::T_PLUS,
         InfixEntry {
-            l_bp: 40,
-            r_bp: 41,
+            l_bp: 60,
+            r_bp: 61,
             op: BinaryOp::Add,
         },
     ),
     (
         SyntaxKind::T_MINUS,
         InfixEntry {
-            l_bp: 40,
-            r_bp: 41,
+            l_bp: 60,
+            r_bp: 61,
             op: BinaryOp::Sub,
         },
     ),
@@ -122,8 +126,8 @@ const INFIX_TABLE: &[(SyntaxKind, InfixEntry)] = &[
     (
         SyntaxKind::T_FAT_ARROW,
         InfixEntry {
-            l_bp: 8,
-            r_bp: 9,
+            l_bp: 5, // Imply is above Seq, below Assign
+            r_bp: 4,
             op: BinaryOp::Imply,
         },
     ),
@@ -138,15 +142,15 @@ const INFIX_TABLE: &[(SyntaxKind, InfixEntry)] = &[
     (
         SyntaxKind::T_EQ,
         InfixEntry {
-            l_bp: 5,
-            r_bp: 4,
+            l_bp: 30, // Assign is lower than Ascribe/Cast
+            r_bp: 29,
             op: BinaryOp::Assign,
         },
     ),
     (
         SyntaxKind::T_SEMI,
         InfixEntry {
-            l_bp: 0,
+            l_bp: 0, // Seq is lowest
             r_bp: 1,
             op: BinaryOp::Seq,
         },

--- a/src/parser/expression/infix.rs
+++ b/src/parser/expression/infix.rs
@@ -21,7 +21,7 @@ where
                 unreachable!("peeked operator");
             };
             let rhs = match op_kind {
-                SyntaxKind::T_COLON | SyntaxKind::K_AS => self.parse_type(),
+                SyntaxKind::T_COLON | SyntaxKind::K_AS => self.parse_type(r_bp),
                 _ => self.parse_expr(r_bp),
             };
             let Some(rhs) = rhs else {

--- a/src/parser/expression/pratt.rs
+++ b/src/parser/expression/pratt.rs
@@ -170,7 +170,7 @@ where
         }
         Some(args)
     }
-    pub(super) fn parse_type(&mut self) -> Option<Expr> {
-        self.parse_expr(0)
+    pub(super) fn parse_type(&mut self, min_bp: u8) -> Option<Expr> {
+        self.parse_expr(min_bp)
     }
 }

--- a/src/parser/tests/expression.rs
+++ b/src/parser/tests/expression.rs
@@ -50,6 +50,10 @@ use rstest::rstest;
 #[case("a = b; c", Expr::Binary { op: BinaryOp::Seq, lhs: Box::new(Expr::Binary { op: BinaryOp::Assign, lhs: Box::new(var("a")), rhs: Box::new(var("b")) }), rhs: Box::new(var("c")) })]
 #[case("a and b => c or d", Expr::Binary { op: BinaryOp::Imply, lhs: Box::new(Expr::Binary { op: BinaryOp::And, lhs: Box::new(var("a")), rhs: Box::new(var("b")) }), rhs: Box::new(Expr::Binary { op: BinaryOp::Or, lhs: Box::new(var("c")), rhs: Box::new(var("d")) }) })]
 #[case("a or b and c", Expr::Binary { op: BinaryOp::Or, lhs: Box::new(var("a")), rhs: Box::new(Expr::Binary { op: BinaryOp::And, lhs: Box::new(var("b")), rhs: Box::new(var("c")) }) })]
+#[case("a + b: T", Expr::Binary { op: BinaryOp::Ascribe, lhs: Box::new(Expr::Binary { op: BinaryOp::Add, lhs: Box::new(var("a")), rhs: Box::new(var("b")) }), rhs: Box::new(var("T")) })]
+#[case("x: T = y", Expr::Binary { op: BinaryOp::Assign, lhs: Box::new(Expr::Binary { op: BinaryOp::Ascribe, lhs: Box::new(var("x")), rhs: Box::new(var("T")) }), rhs: Box::new(var("y")) })]
+#[case("x as T = y", Expr::Binary { op: BinaryOp::Assign, lhs: Box::new(Expr::Binary { op: BinaryOp::Cast, lhs: Box::new(var("x")), rhs: Box::new(var("T")) }), rhs: Box::new(var("y")) })]
+#[case("a => b; c", Expr::Binary { op: BinaryOp::Seq, lhs: Box::new(Expr::Binary { op: BinaryOp::Imply, lhs: Box::new(var("a")), rhs: Box::new(var("b")) }), rhs: Box::new(var("c")) })]
 fn parses_expressions(#[case] src: &str, #[case] expected: Expr) {
     let expr = parse_expression(src).unwrap_or_else(|errs| panic!("errors: {errs:?}"));
     assert_eq!(expr, expected);


### PR DESCRIPTION
## Summary
- tune binding powers so ascribe/cast bind tighter than assign, with imply just above sequencing
- pass binding power through type parsing to avoid assignment leaking into casts
- exercise new precedence rules in expression parser tests

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make markdownlint`
- `make nixie`


------
https://chatgpt.com/codex/tasks/task_e_68bb2cd06dd4832298bf18638aa158eb