### PR TITLE
Refactor token normalisation mapping

### DIFF
--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -33,23 +33,27 @@ pub enum ErrorPattern {
     Custom(String),
 }
 
+const TOKEN_MAP: [(&str, &str); 13] = [
+    ("T_LPAREN", "left paren"),
+    ("T_RPAREN", "right paren"),
+    ("T_LBRACKET", "left bracket"),
+    ("T_RBRACKET", "right bracket"),
+    ("T_LBRACE", "left brace"),
+    ("T_RBRACE", "right brace"),
+    ("T_COMMA", "comma"),
+    ("T_SEMI", "semicolon"),
+    ("T_COLON", "colon"),
+    ("T_DOT", "dot"),
+    ("T_PIPE", "pipe"),
+    ("T_IDENT", "identifier"),
+    ("T_NUMBER", "number"),
+];
+
 /// Replace internal token names with human-readable forms.
 fn normalise_tokens(s: &str) -> String {
-    [
-        ("T_LPAREN", "left paren"),
-        ("T_RPAREN", "right paren"),
-        ("T_LBRACKET", "left bracket"),
-        ("T_RBRACKET", "right bracket"),
-        ("T_LBRACE", "left brace"),
-        ("T_RBRACE", "right brace"),
-        ("T_COMMA", "comma"),
-        ("T_SEMI", "semicolon"),
-        ("T_PIPE", "pipe"),
-        ("T_IDENT", "identifier"),
-        ("T_NUMBER", "number"),
-    ]
-    .into_iter()
-    .fold(s.to_string(), |acc, (raw, human)| acc.replace(raw, human))
+    TOKEN_MAP
+        .iter()
+        .fold(s.to_string(), |acc, &(raw, human)| acc.replace(raw, human))
 }
 
 impl ErrorPattern {


### PR DESCRIPTION
## Summary
- centralise token name replacements in a module constant and add dot and colon support
- reuse TOKEN_MAP in normalise_tokens for broader coverage

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68bf257386548322bdcbfba4760424ec

## Summary by Sourcery

Centralise token normalization mappings in a single constant and extend normalization to include colon and dot tokens.

Enhancements:
- Extract token name replacements into a shared TOKEN_MAP constant
- Update normalise_tokens to use TOKEN_MAP for all replacements
- Add support for colon and dot tokens in normalization