### PR TITLE
Handle struct literal lookahead in if parser

### DIFF
--- a/docs/documentation-style-guide.md
+++ b/docs/documentation-style-guide.md
@@ -71,7 +71,7 @@ contents of the manual.
   they do not execute during documentation tests.
 - Put function attributes after the doc comment.
 
-````rust
+```rust
 /// Returns the sum of `a` and `b`.
 ///
 /// # Parameters
@@ -90,7 +90,7 @@ contents of the manual.
 pub fn add(a: i32, b: i32) -> i32 {
     a + b
 }
-````
+```
 
 ## Diagrams and images
 

--- a/docs/pratt-parser-for-ddlog-expressions.md
+++ b/docs/pratt-parser-for-ddlog-expressions.md
@@ -287,12 +287,14 @@ token as evidence that the `then` branch was absent, producing a clear
 `expected expression for 'then' branch of 'if'` message.
 
 A subtle ambiguity arises from the shared `IDENT {` token sequence used by
-struct literals. When an `if` condition is followed immediately by a brace we
-treat the brace as the start of the `then` branch rather than a struct literal.
-This matches the intent of inputs such as `if flag { ... }` and avoids spurious
-`expected T_COLON` diagnostics. Developers can still use a struct literal as
-the condition by wrapping it in parentheses (`if (Point { x: 1 }) { ... }`),
-which disambiguates the syntax without complicating the Pratt parser.
+struct literals. To resolve this we activate a struct-literal guard for the
+duration of the condition parse. While active it interprets `IDENT {` as a
+variable followed by the branch, preventing the condition from consuming the
+branch braces. The guard automatically suspends inside parentheses, brace
+groups, and closure bodies so expressions such as `if (Point { x: 1 }) { ... }`
+or `if cond { Point { x: 1 } }` continue to parse as intended. This strategy
+eliminates spurious `expected T_COLON` diagnostics without restricting
+legitimate struct literal usage.
 
 ______________________________________________________________________
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -110,7 +110,7 @@ control flow. This phase aims to build a complete grammar.
 
 - [ ] **Implement Control-Flow Parsing**
 
-  - [ ] Implement a parser for `if`/`else` expressions (`e_ite`).
+  - [x] Implement a parser for `if`/`else` expressions (`e_ite`).
 
   - [ ] Implement a parser for `for` loops within rules, including optional
     `if` guards (`parseForStatement` from the Haskell analysis).

--- a/docs/rust-testing-with-rstest-fixtures.md
+++ b/docs/rust-testing-with-rstest-fixtures.md
@@ -1168,8 +1168,8 @@ and Parameterization**
 | Feature                                  | Standard #[test] Approach                                     | rstest Approach                                                                  |
 | ---------------------------------------- | ------------------------------------------------------------- | -------------------------------------------------------------------------------- |
 | Fixture Injection                        | Manual calls to setup functions within each test.             | Fixture name as argument in #[rstest] function; fixture defined with #[fixture]. |
-| Parameterized Tests (Specific Cases)     | Loop inside one test, or multiple distinct #[test] functions. | #[case(...)] attributes on #[rstest] function.                                   |
-| Parameterized Tests (Value Combinations) | Nested loops inside one test, or complex manual generation.   | #[values(...)] attributes on arguments of #[rstest] function.                    |
+| Parameterized Tests (Specific Cases)     | Loop inside one test, or multiple distinct #[test] functions. | #[case(…)] attributes on #[rstest] function.                                     |
+| Parameterized Tests (Value Combinations) | Nested loops inside one test, or complex manual generation.   | #[values(…)] attributes on arguments of #[rstest] function.                      |
 | Async Fixture Setup                      | Manual async block and .await calls inside test.              | async fn fixtures, with #[future] and #[awt] for ergonomic `.await`ing.          |
 | Reusing Parameter Sets                   | Manual duplication of cases or custom helper macros.          | rstest_reuse crate with #[template] and #[apply] attributes.                     |
 
@@ -1313,16 +1313,16 @@ provided by `rstest`:
 | ---------------------------- | -------------------------------------------------------------------------------------------- |
 | #[rstest]                    | Marks a function as an rstest test; enables fixture injection and parameterization.          |
 | #[fixture]                   | Defines a function that provides a test fixture (setup data or services).                    |
-| #[case(...)]                 | Defines a single parameterized test case with specific input values.                         |
-| #[values(...)]               | Defines a list of values for an argument, generating tests for each value or combination.    |
+| #[case(…)]                   | Defines a single parameterized test case with specific input values.                         |
+| #[values(…)]                 | Defines a list of values for an argument, generating tests for each value or combination.    |
 | #[once]                      | Marks a fixture to be initialized only once and shared (as a static reference) across tests. |
 | #[future]                    | Simplifies async argument types by removing impl Future boilerplate.                         |
 | #[awt]                       | (Function or argument level) Automatically .awaits future arguments in async tests.          |
 | #[from(original_name)]       | Allows renaming an injected fixture argument in the test function.                           |
-| #[with(...)]                 | Overrides default arguments of a fixture for a specific test.                                |
-| #[default(...)]              | Provides default values for arguments within a fixture function.                             |
-| #[timeout(...)]              | Sets a timeout for an asynchronous test.                                                     |
-| #[files("glob_pattern",...)] | Injects file paths (or contents, with mode=) matching a glob pattern as test arguments.      |
+| #[with(…)]                   | Overrides default arguments of a fixture for a specific test.                                |
+| #[default(…)]                | Provides default values for arguments within a fixture function.                             |
+| #[timeout(…)]                | Sets a timeout for an asynchronous test.                                                     |
+| #[files("glob_pattern",…)]   | Injects file paths (or contents, with mode=) matching a glob pattern as test arguments.      |
 
 By mastering `rstest`, Rust developers can significantly elevate the quality
 and efficiency of their testing practices, leading to more reliable and

--- a/src/parser/ast/expr.rs
+++ b/src/parser/ast/expr.rs
@@ -161,6 +161,15 @@ pub enum Expr {
         /// Body expression executed when invoked.
         body: Box<Expr>,
     },
+    /// If expression with an optional `else` branch.
+    IfElse {
+        /// Condition controlling the selected branch.
+        condition: Box<Expr>,
+        /// Expression evaluated when the condition is truthy.
+        then_branch: Box<Expr>,
+        /// Expression evaluated when the condition is falsy.
+        else_branch: Box<Expr>,
+    },
     /// Unary operation expression.
     Unary { op: UnaryOp, expr: Box<Expr> },
     /// Binary operation expression.
@@ -209,6 +218,18 @@ impl Expr {
             Self::Closure { params, body } => format_nary(
                 "closure",
                 [format!("({})", params.join(" ")), body.to_sexpr()],
+            ),
+            Self::IfElse {
+                condition,
+                then_branch,
+                else_branch,
+            } => format_nary(
+                "if",
+                [
+                    condition.to_sexpr(),
+                    then_branch.to_sexpr(),
+                    else_branch.to_sexpr(),
+                ],
             ),
             Self::Unary { op, expr } => format_nary(op.symbol(), std::iter::once(expr.to_sexpr())),
             Self::Binary { op, lhs, rhs } => {

--- a/src/parser/expression/prefix.rs
+++ b/src/parser/expression/prefix.rs
@@ -42,10 +42,7 @@ where
 
     fn parse_ident_expression(&mut self, name: String) -> Option<Expr> {
         if matches!(self.ts.peek_kind(), Some(SyntaxKind::T_LBRACE)) {
-            if !self
-                .struct_literal_guard
-                .should_parse_struct_literal(self.expr_depth)
-            {
+            if !self.struct_literal_guard.allows_struct_literal() {
                 return Some(Expr::Variable(name));
             }
             self.ts.next_tok();
@@ -55,8 +52,6 @@ where
             }
             Some(Expr::Struct { name, fields })
         } else {
-            self.struct_literal_guard
-                .consume_without_struct(self.expr_depth);
             Some(Expr::Variable(name))
         }
     }
@@ -66,30 +61,37 @@ where
             self.ts.next_tok();
             return Some(Expr::Tuple(Vec::new()));
         }
-        let first = self.parse_expr(0)?;
-        let mut items = vec![first];
-        let mut is_tuple = false;
-        while matches!(self.ts.peek_kind(), Some(SyntaxKind::T_COMMA)) {
-            is_tuple = true;
-            self.ts.next_tok();
-            if matches!(self.ts.peek_kind(), Some(SyntaxKind::T_RPAREN)) {
-                break;
+        let suspended = self.struct_literal_guard.suspend();
+        let result = (|| {
+            let first = self.parse_expr(0)?;
+            let mut items = vec![first];
+            let mut is_tuple = false;
+            while matches!(self.ts.peek_kind(), Some(SyntaxKind::T_COMMA)) {
+                is_tuple = true;
+                self.ts.next_tok();
+                if matches!(self.ts.peek_kind(), Some(SyntaxKind::T_RPAREN)) {
+                    break;
+                }
+                items.push(self.parse_expr(0)?);
             }
-            items.push(self.parse_expr(0)?);
+            if !self.ts.expect(SyntaxKind::T_RPAREN) {
+                return None;
+            }
+            if is_tuple {
+                Some(Expr::Tuple(items))
+            } else {
+                #[expect(
+                    clippy::expect_used,
+                    reason = "parser invariant: group contains exactly one item"
+                )]
+                let item = items.pop().expect("expected one item in group");
+                Some(Expr::Group(Box::new(item)))
+            }
+        })();
+        if suspended {
+            self.struct_literal_guard.resume();
         }
-        if !self.ts.expect(SyntaxKind::T_RPAREN) {
-            return None;
-        }
-        if is_tuple {
-            Some(Expr::Tuple(items))
-        } else {
-            #[expect(
-                clippy::expect_used,
-                reason = "parser invariant: group contains exactly one item"
-            )]
-            let item = items.pop().expect("expected one item in group");
-            Some(Expr::Group(Box::new(item)))
-        }
+        result
     }
 
     fn parse_brace_group(&mut self) -> Option<Expr> {
@@ -99,11 +101,18 @@ where
             self.ts.push_error(sp, "expected expression");
             return None;
         }
-        let inner = self.parse_expr(0)?;
-        if !self.ts.expect(SyntaxKind::T_RBRACE) {
-            return None;
+        let suspended = self.struct_literal_guard.suspend();
+        let result = (|| {
+            let inner = self.parse_expr(0)?;
+            if !self.ts.expect(SyntaxKind::T_RBRACE) {
+                return None;
+            }
+            Some(Expr::Group(Box::new(inner)))
+        })();
+        if suspended {
+            self.struct_literal_guard.resume();
         }
-        Some(Expr::Group(Box::new(inner)))
+        result
     }
 
     fn parse_closure_literal(&mut self) -> Option<Expr> {
@@ -111,7 +120,12 @@ where
         if !self.ts.expect(SyntaxKind::T_PIPE) {
             return None;
         }
-        let body = self.parse_expr(0)?;
+        let suspended = self.struct_literal_guard.suspend();
+        let result = self.parse_expr(0);
+        if suspended {
+            self.struct_literal_guard.resume();
+        }
+        let body = result?;
         Some(Expr::Closure {
             params,
             body: Box::new(body),
@@ -142,10 +156,9 @@ where
     }
 
     fn parse_if_condition(&mut self) -> Option<Expr> {
-        self.struct_literal_guard
-            .disallow_at_depth(self.expr_depth + 1);
+        self.struct_literal_guard.activate();
         let result = self.parse_if_clause("expected condition expression after 'if'", None);
-        self.struct_literal_guard.reset();
+        self.struct_literal_guard.deactivate();
         result
     }
 

--- a/src/parser/expression/prefix.rs
+++ b/src/parser/expression/prefix.rs
@@ -19,6 +19,7 @@ where
             SyntaxKind::T_LPAREN => self.parse_parenthesized_expr(),
             SyntaxKind::T_PIPE => self.parse_closure_literal(),
             SyntaxKind::T_LBRACE => self.parse_brace_group(),
+            SyntaxKind::K_IF => self.parse_if_expression(),
             k => {
                 let Some((bp, op)) = prefix_binding_power(k) else {
                     self.ts
@@ -41,6 +42,12 @@ where
 
     fn parse_ident_expression(&mut self, name: String) -> Option<Expr> {
         if matches!(self.ts.peek_kind(), Some(SyntaxKind::T_LBRACE)) {
+            if !self
+                .struct_literal_guard
+                .should_parse_struct_literal(self.expr_depth)
+            {
+                return Some(Expr::Variable(name));
+            }
             self.ts.next_tok();
             let fields = self.parse_struct_fields()?;
             if !self.ts.expect(SyntaxKind::T_RBRACE) {
@@ -48,6 +55,8 @@ where
             }
             Some(Expr::Struct { name, fields })
         } else {
+            self.struct_literal_guard
+                .consume_without_struct(self.expr_depth);
             Some(Expr::Variable(name))
         }
     }
@@ -107,6 +116,56 @@ where
             params,
             body: Box::new(body),
         })
+    }
+
+    fn parse_if_expression(&mut self) -> Option<Expr> {
+        let condition = self.parse_if_condition()?;
+        let then_branch =
+            self.parse_if_clause("expected expression for 'then' branch of 'if'", None)?;
+        let else_branch = if matches!(self.ts.peek_kind(), Some(SyntaxKind::K_ELSE)) {
+            let else_span = self
+                .ts
+                .next_tok()
+                .map_or_else(|| self.ts.eof_span(), |(_, span)| span);
+            self.parse_if_clause(
+                "expected expression for 'else' branch of 'if'",
+                Some(else_span),
+            )?
+        } else {
+            Expr::Tuple(Vec::new())
+        };
+        Some(Expr::IfElse {
+            condition: Box::new(condition),
+            then_branch: Box::new(then_branch),
+            else_branch: Box::new(else_branch),
+        })
+    }
+
+    fn parse_if_condition(&mut self) -> Option<Expr> {
+        self.struct_literal_guard
+            .disallow_at_depth(self.expr_depth + 1);
+        let result = self.parse_if_clause("expected condition expression after 'if'", None);
+        self.struct_literal_guard.reset();
+        result
+    }
+
+    fn parse_if_clause(&mut self, expectation: &str, fallback: Option<Span>) -> Option<Expr> {
+        if matches!(self.ts.peek_kind(), Some(SyntaxKind::K_ELSE)) {
+            let span = self.ts.peek_span().unwrap_or_else(|| self.ts.eof_span());
+            self.ts.push_error(span, expectation.to_string());
+            return None;
+        }
+        let error_count = self.ts.errors.len();
+        let expr = self.parse_expr(0);
+        if expr.is_none() && self.ts.errors.len() == error_count {
+            let span = self
+                .ts
+                .peek_span()
+                .or(fallback)
+                .unwrap_or_else(|| self.ts.eof_span());
+            self.ts.push_error(span, expectation.to_string());
+        }
+        expr
     }
 
     /// Parse a comma-separated list of identifiers up to (but not consuming) `terminator`.

--- a/src/parser/expression/token_stream.rs
+++ b/src/parser/expression/token_stream.rs
@@ -62,6 +62,10 @@ where
         rest
     }
 
+    pub(super) fn error_count(&self) -> usize {
+        self.errors.len()
+    }
+
     pub(super) fn push_error(&mut self, span: Span, msg: impl Into<String>) {
         self.errors.push(Simple::custom(span, msg.into()));
     }

--- a/src/parser/tests/expression.rs
+++ b/src/parser/tests/expression.rs
@@ -118,6 +118,29 @@ use rstest::rstest;
         Some(Expr::Group(Box::new(var("z")))),
     )
 )]
+#[case(
+    "if flag { Point { x: 1 } } else { z }",
+    if_expr(
+        var("flag"),
+        Expr::Group(Box::new(struct_expr(
+            "Point",
+            vec![field("x", lit_num("1"))],
+        ))),
+        Some(Expr::Group(Box::new(var("z")))),
+    )
+)]
+#[case(
+    "if a and b { x } else { y }",
+    if_expr(
+        Expr::Binary {
+            op: BinaryOp::And,
+            lhs: Box::new(var("a")),
+            rhs: Box::new(var("b")),
+        },
+        Expr::Group(Box::new(var("x"))),
+        Some(Expr::Group(Box::new(var("y")))),
+    )
+)]
 #[case("if flag value", if_expr(var("flag"), var("value"), None))]
 #[case(
     "if cond { left } else if other { mid } else { right }",

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -221,6 +221,16 @@ where
     }
 }
 
+/// Construct an `if` expression with an optional `else` branch.
+#[must_use]
+pub fn if_expr(condition: Expr, then_branch: Expr, else_branch: Option<Expr>) -> Expr {
+    Expr::IfElse {
+        condition: Box::new(condition),
+        then_branch: Box::new(then_branch),
+        else_branch: Box::new(else_branch.unwrap_or_else(|| Expr::Tuple(Vec::new()))),
+    }
+}
+
 /// Assert that a parser produced no errors.
 ///
 /// # Examples

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -222,12 +222,15 @@ where
 }
 
 /// Construct an `if` expression with an optional `else` branch.
+///
+/// Passing `None` for `else_branch` defaults to the unit `()` expression.
 #[must_use]
 pub fn if_expr(condition: Expr, then_branch: Expr, else_branch: Option<Expr>) -> Expr {
     Expr::IfElse {
         condition: Box::new(condition),
         then_branch: Box::new(then_branch),
-        else_branch: Box::new(else_branch.unwrap_or_else(|| Expr::Tuple(Vec::new()))),
+        // Default to unit `()` when no else is provided.
+        else_branch: Box::new(else_branch.unwrap_or_else(|| tuple(Vec::new()))),
     }
 }
 

--- a/tests/expression_compound.rs
+++ b/tests/expression_compound.rs
@@ -6,8 +6,8 @@
 use ddlint::parser::ast::{BinaryOp, Expr};
 use ddlint::parser::expression::parse_expression;
 use ddlint::test_util::{
-    assert_parse_error, assert_unclosed_delimiter_error, closure, field, lit_num, struct_expr,
-    tuple, var,
+    assert_parse_error, assert_unclosed_delimiter_error, closure, field, if_expr, lit_num,
+    struct_expr, tuple, var,
 };
 use rstest::rstest;
 
@@ -59,4 +59,56 @@ fn compound_expression_errors(
     } else {
         assert_parse_error(&errors, msg, start, end);
     }
+}
+
+#[rstest]
+#[case(
+    "if x { y } else { z }",
+    if_expr(
+        var("x"),
+        Expr::Group(Box::new(var("y"))),
+        Some(Expr::Group(Box::new(var("z")))),
+    )
+)]
+#[case(
+    "if (Point { x: 1 }) { y } else { z }",
+    if_expr(
+        Expr::Group(Box::new(struct_expr(
+            "Point",
+            vec![field("x", lit_num("1"))],
+        ))),
+        Expr::Group(Box::new(var("y"))),
+        Some(Expr::Group(Box::new(var("z")))),
+    )
+)]
+#[case("if flag value", if_expr(var("flag"), var("value"), None))]
+fn parses_if_expressions(#[case] src: &str, #[case] expected: Expr) {
+    let expr = parse_expression(src).unwrap_or_else(|e| panic!("source {src:?} errors: {e:?}"));
+    assert_eq!(expr, expected);
+}
+
+#[rstest]
+#[case(
+    "if cond else value",
+    "expected expression for 'then' branch of 'if'",
+    8,
+    12
+)]
+#[case(
+    "if cond value else",
+    "expected expression for 'else' branch of 'if'",
+    14,
+    18
+)]
+#[case("if", "expected condition expression after 'if'", 2, 2)]
+fn if_expression_errors(
+    #[case] src: &str,
+    #[case] msg: &str,
+    #[case] start: usize,
+    #[case] end: usize,
+) {
+    let Err(errors) = parse_expression(src) else {
+        panic!("expected error");
+    };
+    assert_parse_error(&errors, msg, start, end);
 }

--- a/tests/expression_compound.rs
+++ b/tests/expression_compound.rs
@@ -81,8 +81,48 @@ fn compound_expression_errors(
         Some(Expr::Group(Box::new(var("z")))),
     )
 )]
+#[case(
+    "if flag { Point { x: 1 } } else { z }",
+    if_expr(
+        var("flag"),
+        Expr::Group(Box::new(struct_expr(
+            "Point",
+            vec![field("x", lit_num("1"))],
+        ))),
+        Some(Expr::Group(Box::new(var("z")))),
+    )
+)]
+#[case(
+    "if a and b { x } else { y }",
+    if_expr(
+        Expr::Binary {
+            op: BinaryOp::And,
+            lhs: Box::new(var("a")),
+            rhs: Box::new(var("b")),
+        },
+        Expr::Group(Box::new(var("x"))),
+        Some(Expr::Group(Box::new(var("y")))),
+    )
+)]
 #[case("if flag value", if_expr(var("flag"), var("value"), None))]
 fn parses_if_expressions(#[case] src: &str, #[case] expected: Expr) {
+    let expr = parse_expression(src).unwrap_or_else(|e| panic!("source {src:?} errors: {e:?}"));
+    assert_eq!(expr, expected);
+}
+
+#[rstest]
+#[case(
+    "if flag { Point { x: 1 } } else { z }",
+    if_expr(
+        var("flag"),
+        Expr::Group(Box::new(struct_expr(
+            "Point",
+            vec![field("x", lit_num("1"))],
+        ))),
+        Some(Expr::Group(Box::new(var("z")))),
+    )
+)]
+fn parses_if_then_with_struct_literal(#[case] src: &str, #[case] expected: Expr) {
     let expr = parse_expression(src).unwrap_or_else(|e| panic!("source {src:?} errors: {e:?}"));
     assert_eq!(expr, expected);
 }


### PR DESCRIPTION
## Summary
- track Pratt parser depth and gate struct literal parsing so `if` conditions followed by braces do not misparse as struct literals
- extend the prefix parser with condition-specific handling, improved diagnostics for missing branches, and new helper utilities/tests for `if` expressions
- document the control-flow parser behaviour and mark the roadmap item complete

## Testing
- make lint
- make test

------
https://chatgpt.com/codex/tasks/task_e_68ce7bc548008322b3ffe697f9650291

## Summary by Sourcery

Implement support for `if`/`else` expressions in the Pratt parser, disambiguate struct literal parsing in `if` conditions, enhance diagnostics for missing branches, update the AST, and expand tests and documentation.

New Features:
- Add prefix parsing for `if` expressions with optional `else` branch and represent them as a new IfElse AST node.

Enhancements:
- Introduce expr_depth tracking and a StructLiteralGuard to prevent misparsing struct literals as block braces in `if` conditions.
- Extend prefix parser with `parse_if_expression`, `parse_if_condition`, and `parse_if_clause` for clearer control flow parsing and targeted error diagnostics.

Documentation:
- Document `if`/`else` expression handling in the control-flow parser guide, mark the roadmap item complete, and fix formatting in documentation and rstest guide.

Tests:
- Add parsing and error tests for `if` expressions and an `if_expr` helper in test utilities.