### PR TITLE
Add IPv6 rule comments and format endpoint IP addresses

### DIFF
--- a/examples/functions_and_match.dl
+++ b/examples/functions_and_match.dl
@@ -14,5 +14,7 @@ input relation Host(address: OptionalIPAddress)
 output relation IPv6Addr(addr: bit<128>)
 output relation HostLastByte(address: OptionalIPAddress, last: bit<8>)
 
+// Extract IPv6 addresses by matching Some{IPv6Address{addr}} and emitting addr.
 IPv6Addr(addr) :- Host(.address = Some{IPv6Address{addr}}).
+// Preserve the OptionalIPAddress and emit last_byte(addr) to HostLastByte.
 HostLastByte(addr, last_byte(addr)) :- Host(.address = addr).

--- a/examples/left_join_by_negation.dl
+++ b/examples/left_join_by_negation.dl
@@ -8,7 +8,11 @@ function addr_port(ip: bit<32>, proto: string, preferred_port: bit<16>): string 
         "HTTPS" -> 443,
         _        -> (if (preferred_port != 0) preferred_port else 80)
     };
-    "${ip}:${port}"
+    var o1: bit<8> = ip[31:24];
+    var o2: bit<8> = ip[23:16];
+    var o3: bit<8> = ip[15:8];
+    var o4: bit<8> = ip[7:0];
+    "${o1}.${o2}.${o3}.${o4}:${port}"
 }
 
 output relation EndpointSanitization(endpoint: string, sanitized: bool)


### PR DESCRIPTION
## Summary
- document the IPv6Addr and HostLastByte rules in the functions and match example
- render example endpoint IPs in dotted-quad notation rather than raw integers

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690902659c1c8322910887f45329bae8

## Summary by Sourcery

Document IPv6 validation rules in examples and update example endpoint IP formatting to dotted-quad notation.

Enhancements:
- Document IPv6Addr and HostLastByte rules in example scripts
- Render example endpoint IPs in dotted-quad notation instead of raw integers