### PR TITLE
Address review feedback on docs and spelling

### DIFF
--- a/.vale/styles/concordat/PreferOur.yml
+++ b/.vale/styles/concordat/PreferOur.yml
@@ -7,16 +7,38 @@ nonword: true
 swap:
   color: colour
   colors: colours
+  colored: coloured
+  coloring: colouring
+  colorful: colourful
+  colorless: colourless
   behavior: behaviour
   behaviors: behaviours
+  behavioral: behavioural
+  behaviorally: behaviourally
   neighbor: neighbour
   neighbors: neighbours
+  neighborhood: neighbourhood
+  neighboring: neighbouring
+  neighborly: neighbourly
   flavor: flavour
   flavors: flavours
+  flavored: flavoured
+  flavorful: flavourful
   honor: honour
   honors: honours
+  honored: honoured
+  honoring: honouring
+  honorable: honourable
+  honorary: honorary
   humor: humour
+  humors: humours
+  humorous: humorous
   armor: armour
+  armors: armours
+  armored: armoured
   rumor: rumour
+  rumors: rumours
+  rumored: rumoured
   favorite: favourite
   favorites: favourites
+  favoritism: favouritism

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,7 +104,7 @@
 - **Separate Atomic Refactors:** If refactoring is deemed necessary:
   - Perform the refactoring as a **separate, atomic commit** *after* the
     functional change commit.
-  - Ensure the refactoring adheres to the testing guidelines (behavioural tests
+  - Ensure the refactoring adheres to the testing guidelines (scenario tests
     pass before and after, unit tests added for new units).
   - Ensure the refactoring commit itself passes all quality gates.
 

--- a/docs/differential-datalog-parser-syntax-spec-updated.md
+++ b/docs/differential-datalog-parser-syntax-spec-updated.md
@@ -390,7 +390,7 @@ clear diagnostic that includes a span:
   `type`, `function`, or `relation`.
 - **Non‑extern transformer:** `transformer` lacking the `extern` qualifier.
 - **Duplicate definition:** repeated name for
-  type/relation/index/transformer/import; or function with same `(name, arity)`.
+  type/relation/index/transformer/import, or function with the same `(name, arity)`.
 - **`group_by` misuse:** more than one `group_by` in an expression or wrong
   arity (≠ 2).
 - **String pattern interpolation:** an interpolated string in a pattern context.

--- a/docs/parser-gap-analysis.md
+++ b/docs/parser-gap-analysis.md
@@ -18,8 +18,8 @@
   parsing to obey the spec’s “only fully qualified calls are parsed as calls”
   rule.
 
-In this analysis, references to the rule right-hand side (RHS) mean the rule
-body as opposed to the head.
+In this analysis, RHS (right-hand side) refers to the rule body, not the rule
+head.
 
 ## Where the implementation deviates (or is missing) vs the spec
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -138,8 +138,8 @@ as control flow constructs. This phase aims to build a complete grammar.
 
   - [ ] Extend the tokenizer and literal parser to support raw and interpolated
     string forms, their interned variants, and to reject interpolated strings
-    inside patterns as specified in
-    `docs/differential_datalog_parser_syntax_spec_updated.md`.
+    inside patterns as specified in the updated
+    [parser syntax spec](docs/differential-datalog-parser-syntax-spec-updated.md).
 
   - [ ] Parse width-qualified numeric literals (signed and unsigned integers,
     floats) with range validation and a shaped literal AST so later passes can

--- a/docs/rust-doctest-dry-guide.md
+++ b/docs/rust-doctest-dry-guide.md
@@ -149,7 +149,7 @@ function within the doctest that returns a Result. This leverages the
 Termination trait, which is implemented for Result. The surrounding boilerplate
 can then be hidden from the rendered documentation.
 
-```Rust
+```rust,no_run
 /// # Examples
 ///
 /// ```
@@ -173,7 +173,7 @@ rustdoc provides a lesser-known but more concise shorthand for this exact
 scenario. If a code block ends with the literal token (()), rustdoc will
 automatically wrap the code in a main function that returns a Result.
 
-```Rust
+```rust,no_run
 /// # Examples
 ///
 /// ```
@@ -313,7 +313,7 @@ any pollution of the final binary or the public API.
 The typical implementation pattern is to create a private helper module within
 the library:
 
-```Rust
+```rust,no_run
 // In lib.rs or a submodule
 
 /// A function that requires a complex environment to test.
@@ -399,7 +399,7 @@ builds.[^13]
 
 **The Pattern**:
 
-```Rust
+```rust,no_run
 /// A socket that is only available on Unix platforms.
 #[cfg(any(target_os = "unix", doc))]
 pub struct UnixSocket;
@@ -433,7 +433,7 @@ Pattern 1: #\[cfg\] Inside the Code Block
 This pattern involves placing a #\[cfg\] attribute directly on the code within
 the doctest itself.
 
-```Rust
+```rust,no_run
 /// This example only runs if the "serde" feature is enabled.
 ///
 /// ```
@@ -457,7 +457,7 @@ A more explicit and accurate pattern uses the cfg_attr attribute to
 conditionally add the ignore flag to the doctest's header. This is typically
 done with inner doc comments (//!).
 
-```Rust
+```rust,no_run
 //! #![cfg_attr(not(feature = "serde"), doc = "```ignore")]
 //! #![cfg_attr(feature = "serde", doc = "```")]
 //! // Example code that requires the "serde" feature.
@@ -481,7 +481,7 @@ feature-gated items in the generated documentation. This is achieved with the
 `#[doc(cfg(...))]` attribute, which requires enabling the
 `#![feature(doc_cfg)]` feature gate at the crate root.
 
-```Rust
+```rust,no_run
 // At the crate root (lib.rs)
 #![feature(doc_cfg)]
 


### PR DESCRIPTION
## Summary
- expand the Vale house-style substitutions to cover additional -our derivatives and plurals
- fix remaining terminology and linking nits in the contributor guidance docs
- normalise Rust code fences in the doctest guide to use `rust,no_run`

## Testing
- `make check-fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_69092050a120832299768847ee1f4319

## Summary by Sourcery

Address documentation review feedback by expanding English style substitutions, normalizing Rust code fences, and refining terminology and links across contributor guides.

Enhancements:
- Expand Vale house-style substitutions to cover additional British English '-our' derivatives and plurals
- Normalize Rust code fences in the doctest guide to use `rust,no_run`

Documentation:
- Clarify RHS abbreviation in the parser gap analysis guide
- Update roadmap link to the parser syntax spec
- Rename behavioral tests to scenario tests in AGENTS.md
- Fix punctuation and phrasing in the updated parser syntax specification