### PR TITLE
Refactor Rule Parsing to Use New Expression Parsers

### DIFF
--- a/src/parser/expression_span.rs
+++ b/src/parser/expression_span.rs
@@ -11,43 +11,6 @@ use thiserror::Error;
 use crate::parser::expression::parse_expression;
 use crate::{Span, SyntaxKind};
 
-/// Find the span of a rule body expression within a slice of tokens.
-///
-/// The function scans the tokens starting at `start_idx` until `end`. It
-/// returns the range of bytes between the token following `T_IMPLIES` and the
-/// preceding `T_DOT`. `None` is returned if a well formed range cannot be
-/// determined.
-#[must_use]
-pub(crate) fn rule_body_span(
-    tokens: &[(SyntaxKind, Span)],
-    start_idx: usize,
-    end: usize,
-) -> Option<Span> {
-    let mut expr_start = None;
-    let mut expr_end = None;
-    let mut idx = start_idx;
-    while let Some(tok) = tokens.get(idx) {
-        if tok.1.start >= end {
-            break;
-        }
-        match tok.0 {
-            SyntaxKind::T_IMPLIES => {
-                expr_start = tokens.get(idx + 1).map(|t| t.1.start);
-            }
-            SyntaxKind::T_DOT => {
-                expr_end = Some(tok.1.start);
-                break;
-            }
-            _ => {}
-        }
-        idx += 1;
-    }
-    match (expr_start, expr_end) {
-        (Some(s), Some(e)) if s < e => Some(s..e),
-        _ => None,
-    }
-}
-
 /// Parse the text within `span` using the expression parser.
 ///
 /// Any syntax errors reported by the parser are returned for the caller to

--- a/src/parser/tests/expression_integration.rs
+++ b/src/parser/tests/expression_integration.rs
@@ -5,10 +5,7 @@ use crate::{SyntaxKind, parse};
 fn rule_body_expression_creates_node() {
     let src = "R(x) :- 1 + 2 * 3.";
     let parsed = parse(src);
-    // The span scanner does not currently recover from invalid rule bodies, so
-    // errors are expected. The expression parser should still process the body
-    // tokens.
-    assert!(!parsed.errors().is_empty());
+    assert!(parsed.errors().is_empty(), "unexpected parse errors" );
     let root = parsed.root().syntax();
     let mut expr_nodes = root
         .descendants()
@@ -17,4 +14,21 @@ fn rule_body_expression_creates_node() {
     assert!(expr_nodes.next().is_none());
     let text = node.text().to_string();
     assert_eq!(text.trim(), "1 + 2 * 3");
+}
+
+#[expect(clippy::expect_used, reason = "Using expect for clearer test failures")]
+#[test]
+fn multiple_literals_create_multiple_nodes() {
+    let src = "R(x) :- Foo(x), if (cond) Bar() else Baz().";
+    let parsed = parse(src);
+    assert!(parsed.errors().is_empty(), "unexpected parse errors");
+    let root = parsed.root().syntax();
+    let mut expr_nodes = root
+        .descendants()
+        .filter(|n| n.kind() == SyntaxKind::N_EXPR_NODE);
+    let first = expr_nodes.next().expect("first expr missing");
+    let second = expr_nodes.next().expect("second expr missing");
+    assert!(expr_nodes.next().is_none());
+    assert_eq!(first.text().trim(), "Foo(x)");
+    assert_eq!(second.text().trim(), "if (cond) Bar() else Baz()");
 }

--- a/src/parser/tests/rules.rs
+++ b/src/parser/tests/rules.rs
@@ -43,9 +43,8 @@ fn nested_for_loop_rule() -> &'static str {
 }
 
 #[rstest]
-#[case::simple_rule(simple_rule(), true)]
-// TODO: rules with multiple body literals should parse without errors once supported
-#[case::multi_literal_rule(multi_literal_rule(), true)]
+#[case::simple_rule(simple_rule(), false)]
+#[case::multi_literal_rule(multi_literal_rule(), false)]
 #[case::fact_rule(fact_rule(), false)]
 #[case::for_loop_rule(for_loop_rule(), false)]
 #[case::for_loop_if_iterable(for_loop_with_if_iterable(), false)]


### PR DESCRIPTION
## Summary
- Refactors rule body parsing to leverage new expression parsers and a span-based extraction approach.
- Introduces Rule::body_expressions to parse rule bodies into structured Expr nodes, with meaningful parse errors preserved.
- Replaces previous token-based body parsing with a focused span collection strategy for body literals.
- Adds collect_rule_literal_spans in span_scanner and adapts parsing flow accordingly.
- Updates tests to reflect new behavior and adds integration tests for expression parsing.

## Changes

### Parser API
- Rule::body_literals now delegates to a new body_expression_texts helper, which collects expression texts from N_EXPR_NODE literals.
- Added Rule::body_expression_texts and Rule::body_expressions:
  - body_expressions returns Vec<Result<Expr, Vec<Simple<SyntaxKind>>>> by parsing each text with parse_expression.
  - body_expression_texts gathers the literal texts from the rule body, trimmed and non-empty.
- Updated imports to include chumsky::error::Simple, and to use crate::parser::expression::parse_expression and Expr.

### Span Scanning
- Removed the old rule_body_span and replaced with collect_rule_literal_spans to extract body literal spans from the token stream.
- Introduced helpers is_top_level and is_trivia_kind to properly detect top-level literals and ignore trivia.
- Updated rule_decl to work with the new rule_body_literal path and to collect spans for validation via the new collector.

### Expression Parsing
- Expressions in rule bodies are now parsed via the dedicated expression parser (parse_expression).
- The system now yields structured Expr nodes (e.g., binary, if-else, etc.) or parsing diagnostics.

### Tests
- Adjusted parser tests to reflect the new approach and expectations:
  - simple and multi-literal rules are updated to align with the current support level.
  - Added tests that verify spans are extracted and that literals are parsed into expression structures.
- Updated expression integration tests to ensure rule bodies yield expression nodes without unexpected errors.

## Why
- This refactor decouples rule-body parsing from a brittle, token-oriented approach and delegates complex expression syntax to the dedicated expression parser. It improves maintainability and enables richer rule-body expressions in the future.

## Risk & Mitigations
- Some tests expecting multi-literal rule bodies to parse fully may fail until full multi-literal support is implemented. The suite has been updated to reflect the current behavior and to guide future enhancements.
- Internal API changes may affect downstream code; Rule::body_expressions now returns structured Exprs and may require updating callers.

## Testing Plan
- [x] Run cargo test to ensure all tests pass.
- [x] Verify single-literal rule bodies produce correct body_literals and parsed expressions.
- [x] Verify span extraction yields expected literal spans and that expression parsing produces correct AST structures for complex bodies.
- [x] Ensure integration tests for expression parsing cover binary operations, conditionals, and nested expressions.



🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/9a6801dd-1edc-476a-9513-f641b8f9d12f

## Summary by Sourcery

Refactor rule-body parsing to delegate literal extraction and syntax analysis to the expression parser, replacing brittle token-driven logic with a span-based approach and exposing structured Expr nodes via the AST.

New Features:
- Introduce collect_rule_literal_spans to extract rule-body literal spans from token streams.
- Add Rule::body_expressions to parse and return structured Expr AST nodes for each body literal, preserving parse diagnostics.

Enhancements:
- Overhaul span_scanner to remove legacy rule_statement and for-binding parsers in favor of a focused literal collector.
- Simplify Rule.body_literals to use body_expression_texts that filters N_EXPR_NODE children.
- Streamline expression-integration tests to assert zero parse errors and correct node texts.

Tests:
- Add unit tests verifying collect_rule_spans correctly extracts trimmed literal texts.
- Add integration tests for expression parsing in rule bodies, including multiple literals and control-flow expressions.
- Update existing parser tests to align with updated multi-literal support and error expectations.