### PR TITLE
Update shared-actions SHA in CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Setup Rust
-        uses: leynos/shared-actions/.github/actions/setup-rust@v1.1.0
+        uses: leynos/shared-actions/.github/actions/setup-rust@aebb3f5b831102e2a10ef909c83d7d50ea86c332
       - name: Format
         run: make check-fmt
       - name: Lint
@@ -32,7 +32,7 @@ jobs:
         run: cargo tarpaulin --out lcov
       - name: Upload coverage data to CodeScene
         if: env.CS_ACCESS_TOKEN
-        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@v1.1.1
+        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@aebb3f5b831102e2a10ef909c83d7d50ea86c332
         with:
           format: lcov
           access-token: ${{ env.CS_ACCESS_TOKEN }}


### PR DESCRIPTION
## Summary
- Bump shared-actions SHA references in CI workflows to aebb3f5b831102e2a10ef909c83d7d50ea86c332

## Changes
### CI Workflows
- .github/workflows/ci.yml
  - Setup Rust action updated to leynos/shared-actions/.github/actions/setup-rust@aebb3f5b831102e2a10ef909c83d7d50ea86c332
  - Upload codescene coverage action updated to leynos/shared-actions/.github/actions/upload-codescene-coverage@aebb3f5b831102e2a10ef909c83d7d50ea86c332

## Rationale
- Align with the latest shared-actions changes and pin to a specific revision to ensure reproducible CI runs.

## Validation
- No code changes; CI should run as usual with the new SHA.
- On PR, CI will initialize Rust, run formatting, linting, tests, and upload coverage using the pinned actions.

## Notes
- Branch: terragon/update-sha-shared-actions-qhp9ca

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/a8c9c92d-b38f-4ae4-841d-027fc1816100

## Summary by Sourcery

CI:
- Update setup-rust and upload-codescene-coverage actions in the main CI workflow to use a pinned shared-actions commit SHA instead of version tags.