### PR TITLE
Add ADR: parser crate split for multi-consumer use

### DIFF
--- a/docs/adr-001-parser-crate-split.md
+++ b/docs/adr-001-parser-crate-split.md
@@ -41,8 +41,8 @@ first-class library with explicit layers and versioned contracts.
   the stable interface that exports `ddlog-sema` data into planner inputs.
 - Provenance:
   source-location mapping from semantic nodes back to original spans.
-- Canonicalisation:
-  deterministic normalisation of equivalent plans into a stable shape.
+- Canonicalization:
+  deterministic normalization of equivalent plans into a stable shape.
 - Intermediate representation (IR):
   planner-facing structured form consumed after semantic lowering.
 - Continuous integration (CI):
@@ -57,7 +57,7 @@ first-class library with explicit layers and versioned contracts.
 - Establish stable API and diagnostics contracts suitable for reuse.
 - Reduce coupling between lint-only utilities and compiler-only concerns.
 - Prepare parser outputs for deterministic lowering into future `pliron`
-  dialect and `egg` canonicalisation pipelines.
+  dialect and `egg` canonicalization pipelines.
 - Enable incremental adoption with low migration risk.
 
 ## Requirements
@@ -80,7 +80,7 @@ first-class library with explicit layers and versioned contracts.
   example, semiring, stratification, and key/constraint facts).
 - Define a stable lowering boundary from `ddlog-sema` into planner-facing
   intermediate representation (IR) inputs, without reparsing source text.
-- Ensure deterministic semantic traversal and serialisation semantics for
+- Ensure deterministic semantic traversal and serialization semantics for
   downstream cache-key generation.
 - Keep compatibility with workspace quality gates and existing tests.
 
@@ -237,7 +237,7 @@ Parser and semantic model obligations for future planner work:
 - Preserve semantic facts needed for guarded rewrites (keys, arity, relation
   kinds, stratification, and semiring annotations where applicable).
 - Provide deterministic ordering for semantic collections and symbol views so
-  downstream canonicalisation and hash derivation are stable.
+  downstream canonicalization and hash derivation are stable.
 - Reserve a forward-compatible extension point for planner hints/attributes so
   new planner metadata can be added without source reparsing.
 


### PR DESCRIPTION
## Summary
- Adds Architectural Decision Record (ADR) for parser crate split to support multi-consumer use.
- Aligns project with ADR-driven design and documentation standards.
- No code changes; documentation-only.

## Changes
### Documentation updates
- Added docs/adr-001-parser-crate-split.md as an example ADR focusing on the parser crate split for multi-consumer use, including context, options, decision outcome, and rationale.

### ADR and roadmap artifacts
- Expanded ADR guidance to accompany the new documentation standards and templates.

## Rationale
- This ADR clarifies crate boundaries and coordination between linting and compiler consumers, enabling explicit layering, stable contracts, and clearer migration paths.
- The document serves as a concrete example of the ADR framework and how parser-design decisions should be recorded for future work.

## How to review
- Focus on the new ADR file docs/adr-001-parser-crate-split.md and the accompanying ADR guidance to ensure naming conventions, required sections, and formatting align with team practices.
- Verify that the documentation reflects intended ADR structure and usage for parser design decisions.

## Testing plan
- This PR is documentation-focused; run local Markdown linting if desired and verify formatting in CI for documentation checks.
- Manually skim the ADR content to ensure consistency with the stated conventions and templates.

---
◳ Generated by [DevBoxer](https://www.devboxer.com) ◰

ℹ️ Tag @devboxerhub to ask questions and address PR feedback

📎 **Task**: https://www.devboxer.com/task/87dd22d6-9c1c-4ed8-9b92-81c5741eb50f

## Summary by Sourcery

Document the architectural decision to split the parser into dedicated syntax, semantic, and facade crates to support both linting and compiler consumers.

Documentation:
- Add an ADR describing the planned parser crate split, including context, options considered, chosen direction, and rationale for multi-consumer support.
- Define ownership, coordination policies, migration phases, and future compatibility expectations for the new parser library layering.