### PR TITLE
Implement transformer declaration grammar alignment and diagnostics

### DIFF
--- a/docs/differential-datalog-parser-syntax-spec-updated.md
+++ b/docs/differential-datalog-parser-syntax-spec-updated.md
@@ -231,19 +231,20 @@ Closure   ::= 'function' '(' Params? ')' RetType? Block
 ### 5.4 Transformers (extern‑only)
 
 ```ebnf
-Transformer        ::= 'extern' 'transformer' Ident '(' Params? ')'
-                       ':' TransformerOutputs
+Transformer ::= 'extern' 'transformer' LcName '(' Params? ')' ':' TransformerOutputs
 TransformerOutputs ::= Ident (',' Ident)*
 ```
 
+Notes:
+
+- The output signature after `:` is mandatory and must contain at least one
+  identifier.
+- Zero-input transformers remain valid (`extern transformer t(): Out`).
+- Output identifiers are preserved in order and exposed through the parser AST.
 - A non‑extern `transformer` is rejected.
-- The current parser accepts any non-keyword identifier token for transformer
-  names and output names; it does not apply a case-class restriction such as
-  `LcName` or `UcName`.
 - Transformer declarations are expected to remain on one physical line.
   Recovery for malformed declarations is line-oriented: once parsing fails, the
   scanner discards tokens through the next newline boundary before resuming.
-
 ### 5.5 Relations
 
 Two equivalent forms:
@@ -679,7 +680,13 @@ X(x) :- group_by(sum(x)). // error: expected 2 arguments
 - **Non‑extern transformer:**
 
 ```ddlog
-transformer Foo(); // error: transformer declarations must be extern
+transformer foo(x: T): Out // error: transformer declarations must be extern
+```
+
+- **Missing transformer output signature:**
+
+```ddlog
+extern transformer foo(x: T): // error: transformer declarations require ':' followed by at least one output identifier
 ```
 
 - **Attribute on index:**

--- a/docs/differential-datalog-parser-syntax-spec-updated.md
+++ b/docs/differential-datalog-parser-syntax-spec-updated.md
@@ -245,6 +245,7 @@ Notes:
 - Transformer declarations are expected to remain on one physical line.
   Recovery for malformed declarations is line-oriented: once parsing fails, the
   scanner discards tokens through the next newline boundary before resuming.
+
 ### 5.5 Relations
 
 Two equivalent forms:

--- a/docs/execplans/2-6-5-align-transformer-declaration-grammar.md
+++ b/docs/execplans/2-6-5-align-transformer-declaration-grammar.md
@@ -1,0 +1,404 @@
+# Align transformer declaration grammar and output signatures
+
+This ExecPlan (execution plan) is a living document. The sections
+`Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
+`Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
+proceeds.
+
+Status: DRAFT
+
+## Purpose / big picture
+
+Roadmap item `2.6.5` is open because the parser, tests, and syntax
+specification describe different transformer declarations. The current parser
+accepts only `extern transformer name(inputs...): outputs...`, exposes those
+outputs through `Transformer::outputs()`, and rejects declarations without an
+output list. The normative syntax spec in
+`docs/differential-datalog-parser-syntax-spec-updated.md` still documents the
+older semicolon-only shape with no output signature, so a novice cannot tell
+which contract is real.
+
+After this change, a novice should be able to read one transformer grammar,
+parse a declaration such as
+`extern transformer normalise(input: User): Normalised`, inspect both inputs
+and outputs through the Abstract Syntax Tree (AST), and get deterministic
+diagnostics when the required output signature is missing or empty. Success is
+observable when:
+
+- the parser, unit tests, behavioural tests, and active docs all describe the
+  same transformer grammar;
+- missing-output and non-`extern` declarations produce stable diagnostics;
+- `make check-fmt`, `make lint`, and `make test` pass after the implementation
+  change; and
+- `docs/roadmap.md` item `2.6.5` is marked done only after those checks
+  succeed.
+
+## Recommended decision
+
+Close item `2.6.5` by aligning the syntax spec and parser contract to the
+existing parser-side declaration shape rather than weakening the parser back to
+the older semicolon-only form.
+
+The canonical parser contract for this milestone should become:
+
+- `extern transformer <identifier>(<name: type pairs>?): <output-identifiers>`
+- the output signature after `:` is mandatory and must contain at least one
+  identifier;
+- zero inputs remain valid, but zero outputs do not;
+- multiple outputs remain comma-separated and ordered;
+- non-`extern` transformer declarations keep the existing targeted diagnostic;
+- semicolon policy remains unchanged and out of scope for this item; and
+- parser-stage case-class validation for transformer names and outputs remains
+  out of scope unless the existing code cannot be documented coherently without
+  it.
+
+This is the smallest decision that matches the implemented AST surface,
+existing parser tests, and the already-landed `apply` item behaviour. The
+repository already models transformer outputs in `Transformer::outputs()` and
+uses them in `apply`-related tests. Removing outputs from the declaration
+grammar would therefore be a broader parser and API redesign, not a conformance
+alignment task.
+
+The implementation should also tighten diagnostics around the output signature.
+Today, declarations such as `extern transformer t(x: A):` fail with generic
+unexpected-token errors. This roadmap item should replace those generic
+failures with one deterministic transformer-specific message for missing or
+empty output signatures, for example
+`transformer declarations require ':' followed by at least one output identifier`.
+
+If implementation reveals a hidden consumer that depends on the old
+semicolon-only grammar, stop and escalate. That would be a wider compatibility
+policy decision, not an isolated grammar-alignment fix.
+
+## Constraints
+
+- Align the active written contract in
+  `docs/differential-datalog-parser-syntax-spec-updated.md` section `5.4` to
+  the final parser behaviour.
+- Keep the scope centred on transformer declarations. Do not fold relation
+  form, apply grammar, legacy-token policy, or global statement terminator work
+  from roadmap items `2.6.6` through `2.6.8` into this change.
+- Preserve the existing AST surface unless implementation proves a small,
+  clearly justified refinement is required. In particular,
+  `Transformer::inputs()` and `Transformer::outputs()` should remain available.
+- Keep non-`extern` transformer diagnostics working with the existing message
+  unless a tightly scoped wording change is made everywhere in one pass.
+- Add both unit tests and behavioural tests that prove the accepted grammar and
+  the new deterministic output-signature failures.
+- Update the relevant design documents, not only parser tests and the
+  conformance register.
+- Mark `docs/roadmap.md` item `2.6.5` done only after all documentation,
+  implementation, and validation steps succeed.
+- Run repository quality gates through Make targets using `set -o pipefail` and
+  `tee`.
+- Keep comments and documentation in en-GB-oxendict spelling.
+
+## Tolerances (exception triggers)
+
+- Scope: if the implementation requires edits to more than 10 files or more
+  than 260 net new code lines, stop and escalate. That likely means the work is
+  drifting into a broader grammar or API redesign.
+- Interface: if the only coherent fix requires removing `Transformer::outputs()`
+  or reshaping `Apply` consumers, stop and escalate.
+- Compatibility: if non-test workspace code depends on parsing transformer
+  declarations without output signatures, stop and document those callers
+  before changing behaviour.
+- Grammar: if aligning the spec to the implemented output signature still
+  leaves an unavoidable contradiction around identifier case classes or
+  terminators, stop and escalate with concrete file references instead of
+  silently widening the task.
+- Validation: if `make check-fmt`, `make lint`, or `make test` still fails
+  after three focused fix rounds, stop and escalate with the specific failing
+  targets.
+- Runner stability: if `make test` hits the known repository-wide nextest stall
+  rather than a deterministic regression from this task, capture the evidence
+  and escalate instead of silently substituting a different profile.
+
+## Risks
+
+- Risk: the repository already has two overlapping transformer contracts: the
+  syntax spec's semicolon-only form and the parser/tests' required output list.
+  Severity: high. Likelihood: high. Mitigation: search for transformer grammar
+  examples across `docs/`, `src/parser/tests/`, and `tests/`, then update all
+  contract-bearing examples in one atomic change.
+
+- Risk: output-signature parsing currently fails through generic parser errors,
+  so merely updating the spec could leave usability gaps unaddressed. Severity:
+  high. Likelihood: high. Mitigation: add red tests for missing colon and
+  empty-output cases first, then implement transformer-specific diagnostics in
+  `src/parser/span_scanners/transformers.rs`.
+
+- Risk: transformer declarations and `apply` items are conceptually coupled,
+  so a grammar change could accidentally invalidate existing `apply` examples
+  or behavioural assumptions. Severity: medium. Likelihood: medium. Mitigation:
+  add at least one behavioural test containing both a transformer declaration
+  and an `apply` item in the same programme.
+
+- Risk: identifier case restrictions are inconsistent between the spec
+  (`UcName`) and the parser/tests (generic identifiers such as `normalise` and
+  `out`). Severity: medium. Likelihood: high. Mitigation: keep this milestone
+  focused on documenting current parser behaviour unless stronger case
+  validation can be added without touching `apply` parsing or broader naming
+  policy.
+
+- Risk: semicolon examples in the spec can distract the implementation into a
+  top-level terminator policy change. Severity: medium. Likelihood: medium.
+  Mitigation: treat terminator policy as explicitly out of scope, as in the
+  completed index-grammar conformance work.
+
+## Progress
+
+- [x] (2026-03-27) Reviewed roadmap item `2.6.5`, conformance register item
+  `12`, the syntax spec transformer grammar, parser implementation notes,
+  design doc guidance, current transformer scanner and AST wrappers, and
+  existing parser and behavioural tests.
+- [x] (2026-03-27) Confirmed the live parser contract already requires a colon
+  plus a non-empty output list and exposes that list through
+  `Transformer::outputs()`.
+- [x] (2026-03-27) Drafted this ExecPlan in
+  `docs/execplans/2-6-5-align-transformer-declaration-grammar.md`.
+- [ ] Update red tests to encode the chosen grammar and deterministic failure
+  messages.
+- [ ] Implement any required parser diagnostic changes in
+  `src/parser/span_scanners/transformers.rs` and related helpers.
+- [ ] Align active documentation and conformance records.
+- [ ] Run `make fmt`, `make markdownlint`, `make nixie`,
+  `make check-fmt`, `make lint`, and `make test`.
+- [ ] Mark roadmap item `2.6.5` done after all checks pass.
+
+## Surprises & Discoveries
+
+- The parser side is already much more opinionated than the syntax spec.
+  `src/parser/span_scanners/transformers.rs` requires a top-level `:` followed
+  by at least one output identifier, and malformed declarations yield no
+  transformer node.
+
+- The AST and tests are already built around output signatures.
+  `src/parser/ast/transformer.rs` exposes `outputs()`, and the existing unit
+  and parser-integration tests assert concrete output lists for all successful
+  transformer fixtures.
+
+- `apply` behavioural coverage already assumes the richer transformer contract.
+  `tests/apply_items.rs` pairs a transformer declaration with an `apply`
+  statement, so reverting to a no-output transformer grammar would create
+  additional downstream ambiguity.
+
+- The syntax spec mismatch is not limited to the colon. Section `5.4` also uses
+  `UcName`, while current parser fixtures and behavioural tests use lower-case
+  transformer names such as `normalise`, `correlate`, and `reserved`. This plan
+  keeps that case-policy question tightly bounded so the output signature
+  decision can land first.
+
+- Existing failure coverage for missing outputs is weak. The tests assert only
+  a generic `Unexpected` pattern today, which is too vague for a conformance
+  item whose whole point is to freeze the grammar contract.
+
+## Decision Log
+
+- Decision: recommend aligning the spec and docs to the implemented
+  colon-plus-output-list grammar rather than rewriting the parser to match the
+  older semicolon-only spec. Rationale: this is the smaller change, it matches
+  the existing AST surface and tests, and it avoids breaking the
+  already-implemented transformer/apply story.
+
+- Decision: require a non-empty output signature and add a deterministic
+  transformer-specific diagnostic for missing or empty outputs. Rationale: the
+  current parser already rejects zero-output declarations, but the failure mode
+  is too generic to serve as a stable documented contract.
+
+- Decision: keep semicolon policy out of scope for this milestone.
+  Rationale: the open conformance item is about declaration shape and output
+  signatures, not about harmonizing top-level terminators across the whole
+  grammar.
+
+- Decision: do not widen this milestone into a general identifier case-policy
+  change unless implementation proves the docs cannot be aligned otherwise.
+  Rationale: lower-case transformer names already appear in tests and related
+  `apply` examples, so tightening case classes would have a larger blast radius
+  than the roadmap item requires.
+
+## Outcomes & Retrospective
+
+This ExecPlan has been drafted, but implementation has not started. The
+expected outcome is a single documented transformer grammar with targeted
+diagnostics for missing output signatures, backed by unit and behavioural
+tests. The roadmap checkbox must remain open until that implementation lands
+and all validation commands succeed.
+
+## Context and orientation
+
+The relevant code and documents are concentrated in a small set of files:
+
+- `src/parser/span_scanners/transformers.rs` recognises top-level transformer
+  declarations and already enforces the `extern` requirement plus the current
+  colon-output grammar.
+- `src/parser/ast/transformer.rs` exposes `Transformer::name()`,
+  `Transformer::inputs()`, and `Transformer::outputs()`.
+- `src/parser/ast/parse_utils/outputs.rs` contains the output-list extraction
+  helper and its local tests.
+- `src/parser/tests/transformers.rs` contains the feature-focused unit tests
+  for accepted and rejected transformer declarations.
+- `src/parser/tests/programs.rs`, `src/parser/tests/specs.rs`, and
+  `src/parser/tests/parser.rs` define parser-level integration fixtures and
+  assertions for transformer declarations.
+- `tests/apply_items.rs`, `tests/attribute_placement.rs`, and
+  `tests/name_uniqueness.rs` provide behavioural coverage that already touches
+  transformers indirectly.
+- `docs/differential-datalog-parser-syntax-spec-updated.md`,
+  `docs/parser-conformance-register.md`, `docs/parser-implementation-notes.md`,
+  and `docs/ddlint-design.md` carry the active written contract.
+
+The concrete mismatch today is:
+
+- Spec: `extern transformer UcName(params?);`
+- Code/tests: `extern transformer ident(params?): output(, output)*`
+
+The implementation should resolve that mismatch in code, tests, and docs in one
+atomic change.
+
+## Plan of work
+
+### Stage A: establish red tests for the intended contract
+
+Start by changing tests so they describe the chosen grammar before touching the
+scanner logic.
+
+- Update `src/parser/tests/transformers.rs` so missing outputs and missing
+  output signatures assert one deterministic transformer-specific message
+  rather than a generic `Unexpected` pattern.
+- Add an explicit rejection case for the legacy semicolon-only shape, for
+  example `extern transformer legacy(x: A)` or
+  `extern transformer legacy(x: A);`, depending on the repository's current
+  top-level terminator policy.
+- Keep success coverage for zero-input, single-output, and multi-output
+  declarations.
+- Add a parser-level integration assertion in `src/parser/tests/parser.rs` and
+  related fixtures so the shared parser suite encodes the final grammar too.
+
+At the end of Stage A, the targeted transformer tests should fail for the right
+reason: the grammar contract is now stricter and more specific than the current
+diagnostics.
+
+### Stage B: implement deterministic grammar handling
+
+Adjust the transformer scanner so the chosen contract is enforced explicitly
+and recoverably.
+
+- Refactor `src/parser/span_scanners/transformers.rs` so it can distinguish:
+  `non-extern transformer`, `missing ':'`, and
+  `':' present but no output identifiers`.
+- Keep the span recovery behaviour that skips malformed declarations cleanly so
+  downstream CST construction remains stable.
+- Preserve successful parsing of existing valid fixtures, including multiple
+  outputs and zero inputs.
+- If needed, add a small helper near the scanner or in
+  `src/parser/ast/parse_utils/outputs.rs` to keep output-signature parsing and
+  output-signature diagnostics consistent.
+
+### Stage C: align documentation and public contract text
+
+Once the parser and tests agree, update every active document that carries the
+grammar contract.
+
+- In `docs/parser-conformance-register.md`, rewrite item `12` so the
+  spec/target behaviour matches the chosen grammar and mark the entry
+  `implemented` once the full change is complete.
+- In `docs/differential-datalog-parser-syntax-spec-updated.md` section `5.4`,
+  replace the semicolon-only grammar with the colon-plus-output-list grammar
+  and add one short note stating that empty output signatures are rejected.
+- In `docs/parser-implementation-notes.md`, add a brief parser-boundary note
+  describing the transformer scanner's explicit output-signature requirement
+  and deterministic diagnostics.
+- In `docs/ddlint-design.md`, add one sentence in the parser-contract section
+  clarifying that transformer declarations expose output signatures directly
+  from the CST-backed AST surface because downstream analysis and `apply`
+  handling already depend on them.
+- In code comments, update `src/parser/ast/transformer.rs` and any adjacent
+  parse-helper docs so they describe the frozen contract accurately.
+
+### Stage D: add behavioural coverage for end-to-end parser behaviour
+
+Add or update behavioural tests in `tests/` so the public `parse()` entrypoint
+proves the decision, not just the internal unit suites.
+
+- Add a dedicated `tests/transformer_declaration_grammar.rs` file unless an
+  existing behavioural test file is a clearly better home.
+- Include at least one success case proving that a programme containing a valid
+  transformer declaration yields one transformer with the expected outputs.
+- Include at least one failure case proving that a declaration with no output
+  signature yields the deterministic diagnostic and no transformer node.
+- Include one combined case with a transformer declaration plus an `apply`
+  statement to show the broader parser surface still behaves coherently.
+
+### Stage E: validation and close-out
+
+After implementation and documentation updates:
+
+1. Run `make fmt`, `make markdownlint`, and `make nixie` because this change
+   updates Markdown.
+2. Run `make check-fmt`, `make lint`, and `make test`.
+3. Only after those gates pass, update `docs/roadmap.md` to mark item `2.6.5`
+   done.
+4. Record any final wording or scope decisions back into this ExecPlan's
+   `Decision Log`, `Progress`, and `Outcomes & Retrospective` sections.
+
+## Concrete steps
+
+1. Update unit tests in `src/parser/tests/transformers.rs`.
+
+   - Replace generic output-failure assertions with a transformer-specific
+     diagnostic expectation.
+   - Add one explicit legacy-form rejection case.
+   - Keep success coverage for one output, many outputs, and zero inputs.
+
+2. Update parser-level shared fixtures and assertions.
+
+   - Adjust `src/parser/tests/programs.rs` if new failure fixtures are needed.
+   - Adjust `src/parser/tests/specs.rs` and `src/parser/tests/parser.rs` so the
+     shared parser suite encodes the same contract as the feature-specific
+     transformer tests.
+
+3. Implement scanner diagnostics in `src/parser/span_scanners/transformers.rs`.
+
+   - Preserve existing success cases.
+   - Emit one deterministic message for missing or empty output signatures.
+   - Keep the existing `transformer declarations must be extern` message for
+     non-`extern` declarations.
+
+4. Update AST and helper docs only if required.
+
+   - Keep `Transformer::outputs()` intact.
+   - Update documentation in `src/parser/ast/transformer.rs` and
+     `src/parser/ast/parse_utils/outputs.rs` if it no longer matches the frozen
+     contract.
+
+5. Add behavioural tests in `tests/transformer_declaration_grammar.rs`.
+
+   - One success case.
+   - One output-signature failure case.
+   - One success case combined with `apply`.
+
+6. Update active documentation.
+
+   - `docs/parser-conformance-register.md`
+   - `docs/differential-datalog-parser-syntax-spec-updated.md`
+   - `docs/parser-implementation-notes.md`
+   - `docs/ddlint-design.md`
+   - `docs/roadmap.md` only after all gates pass
+
+## Validation commands
+
+Run the following from the repository root, capturing output with `tee`:
+
+```shell
+set -o pipefail; make fmt 2>&1 | tee /tmp/2-6-5-make-fmt.log
+set -o pipefail; make markdownlint 2>&1 | tee /tmp/2-6-5-make-markdownlint.log
+set -o pipefail; make nixie 2>&1 | tee /tmp/2-6-5-make-nixie.log
+set -o pipefail; make check-fmt 2>&1 | tee /tmp/2-6-5-make-check-fmt.log
+set -o pipefail; make lint 2>&1 | tee /tmp/2-6-5-make-lint.log
+set -o pipefail; make test 2>&1 | tee /tmp/2-6-5-make-test.log
+```
+
+Successful completion means all six commands exit with status `0`, the new
+transformer unit and behavioural tests pass, and the roadmap entry can be
+closed without leaving the conformance register in `scheduled` state.

--- a/docs/execplans/2-6-5-align-transformer-declaration-grammar.md
+++ b/docs/execplans/2-6-5-align-transformer-declaration-grammar.md
@@ -41,16 +41,16 @@ the older semicolon-only form.
 
 The canonical parser contract for this milestone should become:
 
-- `extern transformer <identifier>(<name: type pairs>?): <output-identifiers>`
+- `extern transformer <lowercase-name>(<name: type pairs>?): <output-identifiers>`
+- transformer names must follow the LcName rule (start with a lowercase letter
+  or underscore) and the parser enforces this;
 - the output signature after `:` is mandatory and must contain at least one
   identifier;
 - zero inputs remain valid, but zero outputs do not;
 - multiple outputs remain comma-separated and ordered;
 - non-`extern` transformer declarations keep the existing targeted diagnostic;
-- semicolon policy remains unchanged and out of scope for this item; and
-- parser-stage case-class validation for transformer names and outputs remains
-  out of scope unless the existing code cannot be documented coherently without
-  it.
+  and
+- semicolon policy remains unchanged and out of scope for this item.
 
 This is the smallest decision that matches the implemented AST surface,
 existing parser tests, and the already-landed `apply` item behaviour. The
@@ -134,12 +134,12 @@ policy decision, not an isolated grammar-alignment fix.
   add at least one behavioural test containing both a transformer declaration
   and an `apply` item in the same programme.
 
-- Risk: identifier case restrictions are inconsistent between the spec
-  (`UcName`) and the parser/tests (generic identifiers such as `normalise` and
-  `out`). Severity: medium. Likelihood: high. Mitigation: keep this milestone
-  focused on documenting current parser behaviour unless stronger case
-  validation can be added without touching `apply` parsing or broader naming
-  policy.
+- Risk: identifier case restrictions were inconsistent between the spec
+  (`UcName`) and the parser/tests (lowercase names such as `normalise` and
+  `out`). Severity: medium. Likelihood: high. Resolution: the parser now
+  enforces the LcName rule (lowercase letter or underscore start) for
+  transformer names, aligning parser validation with existing test fixtures and
+  `apply` examples.
 
 - Risk: semicolon examples in the spec can distract the implementation into a
   top-level terminator policy change. Severity: medium. Likelihood: medium.
@@ -188,11 +188,12 @@ policy decision, not an isolated grammar-alignment fix.
   statement, so reverting to a no-output transformer grammar would create
   additional downstream ambiguity.
 
-- The syntax spec mismatch is not limited to the colon. Section `5.4` also uses
-  `UcName`, while current parser fixtures and behavioural tests use lower-case
-  transformer names such as `normalise`, `correlate`, and `reserved`. This plan
-  keeps that case-policy question tightly bounded so the output signature
-  decision can land first.
+- The syntax spec mismatch was not limited to the colon. Section `5.4` also used
+  `UcName`, while parser fixtures and behavioural tests use lowercase
+  transformer names such as `normalise`, `correlate`, and `reserved`. The
+  implementation resolved this by enforcing the LcName rule (lowercase letter
+  or underscore start) in the span scanner, aligning the parser with existing
+  test fixtures.
 
 - Existing failure coverage for missing outputs is weak. The tests assert only
   a generic `Unexpected` pattern today, which is too vague for a conformance
@@ -216,11 +217,12 @@ policy decision, not an isolated grammar-alignment fix.
   signatures, not about harmonizing top-level terminators across the whole
   grammar.
 
-- Decision: do not widen this milestone into a general identifier case-policy
-  change unless implementation proves the docs cannot be aligned otherwise.
-  Rationale: lower-case transformer names already appear in tests and related
-  `apply` examples, so tightening case classes would have a larger blast radius
-  than the roadmap item requires.
+- Decision: enforce the LcName rule for transformer names in the parser.
+  Rationale: lowercase transformer names already appear in tests and related
+  `apply` examples, so enforcing this rule aligns the parser with existing
+  fixtures and provides clearer diagnostics. The implementation validates names
+  in `src/parser/span_scanners/transformers.rs` and emits a targeted diagnostic
+  when capitalized names are used.
 
 ## Outcomes & Retrospective
 

--- a/docs/execplans/2-6-5-align-transformer-declaration-grammar.md
+++ b/docs/execplans/2-6-5-align-transformer-declaration-grammar.md
@@ -20,7 +20,7 @@ which contract is real.
 
 After this change, a novice should be able to read one transformer grammar,
 parse a declaration such as
-`extern transformer normalise(input: User): Normalised`, inspect both inputs
+`extern transformer normalize(input: User): Normalized`, inspect both inputs
 and outputs through the Abstract Syntax Tree (AST), and get deterministic
 diagnostics when the required output signature is missing or empty. Success is
 observable when:
@@ -135,7 +135,7 @@ policy decision, not an isolated grammar-alignment fix.
   and an `apply` item in the same programme.
 
 - Risk: identifier case restrictions were inconsistent between the spec
-  (`UcName`) and the parser/tests (lowercase names such as `normalise` and
+  (`UcName`) and the parser/tests (lowercase names such as `normalize` and
   `out`). Severity: medium. Likelihood: high. Resolution: the parser now
   enforces the LcName rule (lowercase letter or underscore start) for
   transformer names, aligning parser validation with existing test fixtures and
@@ -190,7 +190,7 @@ policy decision, not an isolated grammar-alignment fix.
 
 - The syntax spec mismatch was not limited to the colon. Section `5.4` also used
   `UcName`, while parser fixtures and behavioural tests use lowercase
-  transformer names such as `normalise`, `correlate`, and `reserved`. The
+  transformer names such as `normalize`, `correlate`, and `reserved`. The
   implementation resolved this by enforcing the LcName rule (lowercase letter
   or underscore start) in the span scanner, aligning the parser with existing
   test fixtures.

--- a/docs/execplans/2-6-5-align-transformer-declaration-grammar.md
+++ b/docs/execplans/2-6-5-align-transformer-declaration-grammar.md
@@ -28,8 +28,8 @@ observable when:
 - the parser, unit tests, behavioural tests, and active docs all describe the
   same transformer grammar;
 - missing-output and non-`extern` declarations produce stable diagnostics;
-- `make check-fmt`, `make lint`, and `make test` pass after the implementation
-  change; and
+- `make check-fmt`, `make lint`, `make markdownlint`, `make nixie`, and
+  `CI=1 make test` pass after the implementation change; and
 - `docs/roadmap.md` item `2.6.5` is marked done only after those checks
   succeed.
 

--- a/docs/execplans/2-6-5-align-transformer-declaration-grammar.md
+++ b/docs/execplans/2-6-5-align-transformer-declaration-grammar.md
@@ -166,7 +166,7 @@ policy decision, not an isolated grammar-alignment fix.
 - [x] (2026-03-30) Aligned the syntax spec, parser implementation notes,
   conformance register, and roadmap with the mandatory output-signature grammar.
 - [x] (2026-03-30) Ran `make fmt`, `make markdownlint`, `make nixie`,
-  `make check-fmt`, `make lint`, and `CI=1 make test`.
+  `make check-fmt`, `make lint`, and `Continuous Integration (CI)=1 make test`.
 - [x] (2026-03-30) Confirmed the gate results and kept roadmap item `2.6.5`
   marked done.
 
@@ -294,7 +294,7 @@ and recoverably.
   `non-extern transformer`, `missing ':'`, and
   `':' present but no output identifiers`.
 - Keep the span recovery behaviour that skips malformed declarations cleanly so
-  downstream CST construction remains stable.
+  downstream Concrete Syntax Tree (CST) construction remains stable.
 - Preserve successful parsing of existing valid fixtures, including multiple
   outputs and zero inputs.
 - If needed, add a small helper near the scanner or in
@@ -327,8 +327,8 @@ grammar contract.
 Add or update behavioural tests in `tests/` so the public `parse()` entrypoint
 proves the decision, not just the internal unit suites.
 
-- Add a dedicated `tests/transformer_declaration_grammar.rs` file unless an
-  existing behavioural test file is a clearly better home.
+- Add the behavioural coverage to `tests/apply_items.rs`, which is already the
+  canonical parser-boundary home for transformer-plus-`apply` behaviour.
 - Include at least one success case proving that a programme containing a valid
   transformer declaration yields one transformer with the expected outputs.
 - Include at least one failure case proving that a declaration with no output
@@ -378,7 +378,7 @@ After implementation and documentation updates:
      `src/parser/ast/parse_utils/outputs.rs` if it no longer matches the frozen
      contract.
 
-5. Add behavioural tests in `tests/transformer_declaration_grammar.rs`.
+5. Add behavioural tests in `tests/apply_items.rs`.
 
    - One success case.
    - One output-signature failure case.

--- a/docs/execplans/2-6-5-align-transformer-declaration-grammar.md
+++ b/docs/execplans/2-6-5-align-transformer-declaration-grammar.md
@@ -214,8 +214,7 @@ policy decision, not an isolated grammar-alignment fix.
 
 - Decision: keep semicolon policy out of scope for this milestone.
   Rationale: the open conformance item is about declaration shape and output
-  signatures, not about harmonizing top-level terminators across the whole
-  grammar.
+  signatures, not about harmonizing top-level terminators across the grammar.
 
 - Decision: enforce the LcName rule for transformer names in the parser.
   Rationale: lowercase transformer names already appear in tests and related

--- a/docs/execplans/2-6-5-align-transformer-declaration-grammar.md
+++ b/docs/execplans/2-6-5-align-transformer-declaration-grammar.md
@@ -255,13 +255,14 @@ The relevant code and documents are concentrated in a small set of files:
   `docs/parser-conformance-register.md`, `docs/parser-implementation-notes.md`,
   and `docs/ddlint-design.md` carry the active written contract.
 
-The concrete mismatch today is:
+At the start of this work, the concrete mismatch was:
 
 - Spec: `extern transformer UcName(params?);`
 - Code/tests: `extern transformer ident(params?): output(, output)*`
 
-The implementation should resolve that mismatch in code, tests, and docs in one
-atomic change.
+The implementation resolved that mismatch in code, tests, and docs atomically,
+establishing the current contract:
+`extern transformer name(params...): output(, output)*`.
 
 ## Plan of work
 
@@ -403,7 +404,7 @@ set -o pipefail; make markdownlint 2>&1 | tee /tmp/2-6-5-make-markdownlint.log
 set -o pipefail; make nixie 2>&1 | tee /tmp/2-6-5-make-nixie.log
 set -o pipefail; make check-fmt 2>&1 | tee /tmp/2-6-5-make-check-fmt.log
 set -o pipefail; make lint 2>&1 | tee /tmp/2-6-5-make-lint.log
-set -o pipefail; make test 2>&1 | tee /tmp/2-6-5-make-test.log
+set -o pipefail; CI=1 make test 2>&1 | tee /tmp/2-6-5-make-test.log
 ```
 
 Successful completion means all six commands exit with status `0`, the new

--- a/docs/execplans/2-6-5-align-transformer-declaration-grammar.md
+++ b/docs/execplans/2-6-5-align-transformer-declaration-grammar.md
@@ -166,7 +166,8 @@ policy decision, not an isolated grammar-alignment fix.
 - [x] (2026-03-30) Aligned the syntax spec, parser implementation notes,
   conformance register, and roadmap with the mandatory output-signature grammar.
 - [x] (2026-03-30) Ran `make fmt`, `make markdownlint`, `make nixie`,
-  `make check-fmt`, `make lint`, and `Continuous Integration (CI)=1 make test`.
+  `make check-fmt`, `make lint`, and Continuous Integration (CI)
+  `CI=1 make test`.
 - [x] (2026-03-30) Confirmed the gate results and kept roadmap item `2.6.5`
   marked done.
 
@@ -380,9 +381,9 @@ After implementation and documentation updates:
 
 5. Add behavioural tests in `tests/apply_items.rs`.
 
-   - One success case.
-   - One output-signature failure case.
-   - One success case combined with `apply`.
+   - A simple success case.
+   - An output-signature failure example.
+   - A success case demonstrating use with `apply`.
 
 6. Update active documentation.
 

--- a/docs/execplans/2-6-5-align-transformer-declaration-grammar.md
+++ b/docs/execplans/2-6-5-align-transformer-declaration-grammar.md
@@ -5,7 +5,7 @@ This ExecPlan (execution plan) is a living document. The sections
 `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
 proceeds.
 
-Status: DRAFT
+Status: IMPLEMENTED
 
 ## Purpose / big picture
 
@@ -157,14 +157,18 @@ policy decision, not an isolated grammar-alignment fix.
   `Transformer::outputs()`.
 - [x] (2026-03-27) Drafted this ExecPlan in
   `docs/execplans/2-6-5-align-transformer-declaration-grammar.md`.
-- [ ] Update red tests to encode the chosen grammar and deterministic failure
-  messages.
-- [ ] Implement any required parser diagnostic changes in
-  `src/parser/span_scanners/transformers.rs` and related helpers.
-- [ ] Align active documentation and conformance records.
-- [ ] Run `make fmt`, `make markdownlint`, `make nixie`,
-  `make check-fmt`, `make lint`, and `make test`.
-- [ ] Mark roadmap item `2.6.5` done after all checks pass.
+- [x] (2026-03-30) Updated parser unit and behavioural tests to require the
+  transformer-specific missing-output diagnostic for both missing-colon and
+  empty-output forms.
+- [x] (2026-03-30) Implemented transformer-local extern scan recovery so
+  missing or empty output signatures emit one deterministic custom diagnostic
+  instead of a generic `Unexpected` parser failure.
+- [x] (2026-03-30) Aligned the syntax spec, parser implementation notes,
+  conformance register, and roadmap with the mandatory output-signature grammar.
+- [x] (2026-03-30) Ran `make fmt`, `make markdownlint`, `make nixie`,
+  `make check-fmt`, `make lint`, and `CI=1 make test`.
+- [x] (2026-03-30) Confirmed the gate results and kept roadmap item `2.6.5`
+  marked done.
 
 ## Surprises & Discoveries
 
@@ -219,11 +223,13 @@ policy decision, not an isolated grammar-alignment fix.
 
 ## Outcomes & Retrospective
 
-This ExecPlan has been drafted, but implementation has not started. The
-expected outcome is a single documented transformer grammar with targeted
-diagnostics for missing output signatures, backed by unit and behavioural
-tests. The roadmap checkbox must remain open until that implementation lands
-and all validation commands succeed.
+Implementation landed with full validation. The parser, unit tests, behavioural
+tests, syntax spec, conformance register, parser implementation notes, roadmap,
+and this ExecPlan now agree on the transformer contract:
+`extern transformer name(params...): output(, output)*`, with a deterministic
+diagnostic when the output signature is missing or empty. Validation passed via
+`make fmt`, `make markdownlint`, `make nixie`, `make check-fmt`, `make lint`,
+and `CI=1 make test`.
 
 ## Context and orientation
 

--- a/docs/execplans/2-6-5-align-transformer-declaration-grammar.md
+++ b/docs/execplans/2-6-5-align-transformer-declaration-grammar.md
@@ -236,7 +236,7 @@ and `CI=1 make test`.
 
 The relevant code and documents are concentrated in a small set of files:
 
-- `src/parser/span_scanners/transformers.rs` recognises top-level transformer
+- `src/parser/span_scanners/transformers.rs` recognizes top-level transformer
   declarations and already enforces the `extern` requirement plus the current
   colon-output grammar.
 - `src/parser/ast/transformer.rs` exposes `Transformer::name()`,

--- a/docs/execplans/4-1-1-implement-unused-relation-diagnostics.md
+++ b/docs/execplans/4-1-1-implement-unused-relation-diagnostics.md
@@ -14,7 +14,7 @@ correctness catalogue. After this change, `ddlint` exports an `unused-relation`
 lint rule (`UnusedRelationRule`) that callers must explicitly register in a
 `CstRuleStore` before running the `Runner`. Once registered, the rule emits an
 `unused-relation` warning for each declared relation that has no resolved
-read-like uses anywhere in the analysed program.
+read-like uses anywhere in the analyzed program.
 
 For this milestone, "read from" means a resolved relation-position use in a
 rule body, a `for` iterable, or a `for` guard. A relation named in a rule head

--- a/docs/execplans/phase-2-enforce-qualified-call-rule.md
+++ b/docs/execplans/phase-2-enforce-qualified-call-rule.md
@@ -272,7 +272,7 @@ re-run the failed target, then re-run full gates.
 
 ## Artifacts and notes
 
-Keep command logs under `/tmp/ddlint-*.log` and summarise relevant pass/fail
+Keep command logs under `/tmp/ddlint-*.log` and summarize relevant pass/fail
 lines in the implementation handoff. Prefer focused fixture additions over
 large golden files.
 

--- a/docs/parser-conformance-register.md
+++ b/docs/parser-conformance-register.md
@@ -142,12 +142,15 @@ This register tracks parser behaviour against the syntax specification.
 
 - Topic: output signature requirements and transformer-name token class.
 - Current behaviour (code): parser requires output list after `:`
-  and emits a deterministic diagnostic when the signature is missing or empty
+  and emits a deterministic diagnostic when the signature is missing or empty.
+  Transformer names must start with a lowercase letter or underscore; the
+  parser rejects capitalized names (e.g., `Foo`) with a targeted diagnostic
   (`src/parser/span_scanners/transformers.rs`,
   `src/parser/tests/transformers.rs`). Malformed declarations recover by
   skipping to the next newline boundary through shared scanner utilities.
 - Spec/target behaviour: matches section 5.4's extern-only transformer form
-  with a mandatory `:` plus at least one ordered output identifier.
+  with a mandatory `:` plus at least one ordered output identifier, and
+  enforces lowercase-name class for transformer identifiers.
 - Decision status: `implemented`.
 - Roadmap item: `docs/roadmap.md` item `2.6.5`.
 

--- a/docs/parser-conformance-register.md
+++ b/docs/parser-conformance-register.md
@@ -142,16 +142,12 @@ This register tracks parser behaviour against the syntax specification.
 
 - Topic: output signature requirements and transformer-name token class.
 - Current behaviour (code): parser requires output list after `:`
-  (`src/parser/span_scanners/transformers.rs`). Transformer names and output
-  names are parsed through the generic identifier helper, so the parser accepts
-  any non-keyword identifier token rather than enforcing a lowercase-only name
-  class. The required output list is enforced directly in the chumsky grammar
-  via `.at_least(1)`, and malformed declarations recover by skipping to the
-  next newline boundary through shared scanner utilities.
-- Spec/target behaviour: section 5.4 now matches the implementation by
-  requiring `:` plus at least one output identifier, documenting generic
-  identifier acceptance for transformer names, and recording the single-line
-  recovery contract.
+  and emits a deterministic diagnostic when the signature is missing or empty
+  (`src/parser/span_scanners/transformers.rs`,
+  `src/parser/tests/transformers.rs`). Malformed declarations recover by
+  skipping to the next newline boundary through shared scanner utilities.
+- Spec/target behaviour: matches section 5.4's extern-only transformer form
+  with a mandatory `:` plus at least one ordered output identifier.
 - Decision status: `implemented`.
 - Roadmap item: `docs/roadmap.md` item `2.6.5`.
 

--- a/docs/parser-implementation-notes.md
+++ b/docs/parser-implementation-notes.md
@@ -250,7 +250,7 @@ Important invariants:
 - The span scanner keeps non-`extern` rejection separate from the
   output-signature check and emits the targeted diagnostic
   `transformer declarations require ':' followed by at least one output identifier`
-  when the colon or first output identifier is missing.
+   when the colon or first output identifier is missing.
 
 These helpers are shared intentionally to keep declaration parsing consistent
 across top-level constructs.

--- a/docs/parser-implementation-notes.md
+++ b/docs/parser-implementation-notes.md
@@ -250,7 +250,7 @@ Important invariants:
 - The span scanner keeps non-`extern` rejection separate from the
   output-signature check and emits the targeted diagnostic
   `transformer declarations require ':' followed by at least one output identifier`
-   when the colon or first output identifier is missing.
+  when the colon or first output identifier is missing.
 
 These helpers are shared intentionally to keep declaration parsing consistent
 across top-level constructs.

--- a/docs/parser-implementation-notes.md
+++ b/docs/parser-implementation-notes.md
@@ -253,7 +253,7 @@ Important invariants:
 - The span scanner keeps non-`extern` rejection separate from the
   output-signature check and emits the targeted diagnostic
   `transformer declarations require ':' followed by at least one output identifier`
-   when the colon or first output identifier is missing.
+  when the colon or first output identifier is missing.
 
 These helpers are shared intentionally to keep declaration parsing consistent
 across top-level constructs.
@@ -270,7 +270,7 @@ declaration heads.
 
 ## Diagnostics policy
 
-The parser prefers localised, span-precise diagnostics and recovery over hard
+The parser prefers localized, span-precise diagnostics and recovery over hard
 stops. This keeps CST and AST extraction usable in partially invalid files.
 
 Representative diagnostics include:
@@ -280,7 +280,7 @@ Representative diagnostics include:
 - malformed aggregation signatures,
 - invalid transformer declaration forms.
 
-### Centralised diagnostic messages
+### Centralized diagnostic messages
 
 Diagnostic strings that form part of the parser's contract (asserted in tests
 or exposed through `Parsed::errors()`) are defined once in

--- a/docs/parser-implementation-notes.md
+++ b/docs/parser-implementation-notes.md
@@ -270,7 +270,7 @@ declaration heads.
 
 ## Diagnostics policy
 
-The parser prefers localized, span-precise diagnostics and recovery over hard
+The parser prefers localised, span-precise diagnostics and recovery over hard
 stops. This keeps CST and AST extraction usable in partially invalid files.
 
 Representative diagnostics include:
@@ -280,13 +280,41 @@ Representative diagnostics include:
 - malformed aggregation signatures,
 - invalid transformer declaration forms.
 
+### Centralised diagnostic messages
+
+Diagnostic strings that form part of the parser's contract (asserted in tests
+or exposed through `Parsed::errors()`) are defined once in
+`src/parser/error_messages.rs` and re-exported via `src/test_util/mod.rs`.
+Scanner code and test helpers import the same constants, so message text cannot
+drift between production code and assertions.
+
+Constants currently defined:
+
+- `MISSING_OUTPUT_SIGNATURE_ERROR` — emitted when a transformer declaration
+  omits `:` or has no output identifier after it.
+- `CAPITALIZED_TRANSFORMER_NAME_ERROR` — emitted when a transformer name
+  starts with an uppercase letter instead of a lowercase letter or underscore.
+
+Test utilities that match these messages:
+
+- `assert_custom_parse_error_contains(errors, pattern)` — asserts that at
+  least one `SimpleReason::Custom` error contains the normalised `pattern`.
+- `assert_no_custom_parse_error_contains(errors, pattern)` — the negated
+  counterpart; asserts that no custom error contains `pattern`.
+
+Both helpers normalise internal token names to human-readable forms before
+comparison (via `normalise_tokens`), so assertion strings can use either raw
+token names or their human-readable equivalents.
+
 ## File index
 
 - Tokenization and keyword policy: `src/tokenizer.rs`
 - Entry parse orchestration: `src/parser/mod.rs`
 - Pratt parser: `src/parser/expression/pratt.rs`
 - Prefix/infix helpers: `src/parser/expression/*.rs`
+- Centralised diagnostic messages: `src/parser/error_messages.rs`
 - Rule span scanning: `src/parser/span_scanners/rules.rs`
 - Top-level scanners: `src/parser/span_scanners/*.rs`
 - AST wrappers: `src/parser/ast/*.rs`
 - Shared parse utilities: `src/parser/ast/parse_utils/*.rs`
+- Test assertion helpers: `src/test_util/assertions.rs`

--- a/docs/parser-implementation-notes.md
+++ b/docs/parser-implementation-notes.md
@@ -246,7 +246,10 @@ Important invariants:
   the `Index` wrapper exposes `fields()` plus normalized `on_target()` access
   instead of relation/column helpers tied to the old shorthand.
 - Transformer declarations require
-  `extern transformer name(params...): output(, output)*`.
+  `extern transformer <lowercase-name>(params...): output(, output)*`.
+  Transformer identifiers must be lowercase (start with a lowercase letter or
+  underscore); the span scanner in `src/parser/span_scanners/transformers.rs`
+  rejects capitalized names (e.g., `Foo`) as invalid.
 - The span scanner keeps non-`extern` rejection separate from the
   output-signature check and emits the targeted diagnostic
   `transformer declarations require ':' followed by at least one output identifier`

--- a/docs/parser-implementation-notes.md
+++ b/docs/parser-implementation-notes.md
@@ -298,11 +298,11 @@ Constants currently defined:
 Test utilities that match these messages:
 
 - `assert_custom_parse_error_contains(errors, pattern)` — asserts that at
-  least one `SimpleReason::Custom` error contains the normalised `pattern`.
+  least one `SimpleReason::Custom` error contains the normalized `pattern`.
 - `assert_no_custom_parse_error_contains(errors, pattern)` — the negated
   counterpart; asserts that no custom error contains `pattern`.
 
-Both helpers normalise internal token names to human-readable forms before
+Both helpers normalize internal token names to human-readable forms before
 comparison (via `normalise_tokens`), so assertion strings can use either raw
 token names or their human-readable equivalents.
 
@@ -312,7 +312,7 @@ token names or their human-readable equivalents.
 - Entry parse orchestration: `src/parser/mod.rs`
 - Pratt parser: `src/parser/expression/pratt.rs`
 - Prefix/infix helpers: `src/parser/expression/*.rs`
-- Centralised diagnostic messages: `src/parser/error_messages.rs`
+- Centralized diagnostic messages: `src/parser/error_messages.rs`
 - Rule span scanning: `src/parser/span_scanners/rules.rs`
 - Top-level scanners: `src/parser/span_scanners/*.rs`
 - AST wrappers: `src/parser/ast/*.rs`

--- a/docs/parser-implementation-notes.md
+++ b/docs/parser-implementation-notes.md
@@ -245,6 +245,12 @@ Important invariants:
   shorthand `index Name on Relation(columns)` with a targeted diagnostic, and
   the `Index` wrapper exposes `fields()` plus normalized `on_target()` access
   instead of relation/column helpers tied to the old shorthand.
+- Transformer declarations require
+  `extern transformer name(params...): output(, output)*`.
+- The span scanner keeps non-`extern` rejection separate from the
+  output-signature check and emits the targeted diagnostic
+  `transformer declarations require ':' followed by at least one output identifier`
+   when the colon or first output identifier is missing.
 
 These helpers are shared intentionally to keep declaration parsing consistent
 across top-level constructs.

--- a/examples/extern_transformer_decl.dl
+++ b/examples/extern_transformer_decl.dl
@@ -2,9 +2,9 @@
 typedef node_t = u64
 input relation Edge(from: node_t, to: node_t)
 
-extern transformer SCC(Edges: relation[(node_t, node_t)],
+extern transformer scc(edges: relation[(node_t, node_t)],
                        from:  function(e: (node_t, node_t)): node_t,
                        to:    function(e: (node_t, node_t)): node_t)
-    -> (SCCLabels: relation[(node_t, node_t)])
+    : SCCLabels
 
 /* Example usage would be declared elsewhere; declaration alone is valid for parsing. */

--- a/src/parser/error_messages.rs
+++ b/src/parser/error_messages.rs
@@ -7,3 +7,8 @@
 /// output identifier.
 pub const MISSING_OUTPUT_SIGNATURE_ERROR: &str =
     "transformer declarations require ':' followed by at least one output identifier";
+
+/// Diagnostic emitted when a transformer name starts with an uppercase letter
+/// instead of a lowercase letter or underscore.
+pub const CAPITALIZED_TRANSFORMER_NAME_ERROR: &str =
+    "transformer names must start with a lowercase letter or underscore";

--- a/src/parser/error_messages.rs
+++ b/src/parser/error_messages.rs
@@ -1,0 +1,9 @@
+//! Shared parser diagnostic messages.
+//!
+//! Centralizing parser-facing message text keeps scanner code and test helpers
+//! aligned when diagnostics are intentionally part of the parser contract.
+
+/// Diagnostic emitted when a transformer declaration omits `:` or its first
+/// output identifier.
+pub const MISSING_OUTPUT_SIGNATURE_ERROR: &str =
+    "transformer declarations require ':' followed by at least one output identifier";

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -13,6 +13,7 @@ mod lexer_helpers;
 
 mod token_stream;
 
+pub(crate) mod error_messages;
 pub(crate) mod span_utils;
 
 mod span_collector;

--- a/src/parser/span_scanners/tests/mod.rs
+++ b/src/parser/span_scanners/tests/mod.rs
@@ -387,3 +387,4 @@ fn parse_tokens_skips_non_rule_constructs_when_scanning_rules() {
 }
 
 mod attribute_tests;
+mod transformer_tests;

--- a/src/parser/span_scanners/tests/transformer_tests.rs
+++ b/src/parser/span_scanners/tests/transformer_tests.rs
@@ -1,0 +1,152 @@
+//! Tests for the transformer span scanner.
+//!
+//! These exercise `collect_transformer_spans` directly to cover boundary
+//! conditions in the private helper functions: balanced-paren skipping,
+//! identifier validation, error-span computation, and recovery.
+
+use super::super::collect_transformer_spans;
+use crate::parser::error_messages::{
+    CAPITALIZED_TRANSFORMER_NAME_ERROR, MISSING_OUTPUT_SIGNATURE_ERROR,
+};
+use crate::test_util::{
+    assert_custom_parse_error_contains, assert_no_custom_parse_error_contains,
+    assert_no_parse_errors, tokenize,
+};
+use rstest::rstest;
+
+// ── Valid declarations ──────────────────────────────────────────────
+
+#[test]
+fn empty_source_produces_no_spans_or_errors() {
+    let tokens = tokenize("");
+    let (spans, errors) = collect_transformer_spans(&tokens, "");
+    assert!(spans.is_empty());
+    assert_no_parse_errors(&errors);
+}
+
+#[test]
+fn source_without_transformer_produces_no_spans() {
+    let src = "input relation R(x: u32)\n";
+    let tokens = tokenize(src);
+    let (spans, errors) = collect_transformer_spans(&tokens, src);
+    assert!(spans.is_empty());
+    assert_no_parse_errors(&errors);
+}
+
+#[test]
+fn underscore_prefixed_name_is_accepted() {
+    let src = "extern transformer _private(a: T): Out\n";
+    let tokens = tokenize(src);
+    let (spans, errors) = collect_transformer_spans(&tokens, src);
+    assert_eq!(spans.len(), 1);
+    assert_no_parse_errors(&errors);
+}
+
+#[test]
+fn missing_final_newline_still_produces_span() {
+    let src = "extern transformer t(a: T): Out";
+    let tokens = tokenize(src);
+    let (spans, errors) = collect_transformer_spans(&tokens, src);
+    assert_eq!(spans.len(), 1);
+    assert_no_parse_errors(&errors);
+}
+
+#[rstest]
+#[case(
+    "extern transformer t(a: (u32, u32)): Out",
+    1,
+    "nested parens in parameter type"
+)]
+#[case(
+    "extern transformer t(a: Map<K, V>): Out",
+    1,
+    "angle-bracket generic in parameter type"
+)]
+fn nested_constructs_inside_params(
+    #[case] src: &str,
+    #[case] expected_count: usize,
+    #[case] description: &str,
+) {
+    let tokens = tokenize(src);
+    let (spans, errors) = collect_transformer_spans(&tokens, src);
+    assert_eq!(spans.len(), expected_count, "{description}");
+    assert_no_parse_errors(&errors);
+}
+
+#[test]
+fn multiple_transformers_in_one_source() {
+    let src = concat!(
+        "extern transformer a(x: T): Out1\n",
+        "extern transformer b(y: U): Out2\n",
+    );
+    let tokens = tokenize(src);
+    let (spans, errors) = collect_transformer_spans(&tokens, src);
+    assert_eq!(spans.len(), 2);
+    assert_no_parse_errors(&errors);
+}
+
+// ── Invalid names ───────────────────────────────────────────────────
+
+#[test]
+fn capitalized_name_emits_diagnostic_and_no_span() {
+    let src = "extern transformer Foo(a: T): Out\n";
+    let tokens = tokenize(src);
+    let (spans, errors) = collect_transformer_spans(&tokens, src);
+    assert!(spans.is_empty());
+    assert_custom_parse_error_contains(&errors, CAPITALIZED_TRANSFORMER_NAME_ERROR);
+}
+
+// ── Missing output signature ────────────────────────────────────────
+
+#[rstest]
+#[case("extern transformer t(a: T)\n", "missing colon and outputs")]
+#[case(
+    "extern transformer t(a: T):\n",
+    "colon present but no output identifier"
+)]
+fn missing_output_signature_variants(#[case] src: &str, #[case] description: &str) {
+    let tokens = tokenize(src);
+    let (spans, errors) = collect_transformer_spans(&tokens, src);
+    assert!(spans.is_empty(), "{description}: expected no spans");
+    assert_custom_parse_error_contains(&errors, MISSING_OUTPUT_SIGNATURE_ERROR);
+}
+
+// ── Unbalanced parentheses ──────────────────────────────────────────
+
+#[test]
+fn unbalanced_open_paren_produces_error_not_panic() {
+    let src = "extern transformer t(a: T\n";
+    let tokens = tokenize(src);
+    let (spans, errors) = collect_transformer_spans(&tokens, src);
+    assert!(spans.is_empty());
+    assert!(!errors.is_empty(), "expected error for unclosed paren");
+}
+
+// ── Non-extern rejection ────────────────────────────────────────────
+
+#[test]
+fn non_extern_transformer_emits_must_be_extern_error() {
+    let src = "transformer local(a: T): Out\n";
+    let tokens = tokenize(src);
+    let (spans, errors) = collect_transformer_spans(&tokens, src);
+    assert!(spans.is_empty());
+    assert_custom_parse_error_contains(&errors, "must be extern");
+}
+
+// ── Recovery isolation ──────────────────────────────────────────────
+
+#[test]
+fn malformed_declaration_followed_by_valid_one_recovers() {
+    let src = concat!(
+        "extern transformer bad(a: T):\n",
+        "extern transformer good(b: U): Out\n",
+    );
+    let tokens = tokenize(src);
+    let (spans, errors) = collect_transformer_spans(&tokens, src);
+    assert_eq!(spans.len(), 1, "second transformer should still parse");
+    assert!(
+        !errors.is_empty(),
+        "first transformer should produce errors"
+    );
+    assert_no_custom_parse_error_contains(&errors, "must be extern");
+}

--- a/src/parser/span_scanners/transformers.rs
+++ b/src/parser/span_scanners/transformers.rs
@@ -75,6 +75,18 @@ fn handle_extern_transformer(st: &mut State<'_>, span: Span) {
         .map(move |sp: Span| start..sp.end);
     let (res, errs) = st.parse_span(parser, start);
     if let Some(declaration_span) = res {
+        // Validate transformer name is lowercase
+        if let Some(name_span) = extract_transformer_name_span(st, start) {
+            let src = st.stream.src();
+            if let Some(name) = src.get(name_span.clone())
+                && !is_lowercase_ident(name)
+            {
+                st.extra.push(Simple::custom(
+                    name_span,
+                    "transformer names must start with a lowercase letter or underscore",
+                ));
+            }
+        }
         st.stream.skip_until(declaration_span.end);
         st.spans.push(declaration_span);
         st.extra.extend(errs);
@@ -138,6 +150,12 @@ fn missing_output_signature_span(st: &State<'_>, start: usize) -> Option<Span> {
     if !matches_token(tokens, idx, SyntaxKind::T_IDENT) {
         return None;
     }
+    // Validate that the transformer name is lowercase
+    let name_span = tokens.get(idx)?.1.clone();
+    let name = src.get(name_span.clone())?;
+    if !is_lowercase_ident(name) {
+        return None;
+    }
     idx += 1;
     idx = skip_trivia(tokens, idx);
 
@@ -189,13 +207,11 @@ fn skip_balanced_parens(tokens: &[(SyntaxKind, Span)], start: usize) -> Option<(
 
 fn declaration_error_end(
     src: &str,
-    tokens: &[(SyntaxKind, Span)],
-    idx: usize,
+    _tokens: &[(SyntaxKind, Span)],
+    _idx: usize,
     fallback_end: usize,
 ) -> usize {
-    tokens
-        .get(idx)
-        .map_or(fallback_end, |(_, span)| line_end_at(src, span.end))
+    line_end_at(src, fallback_end)
 }
 
 fn line_end_at(src: &str, start: usize) -> usize {
@@ -219,6 +235,39 @@ fn skip_trivia(tokens: &[(SyntaxKind, Span)], mut idx: usize) -> usize {
 
 fn should_stop_skipping_trivia(kind: SyntaxKind) -> bool {
     !matches!(kind, SyntaxKind::T_WHITESPACE | SyntaxKind::T_COMMENT)
+}
+
+fn is_lowercase_ident(ident: &str) -> bool {
+    ident
+        .chars()
+        .next()
+        .is_some_and(|ch| ch == '_' || ch.is_ascii_lowercase())
+}
+
+fn extract_transformer_name_span(st: &State<'_>, start: usize) -> Option<Span> {
+    let tokens = st.stream.tokens();
+    let mut idx = tokens.iter().position(|(_, span)| span.start == start)?;
+
+    // Skip 'extern'
+    if !matches_token(tokens, idx, SyntaxKind::K_EXTERN) {
+        return None;
+    }
+    idx += 1;
+    idx = skip_trivia(tokens, idx);
+
+    // Skip 'transformer'
+    if !matches_token(tokens, idx, SyntaxKind::K_TRANSFORMER) {
+        return None;
+    }
+    idx += 1;
+    idx = skip_trivia(tokens, idx);
+
+    // Return the name identifier span
+    if matches_token(tokens, idx, SyntaxKind::T_IDENT) {
+        tokens.get(idx).map(|(_, span)| span.clone())
+    } else {
+        None
+    }
 }
 
 fn matches_token(tokens: &[(SyntaxKind, Span)], idx: usize, expected: SyntaxKind) -> bool {

--- a/src/parser/span_scanners/transformers.rs
+++ b/src/parser/span_scanners/transformers.rs
@@ -137,9 +137,12 @@ fn is_extern_transformer_start(st: &State<'_>) -> bool {
         .is_some_and(|(kind, _)| *kind == SyntaxKind::K_TRANSFORMER)
 }
 
-fn missing_output_signature_span_unchecked(st: &State<'_>, start: usize) -> Option<Span> {
-    let tokens = st.stream.tokens();
-    let src = st.stream.src();
+/// Skips past the `extern transformer <ident>` prefix, returning the
+/// identifier's span and the index immediately after it (past trivia).
+fn skip_extern_transformer_prefix(
+    tokens: &[(SyntaxKind, Span)],
+    start: usize,
+) -> Option<(Span, usize)> {
     let mut idx = tokens.iter().position(|(_, span)| span.start == start)?;
 
     if !matches_token(tokens, idx, SyntaxKind::K_EXTERN) {
@@ -157,9 +160,17 @@ fn missing_output_signature_span_unchecked(st: &State<'_>, start: usize) -> Opti
     if !matches_token(tokens, idx, SyntaxKind::T_IDENT) {
         return None;
     }
+    let ident_span = tokens.get(idx)?.1.clone();
     idx += 1;
     idx = skip_trivia(tokens, idx);
 
+    Some((ident_span, idx))
+}
+
+fn missing_output_signature_span_unchecked(st: &State<'_>, start: usize) -> Option<Span> {
+    let tokens = st.stream.tokens();
+    let src = st.stream.src();
+    let (_ident_span, idx) = skip_extern_transformer_prefix(tokens, start)?;
     missing_output_signature_span_impl(src, tokens, idx, start)
 }
 
@@ -180,7 +191,7 @@ fn missing_output_signature_span_impl(
     idx = skip_trivia(tokens, next_idx);
 
     if !matches_token(tokens, idx, SyntaxKind::T_COLON) {
-        return Some(start..declaration_error_end(src, tokens, idx, decl_end));
+        return Some(start..declaration_error_end(src, decl_end));
     }
     let colon_end = tokens.get(idx).map_or(decl_end, |(_, span)| span.end);
     idx += 1;
@@ -189,7 +200,7 @@ fn missing_output_signature_span_impl(
     if matches_token(tokens, idx, SyntaxKind::T_IDENT) {
         None
     } else {
-        Some(start..declaration_error_end(src, tokens, idx, colon_end))
+        Some(start..declaration_error_end(src, colon_end))
     }
 }
 
@@ -215,12 +226,7 @@ fn skip_balanced_parens(tokens: &[(SyntaxKind, Span)], start: usize) -> Option<(
     None
 }
 
-fn declaration_error_end(
-    src: &str,
-    _tokens: &[(SyntaxKind, Span)],
-    _idx: usize,
-    fallback_end: usize,
-) -> usize {
+fn declaration_error_end(src: &str, fallback_end: usize) -> usize {
     line_end_at(src, fallback_end)
 }
 
@@ -256,28 +262,8 @@ fn is_lowercase_ident(ident: &str) -> bool {
 
 fn extract_transformer_name_span(st: &State<'_>, start: usize) -> Option<Span> {
     let tokens = st.stream.tokens();
-    let mut idx = tokens.iter().position(|(_, span)| span.start == start)?;
-
-    // Skip 'extern'
-    if !matches_token(tokens, idx, SyntaxKind::K_EXTERN) {
-        return None;
-    }
-    idx += 1;
-    idx = skip_trivia(tokens, idx);
-
-    // Skip 'transformer'
-    if !matches_token(tokens, idx, SyntaxKind::K_TRANSFORMER) {
-        return None;
-    }
-    idx += 1;
-    idx = skip_trivia(tokens, idx);
-
-    // Return the name identifier span
-    if matches_token(tokens, idx, SyntaxKind::T_IDENT) {
-        tokens.get(idx).map(|(_, span)| span.clone())
-    } else {
-        None
-    }
+    let (ident_span, _idx) = skip_extern_transformer_prefix(tokens, start)?;
+    Some(ident_span)
 }
 
 fn matches_token(tokens: &[(SyntaxKind, Span)], idx: usize, expected: SyntaxKind) -> bool {

--- a/src/parser/span_scanners/transformers.rs
+++ b/src/parser/span_scanners/transformers.rs
@@ -8,9 +8,11 @@ use chumsky::prelude::*;
 use crate::parser::lexer_helpers::{balanced_block, ident, inline_ws};
 use crate::{Span, SyntaxKind};
 
-use super::utils::{State, collect_extern_declarations_with_rule};
+use super::utils::State;
 
 const NON_EXTERN_TRANSFORMER_ERROR: &str = "transformer declarations must be extern";
+const MISSING_OUTPUT_SIGNATURE_ERROR: &str =
+    "transformer declarations require ':' followed by at least one output identifier";
 
 fn transformer_decl() -> impl Parser<SyntaxKind, Span, Error = Simple<SyntaxKind>> {
     let ws = inline_ws().repeated();
@@ -37,13 +39,54 @@ pub(crate) fn collect_transformer_spans(
     tokens: &[(SyntaxKind, Span)],
     src: &str,
 ) -> (Vec<Span>, Vec<Simple<SyntaxKind>>) {
-    collect_extern_declarations_with_rule(
-        tokens,
-        src,
-        SyntaxKind::K_TRANSFORMER,
-        transformer_decl,
-        handle_non_extern_transformer,
-    )
+    let mut st: State<'_> = State::new(tokens, src, Vec::new());
+
+    while let Some(&(token_kind, ref span_ref)) = st.stream.peek() {
+        let span = span_ref.clone();
+        if token_kind == SyntaxKind::K_EXTERN {
+            handle_extern_transformer(&mut st, span);
+        } else if token_kind == SyntaxKind::K_TRANSFORMER {
+            handle_non_extern_transformer(&mut st, span);
+        } else {
+            st.stream.advance();
+        }
+    }
+
+    st.into_parts()
+}
+
+fn handle_extern_transformer(st: &mut State<'_>, span: Span) {
+    let is_transformer_decl = st
+        .stream
+        .peek_after_ws_inline()
+        .is_some_and(|(kind, _)| *kind == SyntaxKind::K_TRANSFORMER);
+    if !is_transformer_decl {
+        st.skip_line();
+        return;
+    }
+
+    let ws = inline_ws().repeated();
+    let start = span.start;
+    let parser = just(SyntaxKind::K_EXTERN)
+        .padded_by(ws.clone())
+        .ignore_then(transformer_decl())
+        .map(move |sp: Span| start..sp.end);
+    let (res, errs) = st.parse_span(parser, start);
+    if let Some(ref declaration_span) = res {
+        st.stream.skip_until(declaration_span.end);
+        st.spans.push(declaration_span.clone());
+        st.extra.extend(errs);
+        return;
+    }
+
+    let error_span = start..st.stream.line_end(st.stream.cursor());
+    st.skip_line();
+    if has_missing_output_signature(st, start, error_span.end) {
+        st.extra
+            .push(Simple::custom(error_span, MISSING_OUTPUT_SIGNATURE_ERROR));
+    } else {
+        st.extra.extend(errs);
+    }
 }
 
 fn handle_non_extern_transformer(st: &mut State<'_>, span: Span) {
@@ -66,4 +109,97 @@ fn push_non_extern_transformer_error(
 ) {
     extra.extend(errs);
     extra.push(Simple::custom(span, NON_EXTERN_TRANSFORMER_ERROR));
+}
+
+fn has_missing_output_signature(st: &State<'_>, start: usize, line_end: usize) -> bool {
+    let tokens = st.stream.tokens();
+    let src = st.stream.src();
+    let Some(mut idx) = tokens.iter().position(|(_, span)| span.start == start) else {
+        return false;
+    };
+
+    if !matches_token(tokens, idx, SyntaxKind::K_EXTERN) {
+        return false;
+    }
+    idx += 1;
+    idx = skip_inline_trivia(tokens, src, idx, line_end);
+
+    if !matches_token(tokens, idx, SyntaxKind::K_TRANSFORMER) {
+        return false;
+    }
+    idx += 1;
+    idx = skip_inline_trivia(tokens, src, idx, line_end);
+
+    if !matches_token(tokens, idx, SyntaxKind::T_IDENT) {
+        return false;
+    }
+    idx += 1;
+    idx = skip_inline_trivia(tokens, src, idx, line_end);
+
+    let Some(next_idx) = skip_balanced_parens(tokens, idx, line_end) else {
+        return false;
+    };
+    idx = skip_inline_trivia(tokens, src, next_idx, line_end);
+
+    if !matches_token(tokens, idx, SyntaxKind::T_COLON) {
+        return true;
+    }
+    idx += 1;
+    idx = skip_inline_trivia(tokens, src, idx, line_end);
+
+    !matches_token(tokens, idx, SyntaxKind::T_IDENT)
+}
+
+fn skip_balanced_parens(
+    tokens: &[(SyntaxKind, Span)],
+    start: usize,
+    line_end: usize,
+) -> Option<usize> {
+    if !matches_token(tokens, start, SyntaxKind::T_LPAREN) {
+        return None;
+    }
+
+    let mut depth = 0usize;
+    for (idx, (kind, span)) in tokens.iter().enumerate().skip(start) {
+        if span.start >= line_end {
+            return None;
+        }
+
+        match kind {
+            SyntaxKind::T_LPAREN => depth += 1,
+            SyntaxKind::T_RPAREN => {
+                depth = depth.checked_sub(1)?;
+                if depth == 0 {
+                    return Some(idx + 1);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    None
+}
+
+fn skip_inline_trivia(
+    tokens: &[(SyntaxKind, Span)],
+    src: &str,
+    mut idx: usize,
+    line_end: usize,
+) -> usize {
+    while let Some((kind, span)) = tokens.get(idx) {
+        if span.start >= line_end
+            || !matches!(kind, SyntaxKind::T_WHITESPACE | SyntaxKind::T_COMMENT)
+            || src
+                .get(span.clone())
+                .is_some_and(|text| text.contains('\n'))
+        {
+            break;
+        }
+        idx += 1;
+    }
+    idx
+}
+
+fn matches_token(tokens: &[(SyntaxKind, Span)], idx: usize, expected: SyntaxKind) -> bool {
+    tokens.get(idx).is_some_and(|(kind, _)| *kind == expected)
 }

--- a/src/parser/span_scanners/transformers.rs
+++ b/src/parser/span_scanners/transformers.rs
@@ -111,6 +111,7 @@ fn handle_extern_transformer(st: &mut State<'_>, span: Span) {
     if let Some(error_span) = missing_output_signature_span_unchecked(st, start) {
         st.extra
             .push(Simple::custom(error_span, MISSING_OUTPUT_SIGNATURE_ERROR));
+        return;
     }
 
     st.extra.extend(errs);

--- a/src/parser/span_scanners/transformers.rs
+++ b/src/parser/span_scanners/transformers.rs
@@ -61,6 +61,22 @@ pub(crate) fn collect_transformer_spans(
     st.into_parts()
 }
 
+/// Validates that the transformer name starting at `start` begins with a
+/// lowercase letter or underscore, emitting a targeted diagnostic if not.
+fn push_invalid_name_diagnostic_if_needed(st: &mut State<'_>, start: usize) {
+    let Some(name_span) = extract_transformer_name_span(st, start) else {
+        return;
+    };
+    if let Some(name) = st.stream.src().get(name_span.clone())
+        && !is_lowercase_ident(name)
+    {
+        st.extra.push(Simple::custom(
+            name_span,
+            "transformer names must start with a lowercase letter or underscore",
+        ));
+    }
+}
+
 fn handle_extern_transformer(st: &mut State<'_>, span: Span) {
     if !is_extern_transformer_start(st) {
         st.skip_line();
@@ -75,18 +91,7 @@ fn handle_extern_transformer(st: &mut State<'_>, span: Span) {
         .map(move |sp: Span| start..sp.end);
     let (res, errs) = st.parse_span(parser, start);
     if let Some(declaration_span) = res {
-        // Validate transformer name is lowercase
-        if let Some(name_span) = extract_transformer_name_span(st, start) {
-            let src = st.stream.src();
-            if let Some(name) = src.get(name_span.clone())
-                && !is_lowercase_ident(name)
-            {
-                st.extra.push(Simple::custom(
-                    name_span,
-                    "transformer names must start with a lowercase letter or underscore",
-                ));
-            }
-        }
+        push_invalid_name_diagnostic_if_needed(st, start);
         st.stream.skip_until(declaration_span.end);
         st.spans.push(declaration_span);
         st.extra.extend(errs);
@@ -94,27 +99,13 @@ fn handle_extern_transformer(st: &mut State<'_>, span: Span) {
     }
 
     st.skip_line();
+    push_invalid_name_diagnostic_if_needed(st, start);
 
-    // Check for lowercase name violation
-    if let Some(name_span) = extract_transformer_name_span(st, start) {
-        let src = st.stream.src();
-        if let Some(name) = src.get(name_span.clone())
-            && !is_lowercase_ident(name)
-        {
-            st.extra.push(Simple::custom(
-                name_span,
-                "transformer names must start with a lowercase letter or underscore",
-            ));
-        }
-    }
-
-    // Check for missing output signature
     if let Some(error_span) = missing_output_signature_span_unchecked(st, start) {
         st.extra
             .push(Simple::custom(error_span, MISSING_OUTPUT_SIGNATURE_ERROR));
     }
 
-    // Always extend with other parse errors
     st.extra.extend(errs);
 }
 

--- a/src/parser/span_scanners/transformers.rs
+++ b/src/parser/span_scanners/transformers.rs
@@ -208,8 +208,8 @@ fn line_end_at(src: &str, start: usize) -> usize {
 }
 
 fn skip_trivia(tokens: &[(SyntaxKind, Span)], mut idx: usize) -> usize {
-    while let Some((kind, span)) = tokens.get(idx) {
-        if should_stop_skipping_trivia(*kind, span) {
+    while let Some((kind, _span)) = tokens.get(idx) {
+        if should_stop_skipping_trivia(*kind) {
             break;
         }
         idx += 1;
@@ -217,7 +217,7 @@ fn skip_trivia(tokens: &[(SyntaxKind, Span)], mut idx: usize) -> usize {
     idx
 }
 
-fn should_stop_skipping_trivia(kind: SyntaxKind, _span: &Span) -> bool {
+fn should_stop_skipping_trivia(kind: SyntaxKind) -> bool {
     !matches!(kind, SyntaxKind::T_WHITESPACE | SyntaxKind::T_COMMENT)
 }
 

--- a/src/parser/span_scanners/transformers.rs
+++ b/src/parser/span_scanners/transformers.rs
@@ -109,6 +109,7 @@ fn handle_extern_transformer(st: &mut State<'_>, span: Span) {
     push_invalid_name_diagnostic_if_needed(st, start);
 
     if let Some(error_span) = missing_output_signature_span_unchecked(st, start) {
+        st.stream.skip_until(error_span.end);
         st.extra
             .push(Simple::custom(error_span, MISSING_OUTPUT_SIGNATURE_ERROR));
         return;

--- a/src/parser/span_scanners/transformers.rs
+++ b/src/parser/span_scanners/transformers.rs
@@ -49,8 +49,8 @@ pub(crate) fn collect_transformer_spans(
 ) -> (Vec<Span>, Vec<Simple<SyntaxKind>>) {
     let mut st: State<'_> = State::new(tokens, src, Vec::new());
 
-    while let Some(&(token_kind, ref span_ref)) = st.stream.peek() {
-        let span = span_ref.clone();
+    while let Some(&(token_kind, ref span)) = st.stream.peek() {
+        let span = span.clone();
         if token_kind == SyntaxKind::K_EXTERN {
             handle_extern_transformer(&mut st, span);
         } else if token_kind == SyntaxKind::K_TRANSFORMER {
@@ -197,13 +197,16 @@ fn missing_output_signature_span_impl(
     mut idx: usize,
     start: usize,
 ) -> Option<Span> {
-    // The recovery scan mirrors the declaration prefix exactly:
-    // `extern transformer <ident>(...)`.
+    // The recovery scan mirrors the declaration prefix: `extern transformer <ident>(...)`.
     //
-    // It intentionally tolerates multiline trivia because the parser accepts
-    // newline-separated parameter lists. If the parameter list itself is
-    // malformed, we fall back to the original parser errors instead of
-    // reclassifying the failure as "missing output signature".
+    // Note: skip_extern_transformer_prefix() uses skip_trivia() between prefix tokens
+    // (allowing multiline trivia), while the real parser uses inline_ws(). This is a
+    // deliberate trade-off for simpler recovery logic: the scanner may accept some
+    // constructs the parser rejects, but such cases still produce parser errors.
+    // Multiline trivia is valid inside balanced_block (parameter lists), so parameter
+    // list recovery remains correct. If the parameter list itself is malformed, we
+    // fall back to the original parser errors instead of reclassifying as "missing
+    // output signature".
     let (next_idx, decl_end) = skip_balanced_parens(tokens, idx)?;
     idx = skip_trivia(tokens, next_idx);
 

--- a/src/parser/span_scanners/transformers.rs
+++ b/src/parser/span_scanners/transformers.rs
@@ -63,9 +63,10 @@ pub(crate) fn collect_transformer_spans(
 
 /// Validates that the transformer name starting at `start` begins with a
 /// lowercase letter or underscore, emitting a targeted diagnostic if not.
-fn push_invalid_name_diagnostic_if_needed(st: &mut State<'_>, start: usize) {
+/// Returns `true` if the name is valid, `false` otherwise.
+fn push_invalid_name_diagnostic_if_needed(st: &mut State<'_>, start: usize) -> bool {
     let Some(name_span) = extract_transformer_name_span(st, start) else {
-        return;
+        return true;
     };
     if let Some(name) = st.stream.src().get(name_span.clone())
         && !is_lowercase_ident(name)
@@ -74,7 +75,9 @@ fn push_invalid_name_diagnostic_if_needed(st: &mut State<'_>, start: usize) {
             name_span,
             "transformer names must start with a lowercase letter or underscore",
         ));
+        return false;
     }
+    true
 }
 
 fn handle_extern_transformer(st: &mut State<'_>, span: Span) {
@@ -91,9 +94,11 @@ fn handle_extern_transformer(st: &mut State<'_>, span: Span) {
         .map(move |sp: Span| start..sp.end);
     let (res, errs) = st.parse_span(parser, start);
     if let Some(declaration_span) = res {
-        push_invalid_name_diagnostic_if_needed(st, start);
+        let name_valid = push_invalid_name_diagnostic_if_needed(st, start);
         st.stream.skip_until(declaration_span.end);
-        st.spans.push(declaration_span);
+        if name_valid {
+            st.spans.push(declaration_span);
+        }
         st.extra.extend(errs);
         return;
     }

--- a/src/parser/span_scanners/transformers.rs
+++ b/src/parser/span_scanners/transformers.rs
@@ -6,7 +6,9 @@
 
 use chumsky::prelude::*;
 
-use crate::parser::error_messages::MISSING_OUTPUT_SIGNATURE_ERROR;
+use crate::parser::error_messages::{
+    CAPITALIZED_TRANSFORMER_NAME_ERROR, MISSING_OUTPUT_SIGNATURE_ERROR,
+};
 use crate::parser::lexer_helpers::{balanced_block, ident, inline_ws};
 use crate::{Span, SyntaxKind};
 
@@ -73,7 +75,7 @@ fn push_invalid_name_diagnostic_if_needed(st: &mut State<'_>, start: usize) -> b
     {
         st.extra.push(Simple::custom(
             name_span,
-            "transformer names must start with a lowercase letter or underscore",
+            CAPITALIZED_TRANSFORMER_NAME_ERROR,
         ));
         return false;
     }

--- a/src/parser/span_scanners/transformers.rs
+++ b/src/parser/span_scanners/transformers.rs
@@ -1,18 +1,18 @@
 //! Scanner for transformer declarations.
 //!
-//! Parses transformer definitions, delegating shared extern handling to the
-//! utilities module.
+//! This scanner owns transformer-specific recovery, including the targeted
+//! missing-output diagnostic for malformed `extern transformer` declarations.
+//! It imports only [`State`] from the shared scanner utilities.
 
 use chumsky::prelude::*;
 
+use crate::parser::error_messages::MISSING_OUTPUT_SIGNATURE_ERROR;
 use crate::parser::lexer_helpers::{balanced_block, ident, inline_ws};
 use crate::{Span, SyntaxKind};
 
 use super::utils::State;
 
 const NON_EXTERN_TRANSFORMER_ERROR: &str = "transformer declarations must be extern";
-const MISSING_OUTPUT_SIGNATURE_ERROR: &str =
-    "transformer declarations require ':' followed by at least one output identifier";
 
 fn transformer_decl() -> impl Parser<SyntaxKind, Span, Error = Simple<SyntaxKind>> {
     let ws = inline_ws().repeated();
@@ -35,6 +35,12 @@ fn transformer_decl() -> impl Parser<SyntaxKind, Span, Error = Simple<SyntaxKind
         .map_with_span(|_, sp: Span| sp)
 }
 
+/// Collect transformer declaration spans and related parse errors.
+///
+/// `tokens` is the tokenized source stream, and `src` is the backing source
+/// text used for span slicing. The returned tuple contains the collected
+/// transformer spans plus any `Simple<SyntaxKind>` diagnostics raised while
+/// scanning malformed declarations.
 pub(crate) fn collect_transformer_spans(
     tokens: &[(SyntaxKind, Span)],
     src: &str,
@@ -56,11 +62,7 @@ pub(crate) fn collect_transformer_spans(
 }
 
 fn handle_extern_transformer(st: &mut State<'_>, span: Span) {
-    let is_transformer_decl = st
-        .stream
-        .peek_after_ws_inline()
-        .is_some_and(|(kind, _)| *kind == SyntaxKind::K_TRANSFORMER);
-    if !is_transformer_decl {
+    if !is_extern_transformer_start(st) {
         st.skip_line();
         return;
     }
@@ -68,7 +70,7 @@ fn handle_extern_transformer(st: &mut State<'_>, span: Span) {
     let ws = inline_ws().repeated();
     let start = span.start;
     let parser = just(SyntaxKind::K_EXTERN)
-        .padded_by(ws.clone())
+        .padded_by(ws)
         .ignore_then(transformer_decl())
         .map(move |sp: Span| start..sp.end);
     let (res, errs) = st.parse_span(parser, start);
@@ -79,9 +81,8 @@ fn handle_extern_transformer(st: &mut State<'_>, span: Span) {
         return;
     }
 
-    let error_span = start..st.stream.line_end(st.stream.cursor());
     st.skip_line();
-    if has_missing_output_signature(st, start, error_span.end) {
+    if let Some(error_span) = missing_output_signature_span(st, start) {
         st.extra
             .push(Simple::custom(error_span, MISSING_OUTPUT_SIGNATURE_ERROR));
     } else {
@@ -111,66 +112,72 @@ fn push_non_extern_transformer_error(
     extra.push(Simple::custom(span, NON_EXTERN_TRANSFORMER_ERROR));
 }
 
-fn has_missing_output_signature(st: &State<'_>, start: usize, line_end: usize) -> bool {
-    let tokens = st.stream.tokens();
-    let src = st.stream.src();
-    let Some(mut idx) = tokens.iter().position(|(_, span)| span.start == start) else {
-        return false;
-    };
-
-    if !matches_token(tokens, idx, SyntaxKind::K_EXTERN) {
-        return false;
-    }
-    idx += 1;
-    idx = skip_inline_trivia(tokens, src, idx, line_end);
-
-    if !matches_token(tokens, idx, SyntaxKind::K_TRANSFORMER) {
-        return false;
-    }
-    idx += 1;
-    idx = skip_inline_trivia(tokens, src, idx, line_end);
-
-    if !matches_token(tokens, idx, SyntaxKind::T_IDENT) {
-        return false;
-    }
-    idx += 1;
-    idx = skip_inline_trivia(tokens, src, idx, line_end);
-
-    let Some(next_idx) = skip_balanced_parens(tokens, idx, line_end) else {
-        return false;
-    };
-    idx = skip_inline_trivia(tokens, src, next_idx, line_end);
-
-    if !matches_token(tokens, idx, SyntaxKind::T_COLON) {
-        return true;
-    }
-    idx += 1;
-    idx = skip_inline_trivia(tokens, src, idx, line_end);
-
-    !matches_token(tokens, idx, SyntaxKind::T_IDENT)
+fn is_extern_transformer_start(st: &State<'_>) -> bool {
+    st.stream
+        .peek_after_ws_inline()
+        .is_some_and(|(kind, _)| *kind == SyntaxKind::K_TRANSFORMER)
 }
 
-fn skip_balanced_parens(
-    tokens: &[(SyntaxKind, Span)],
-    start: usize,
-    line_end: usize,
-) -> Option<usize> {
+fn missing_output_signature_span(st: &State<'_>, start: usize) -> Option<Span> {
+    let tokens = st.stream.tokens();
+    let src = st.stream.src();
+    let mut idx = tokens.iter().position(|(_, span)| span.start == start)?;
+
+    if !matches_token(tokens, idx, SyntaxKind::K_EXTERN) {
+        return None;
+    }
+    idx += 1;
+    idx = skip_trivia(tokens, idx);
+
+    if !matches_token(tokens, idx, SyntaxKind::K_TRANSFORMER) {
+        return None;
+    }
+    idx += 1;
+    idx = skip_trivia(tokens, idx);
+
+    if !matches_token(tokens, idx, SyntaxKind::T_IDENT) {
+        return None;
+    }
+    idx += 1;
+    idx = skip_trivia(tokens, idx);
+
+    // The recovery scan mirrors the declaration prefix exactly:
+    // `extern transformer <ident>(...)`.
+    //
+    // It intentionally tolerates multiline trivia because the parser accepts
+    // newline-separated parameter lists. If the parameter list itself is
+    // malformed, we fall back to the original parser errors instead of
+    // reclassifying the failure as "missing output signature".
+    let (next_idx, decl_end) = skip_balanced_parens(tokens, idx)?;
+    idx = skip_trivia(tokens, next_idx);
+
+    if !matches_token(tokens, idx, SyntaxKind::T_COLON) {
+        return Some(start..declaration_error_end(src, tokens, idx, decl_end));
+    }
+    let colon_end = tokens.get(idx).map_or(decl_end, |(_, span)| span.end);
+    idx += 1;
+    idx = skip_trivia(tokens, idx);
+
+    if matches_token(tokens, idx, SyntaxKind::T_IDENT) {
+        None
+    } else {
+        Some(start..declaration_error_end(src, tokens, idx, colon_end))
+    }
+}
+
+fn skip_balanced_parens(tokens: &[(SyntaxKind, Span)], start: usize) -> Option<(usize, usize)> {
     if !matches_token(tokens, start, SyntaxKind::T_LPAREN) {
         return None;
     }
 
     let mut depth = 0usize;
     for (idx, (kind, span)) in tokens.iter().enumerate().skip(start) {
-        if span.start >= line_end {
-            return None;
-        }
-
         match kind {
             SyntaxKind::T_LPAREN => depth += 1,
             SyntaxKind::T_RPAREN => {
                 depth = depth.checked_sub(1)?;
                 if depth == 0 {
-                    return Some(idx + 1);
+                    return Some((idx + 1, span.end));
                 }
             }
             _ => {}
@@ -180,24 +187,38 @@ fn skip_balanced_parens(
     None
 }
 
-fn skip_inline_trivia(
-    tokens: &[(SyntaxKind, Span)],
+fn declaration_error_end(
     src: &str,
-    mut idx: usize,
-    line_end: usize,
+    tokens: &[(SyntaxKind, Span)],
+    idx: usize,
+    fallback_end: usize,
 ) -> usize {
+    tokens.get(idx).map_or(fallback_end, |(_, span)| {
+        span.end.max(line_end_at(src, span.end))
+    })
+}
+
+fn line_end_at(src: &str, start: usize) -> usize {
+    src.as_bytes()
+        .iter()
+        .enumerate()
+        .skip(start)
+        .find_map(|(idx, byte)| (*byte == b'\n').then_some(idx + 1))
+        .unwrap_or(src.len())
+}
+
+fn skip_trivia(tokens: &[(SyntaxKind, Span)], mut idx: usize) -> usize {
     while let Some((kind, span)) = tokens.get(idx) {
-        if span.start >= line_end
-            || !matches!(kind, SyntaxKind::T_WHITESPACE | SyntaxKind::T_COMMENT)
-            || src
-                .get(span.clone())
-                .is_some_and(|text| text.contains('\n'))
-        {
+        if should_stop_skipping_trivia(*kind, span) {
             break;
         }
         idx += 1;
     }
     idx
+}
+
+fn should_stop_skipping_trivia(kind: SyntaxKind, _span: &Span) -> bool {
+    !matches!(kind, SyntaxKind::T_WHITESPACE | SyntaxKind::T_COMMENT)
 }
 
 fn matches_token(tokens: &[(SyntaxKind, Span)], idx: usize, expected: SyntaxKind) -> bool {

--- a/src/parser/span_scanners/transformers.rs
+++ b/src/parser/span_scanners/transformers.rs
@@ -74,9 +74,9 @@ fn handle_extern_transformer(st: &mut State<'_>, span: Span) {
         .ignore_then(transformer_decl())
         .map(move |sp: Span| start..sp.end);
     let (res, errs) = st.parse_span(parser, start);
-    if let Some(ref declaration_span) = res {
+    if let Some(declaration_span) = res {
         st.stream.skip_until(declaration_span.end);
-        st.spans.push(declaration_span.clone());
+        st.spans.push(declaration_span);
         st.extra.extend(errs);
         return;
     }
@@ -193,9 +193,9 @@ fn declaration_error_end(
     idx: usize,
     fallback_end: usize,
 ) -> usize {
-    tokens.get(idx).map_or(fallback_end, |(_, span)| {
-        span.end.max(line_end_at(src, span.end))
-    })
+    tokens
+        .get(idx)
+        .map_or(fallback_end, |(_, span)| line_end_at(src, span.end))
 }
 
 fn line_end_at(src: &str, start: usize) -> usize {

--- a/src/parser/span_scanners/transformers.rs
+++ b/src/parser/span_scanners/transformers.rs
@@ -94,12 +94,28 @@ fn handle_extern_transformer(st: &mut State<'_>, span: Span) {
     }
 
     st.skip_line();
-    if let Some(error_span) = missing_output_signature_span(st, start) {
+
+    // Check for lowercase name violation
+    if let Some(name_span) = extract_transformer_name_span(st, start) {
+        let src = st.stream.src();
+        if let Some(name) = src.get(name_span.clone())
+            && !is_lowercase_ident(name)
+        {
+            st.extra.push(Simple::custom(
+                name_span,
+                "transformer names must start with a lowercase letter or underscore",
+            ));
+        }
+    }
+
+    // Check for missing output signature
+    if let Some(error_span) = missing_output_signature_span_unchecked(st, start) {
         st.extra
             .push(Simple::custom(error_span, MISSING_OUTPUT_SIGNATURE_ERROR));
-    } else {
-        st.extra.extend(errs);
     }
+
+    // Always extend with other parse errors
+    st.extra.extend(errs);
 }
 
 fn handle_non_extern_transformer(st: &mut State<'_>, span: Span) {
@@ -130,7 +146,7 @@ fn is_extern_transformer_start(st: &State<'_>) -> bool {
         .is_some_and(|(kind, _)| *kind == SyntaxKind::K_TRANSFORMER)
 }
 
-fn missing_output_signature_span(st: &State<'_>, start: usize) -> Option<Span> {
+fn missing_output_signature_span_unchecked(st: &State<'_>, start: usize) -> Option<Span> {
     let tokens = st.stream.tokens();
     let src = st.stream.src();
     let mut idx = tokens.iter().position(|(_, span)| span.start == start)?;
@@ -150,15 +166,18 @@ fn missing_output_signature_span(st: &State<'_>, start: usize) -> Option<Span> {
     if !matches_token(tokens, idx, SyntaxKind::T_IDENT) {
         return None;
     }
-    // Validate that the transformer name is lowercase
-    let name_span = tokens.get(idx)?.1.clone();
-    let name = src.get(name_span.clone())?;
-    if !is_lowercase_ident(name) {
-        return None;
-    }
     idx += 1;
     idx = skip_trivia(tokens, idx);
 
+    missing_output_signature_span_impl(src, tokens, idx, start)
+}
+
+fn missing_output_signature_span_impl(
+    src: &str,
+    tokens: &[(SyntaxKind, Span)],
+    mut idx: usize,
+    start: usize,
+) -> Option<Span> {
     // The recovery scan mirrors the declaration prefix exactly:
     // `extern transformer <ident>(...)`.
     //

--- a/src/parser/span_scanners/transformers.rs
+++ b/src/parser/span_scanners/transformers.rs
@@ -105,7 +105,6 @@ fn handle_extern_transformer(st: &mut State<'_>, span: Span) {
         return;
     }
 
-    st.skip_line();
     push_invalid_name_diagnostic_if_needed(st, start);
 
     if let Some(error_span) = missing_output_signature_span_unchecked(st, start) {
@@ -115,6 +114,15 @@ fn handle_extern_transformer(st: &mut State<'_>, span: Span) {
         return;
     }
 
+    // For other parse failures, skip past all tokens involved in the error.
+    // Use the maximum span end from parser errors to avoid leaving the cursor
+    // in the middle of a multiline declaration.
+    let max_error_end = errs
+        .iter()
+        .map(|e| e.span().end)
+        .max()
+        .unwrap_or_else(|| st.stream.line_end(st.stream.cursor()));
+    st.stream.skip_until(max_error_end);
     st.extra.extend(errs);
 }
 

--- a/src/parser/span_scanners/utils.rs
+++ b/src/parser/span_scanners/utils.rs
@@ -6,7 +6,6 @@
 
 use chumsky::prelude::*;
 
-use crate::parser::lexer_helpers::inline_ws;
 use crate::parser::span_collector::SpanCollector;
 use crate::{Span, SyntaxKind};
 
@@ -55,58 +54,4 @@ where
     }
     st.extra.extend(errs.clone());
     (res, errs)
-}
-
-/// Collect spans for declarations that must be prefixed by `extern`.
-///
-/// The helper scans the token stream for `extern` declarations, recording
-/// spans and parse errors via `parse_and_record`. Any non-extern occurrence of
-/// `kind` is delegated to `on_non_extern` so callers can inject additional
-/// diagnostics or recovery behaviour.
-pub(crate) fn collect_extern_declarations_with_rule<P, FDecl, FNonExtern>(
-    tokens: &[(SyntaxKind, Span)],
-    src: &str,
-    kind: SyntaxKind,
-    decl_parser: FDecl,
-    mut on_non_extern: FNonExtern,
-) -> (Vec<Span>, Vec<Simple<SyntaxKind>>)
-where
-    P: Parser<SyntaxKind, Span, Error = Simple<SyntaxKind>>,
-    FDecl: Fn() -> P,
-    FNonExtern: FnMut(&mut State<'_>, Span),
-{
-    let mut st: State<'_> = State::new(tokens, src, Vec::new());
-
-    let handle_extern = |st: &mut State<'_>, span: Span| {
-        let is_decl = st
-            .stream
-            .peek_after_ws_inline()
-            .is_some_and(|(k, _)| *k == kind);
-        if !is_decl {
-            st.skip_line();
-            return;
-        }
-
-        let ws = inline_ws().repeated();
-        let start = span.start;
-        let parser = just(SyntaxKind::K_EXTERN)
-            .padded_by(ws.clone())
-            .ignore_then(decl_parser())
-            .map(move |sp: Span| start..sp.end);
-
-        parse_and_record(st, start, parser);
-    };
-
-    while let Some(&(token_kind, ref span_ref)) = st.stream.peek() {
-        let span = span_ref.clone();
-        if token_kind == SyntaxKind::K_EXTERN {
-            handle_extern(&mut st, span);
-        } else if token_kind == kind {
-            on_non_extern(&mut st, span);
-        } else {
-            st.stream.advance();
-        }
-    }
-
-    st.into_parts()
 }

--- a/src/parser/tests/programs.rs
+++ b/src/parser/tests/programs.rs
@@ -181,7 +181,7 @@ impl TransformerProgram {
                 "extern transformer correlate(users: User, sessions: UserSession): UserActivity, SessionAlerts"
             }
             Self::TransformerInvalid => {
-                "extern transformer incomplete_transformer(input: SomeData):"
+                "extern transformer incomplete_transformer(input: SomeData)"
             }
             Self::TransformerNoInputs => {
                 "extern transformer no_inputs(): OutputType"

--- a/src/parser/tests/transformers.rs
+++ b/src/parser/tests/transformers.rs
@@ -5,7 +5,8 @@
 use super::helpers::parse_transformer;
 use crate::test_util::{
     CAPITALIZED_TRANSFORMER_NAME_ERROR, ErrorPattern, MISSING_OUTPUT_SIGNATURE_ERROR,
-    assert_custom_parse_error_contains, assert_no_parse_errors, assert_parse_error,
+    assert_custom_parse_error_contains, assert_no_custom_parse_error_contains,
+    assert_no_parse_errors, assert_parse_error,
 };
 use rstest::{fixture, rstest};
 
@@ -118,13 +119,7 @@ fn transformer_malformed_inputs_multiline_error(transformer_invalid_inputs_multi
     // Should NOT produce a transformer node
     assert!(parsed.root().transformers().is_empty());
     // Verify we don't get a spurious "must be extern" error
-    let has_extern_error = errors
-        .iter()
-        .any(|e| format!("{e:?}").contains("must be extern"));
-    assert!(
-        !has_extern_error,
-        "should not emit 'must be extern' error for malformed extern transformer"
-    );
+    assert_no_custom_parse_error_contains(errors, "must be extern");
 }
 
 #[rstest]

--- a/src/parser/tests/transformers.rs
+++ b/src/parser/tests/transformers.rs
@@ -6,6 +6,9 @@ use super::helpers::parse_transformer;
 use crate::test_util::{ErrorPattern, assert_no_parse_errors, assert_parse_error};
 use rstest::{fixture, rstest};
 
+const MISSING_OUTPUT_SIGNATURE_ERROR: &str =
+    "transformer declarations require ':' followed by at least one output identifier";
+
 #[fixture]
 fn transformer_single_io() -> &'static str {
     "extern transformer normalize(input: UnnormalizedData): NormalizedData"
@@ -18,7 +21,7 @@ fn transformer_multi_io() -> &'static str {
 
 #[fixture]
 fn transformer_invalid() -> &'static str {
-    "extern transformer incomplete_transformer(input: SomeData):"
+    "extern transformer incomplete_transformer(input: SomeData)"
 }
 
 #[fixture]
@@ -81,8 +84,18 @@ fn parses_transformers(
 }
 
 #[rstest]
-#[case::no_outputs(transformer_no_outputs(), ErrorPattern::from("Unexpected"), 0, 48)]
-#[case::invalid_decl(transformer_invalid(), ErrorPattern::from("Unexpected"), 0, 59)]
+#[case::missing_colon(
+    transformer_invalid(),
+    ErrorPattern::from(MISSING_OUTPUT_SIGNATURE_ERROR),
+    0,
+    58
+)]
+#[case::no_outputs(
+    transformer_no_outputs(),
+    ErrorPattern::from(MISSING_OUTPUT_SIGNATURE_ERROR),
+    0,
+    48
+)]
 fn transformer_error_cases(
     #[case] src: &str,
     #[case] pattern: ErrorPattern,

--- a/src/parser/tests/transformers.rs
+++ b/src/parser/tests/transformers.rs
@@ -94,18 +94,6 @@ fn parses_transformers(
 
 #[rstest]
 #[case::malformed_inputs(transformer_invalid_inputs(), ErrorPattern::from("Unexpected"), 0, 44)]
-#[case::missing_colon(
-    transformer_invalid(),
-    ErrorPattern::from(MISSING_OUTPUT_SIGNATURE_ERROR),
-    0,
-    58
-)]
-#[case::no_outputs(
-    transformer_no_outputs(),
-    ErrorPattern::from(MISSING_OUTPUT_SIGNATURE_ERROR),
-    0,
-    48
-)]
 fn transformer_error_cases(
     #[case] src: &str,
     #[case] pattern: ErrorPattern,
@@ -115,6 +103,15 @@ fn transformer_error_cases(
     let parsed = crate::parse(src);
     let errors = parsed.errors();
     assert_parse_error(errors, pattern, start, end);
+    assert!(parsed.root().transformers().is_empty());
+}
+
+#[rstest]
+#[case::missing_colon(transformer_invalid(), MISSING_OUTPUT_SIGNATURE_ERROR)]
+#[case::no_outputs(transformer_no_outputs(), MISSING_OUTPUT_SIGNATURE_ERROR)]
+fn transformer_missing_output_signature_errors(#[case] src: &str, #[case] expected_message: &str) {
+    let parsed = crate::parse(src);
+    crate::test_util::assert_custom_parse_error_contains(parsed.errors(), expected_message);
     assert!(parsed.root().transformers().is_empty());
 }
 

--- a/src/parser/tests/transformers.rs
+++ b/src/parser/tests/transformers.rs
@@ -3,11 +3,10 @@
 //! Validates extern transformer syntax and edge cases.
 
 use super::helpers::parse_transformer;
-use crate::test_util::{ErrorPattern, assert_no_parse_errors, assert_parse_error};
+use crate::test_util::{
+    ErrorPattern, MISSING_OUTPUT_SIGNATURE_ERROR, assert_no_parse_errors, assert_parse_error,
+};
 use rstest::{fixture, rstest};
-
-const MISSING_OUTPUT_SIGNATURE_ERROR: &str =
-    "transformer declarations require ':' followed by at least one output identifier";
 
 #[fixture]
 fn transformer_single_io() -> &'static str {
@@ -25,6 +24,11 @@ fn transformer_invalid() -> &'static str {
 }
 
 #[fixture]
+fn transformer_invalid_inputs() -> &'static str {
+    "extern transformer malformed(input: SomeData"
+}
+
+#[fixture]
 fn transformer_no_inputs() -> &'static str {
     "extern transformer no_inputs(): OutputType"
 }
@@ -32,6 +36,11 @@ fn transformer_no_inputs() -> &'static str {
 #[fixture]
 fn transformer_no_outputs() -> &'static str {
     "extern transformer no_outputs(input: InputType):"
+}
+
+#[fixture]
+fn transformer_multiline_no_outputs() -> &'static str {
+    "extern transformer multiline(\n    input: InputType\n):"
 }
 
 #[fixture]
@@ -84,6 +93,7 @@ fn parses_transformers(
 }
 
 #[rstest]
+#[case::malformed_inputs(transformer_invalid_inputs(), ErrorPattern::from("Unexpected"), 0, 44)]
 #[case::missing_colon(
     transformer_invalid(),
     ErrorPattern::from(MISSING_OUTPUT_SIGNATURE_ERROR),
@@ -105,6 +115,18 @@ fn transformer_error_cases(
     let parsed = crate::parse(src);
     let errors = parsed.errors();
     assert_parse_error(errors, pattern, start, end);
+    assert!(parsed.root().transformers().is_empty());
+}
+
+#[rstest]
+fn multiline_transformer_without_outputs_reports_targeted_error(
+    transformer_multiline_no_outputs: &str,
+) {
+    let parsed = crate::parse(transformer_multiline_no_outputs);
+    crate::test_util::assert_custom_parse_error_contains(
+        parsed.errors(),
+        MISSING_OUTPUT_SIGNATURE_ERROR,
+    );
     assert!(parsed.root().transformers().is_empty());
 }
 

--- a/src/parser/tests/transformers.rs
+++ b/src/parser/tests/transformers.rs
@@ -166,6 +166,26 @@ fn transformer_requires_extern(transformer_non_extern: &str) {
 }
 
 #[rstest]
+fn transformer_capitalized_name_rejected() {
+    let src = "extern transformer Foo(input: InputType): OutputType";
+    let parsed = crate::parse(src);
+    let errors = parsed.errors();
+    let expected_message = "transformer names must start with a lowercase letter or underscore";
+    let matching_error = errors.iter().find(|error| {
+        let rendered = format!("{error:?}");
+        rendered.contains(expected_message)
+    });
+    assert!(
+        matching_error.is_some(),
+        "expected lowercase-name error for capitalized transformer, got: {errors:?}"
+    );
+    assert!(
+        parsed.root().transformers().is_empty(),
+        "capitalized transformer should not be added to AST"
+    );
+}
+
+#[rstest]
 fn transformer_requires_extern_for_malformed(transformer_non_extern_malformed: &str) {
     let parsed = crate::parse(transformer_non_extern_malformed);
     let errors = parsed.errors();

--- a/src/parser/tests/transformers.rs
+++ b/src/parser/tests/transformers.rs
@@ -161,10 +161,22 @@ fn transformer_requires_extern(transformer_non_extern: &str) {
 }
 
 #[rstest]
-fn transformer_capitalized_name_rejected() {
-    let src = "extern transformer Foo(input: InputType): OutputType";
+#[case::simple_capitalized("extern transformer Foo(input: InputType): OutputType")]
+#[case::capitalized_missing_colon("extern transformer Foo(input: InputType) OutputType")]
+#[case::capitalized_empty_output("extern transformer Foo(input: InputType):")]
+fn transformer_capitalized_name_rejected(#[case] src: &str) {
     let parsed = crate::parse(src);
     assert_custom_parse_error_contains(parsed.errors(), CAPITALIZED_TRANSFORMER_NAME_ERROR);
+    assert!(parsed.root().transformers().is_empty());
+}
+
+#[rstest]
+#[case::capitalized_missing_colon("extern transformer Foo(input: InputType) OutputType")]
+#[case::capitalized_empty_output("extern transformer Foo(input: InputType):")]
+fn transformer_capitalized_name_with_missing_output(#[case] src: &str) {
+    let parsed = crate::parse(src);
+    assert_custom_parse_error_contains(parsed.errors(), CAPITALIZED_TRANSFORMER_NAME_ERROR);
+    assert_custom_parse_error_contains(parsed.errors(), MISSING_OUTPUT_SIGNATURE_ERROR);
     assert!(parsed.root().transformers().is_empty());
 }
 

--- a/src/parser/tests/transformers.rs
+++ b/src/parser/tests/transformers.rs
@@ -41,7 +41,7 @@ fn transformer_no_outputs() -> &'static str {
 
 #[fixture]
 fn transformer_multiline_no_outputs() -> &'static str {
-    "extern transformer multiline(\n    input: InputType\n):"
+    "extern transformer multiline(\n    transformer: InputType\n):"
 }
 
 #[fixture]

--- a/src/parser/tests/transformers.rs
+++ b/src/parser/tests/transformers.rs
@@ -109,21 +109,10 @@ fn transformer_error_cases(
 #[rstest]
 #[case::missing_colon(transformer_invalid(), MISSING_OUTPUT_SIGNATURE_ERROR)]
 #[case::no_outputs(transformer_no_outputs(), MISSING_OUTPUT_SIGNATURE_ERROR)]
+#[case::multiline(transformer_multiline_no_outputs(), MISSING_OUTPUT_SIGNATURE_ERROR)]
 fn transformer_missing_output_signature_errors(#[case] src: &str, #[case] expected_message: &str) {
     let parsed = crate::parse(src);
     crate::test_util::assert_custom_parse_error_contains(parsed.errors(), expected_message);
-    assert!(parsed.root().transformers().is_empty());
-}
-
-#[rstest]
-fn multiline_transformer_without_outputs_reports_targeted_error(
-    transformer_multiline_no_outputs: &str,
-) {
-    let parsed = crate::parse(transformer_multiline_no_outputs);
-    crate::test_util::assert_custom_parse_error_contains(
-        parsed.errors(),
-        MISSING_OUTPUT_SIGNATURE_ERROR,
-    );
     assert!(parsed.root().transformers().is_empty());
 }
 

--- a/src/parser/tests/transformers.rs
+++ b/src/parser/tests/transformers.rs
@@ -93,16 +93,10 @@ fn parses_transformers(
 }
 
 #[rstest]
-#[case::malformed_inputs(transformer_invalid_inputs(), ErrorPattern::from("Unexpected"), 0, 44)]
-fn transformer_error_cases(
-    #[case] src: &str,
-    #[case] pattern: ErrorPattern,
-    #[case] start: usize,
-    #[case] end: usize,
-) {
-    let parsed = crate::parse(src);
+fn transformer_malformed_inputs_error(transformer_invalid_inputs: &str) {
+    let parsed = crate::parse(transformer_invalid_inputs);
     let errors = parsed.errors();
-    assert_parse_error(errors, pattern, start, end);
+    assert_parse_error(errors, ErrorPattern::from("Unexpected"), 0, 44);
     assert!(parsed.root().transformers().is_empty());
 }
 

--- a/src/parser/tests/transformers.rs
+++ b/src/parser/tests/transformers.rs
@@ -30,6 +30,11 @@ fn transformer_invalid_inputs() -> &'static str {
 }
 
 #[fixture]
+fn transformer_invalid_inputs_multiline() -> &'static str {
+    "extern transformer broken(\n    transformer: Type"
+}
+
+#[fixture]
 fn transformer_no_inputs() -> &'static str {
     "extern transformer no_inputs(): OutputType"
 }
@@ -99,6 +104,27 @@ fn transformer_malformed_inputs_error(transformer_invalid_inputs: &str) {
     let errors = parsed.errors();
     assert_parse_error(errors, ErrorPattern::from("Unexpected"), 0, 44);
     assert!(parsed.root().transformers().is_empty());
+}
+
+#[rstest]
+fn transformer_malformed_inputs_multiline_error(transformer_invalid_inputs_multiline: &str) {
+    let parsed = crate::parse(transformer_invalid_inputs_multiline);
+    let errors = parsed.errors();
+    // Should get an "Unexpected" error for the unterminated parameter list
+    assert!(
+        !errors.is_empty(),
+        "expected parse errors for unterminated multiline parameter list"
+    );
+    // Should NOT produce a transformer node
+    assert!(parsed.root().transformers().is_empty());
+    // Verify we don't get a spurious "must be extern" error
+    let has_extern_error = errors
+        .iter()
+        .any(|e| format!("{e:?}").contains("must be extern"));
+    assert!(
+        !has_extern_error,
+        "should not emit 'must be extern' error for malformed extern transformer"
+    );
 }
 
 #[rstest]

--- a/src/parser/tests/transformers.rs
+++ b/src/parser/tests/transformers.rs
@@ -4,7 +4,8 @@
 
 use super::helpers::parse_transformer;
 use crate::test_util::{
-    ErrorPattern, MISSING_OUTPUT_SIGNATURE_ERROR, assert_no_parse_errors, assert_parse_error,
+    CAPITALIZED_TRANSFORMER_NAME_ERROR, ErrorPattern, MISSING_OUTPUT_SIGNATURE_ERROR,
+    assert_custom_parse_error_contains, assert_no_parse_errors, assert_parse_error,
 };
 use rstest::{fixture, rstest};
 
@@ -163,20 +164,8 @@ fn transformer_requires_extern(transformer_non_extern: &str) {
 fn transformer_capitalized_name_rejected() {
     let src = "extern transformer Foo(input: InputType): OutputType";
     let parsed = crate::parse(src);
-    let errors = parsed.errors();
-    let expected_message = "transformer names must start with a lowercase letter or underscore";
-    let matching_error = errors.iter().find(|error| {
-        let rendered = format!("{error:?}");
-        rendered.contains(expected_message)
-    });
-    assert!(
-        matching_error.is_some(),
-        "expected lowercase-name error for capitalized transformer, got: {errors:?}"
-    );
-    assert!(
-        parsed.root().transformers().is_empty(),
-        "capitalized transformer should not be added to AST"
-    );
+    assert_custom_parse_error_contains(parsed.errors(), CAPITALIZED_TRANSFORMER_NAME_ERROR);
+    assert!(parsed.root().transformers().is_empty());
 }
 
 #[rstest]

--- a/src/test_util/assertions.rs
+++ b/src/test_util/assertions.rs
@@ -166,6 +166,39 @@ pub fn assert_custom_parse_error_contains(
     );
 }
 
+/// Assert that no custom parser error message contains `forbidden_pattern`.
+///
+/// This is the negated counterpart to [`assert_custom_parse_error_contains`],
+/// useful for verifying that specific error messages are not emitted.
+///
+/// # Examples
+///
+/// ```
+/// use chumsky::error::Simple;
+/// use ddlint::{SyntaxKind, test_util::assert_no_custom_parse_error_contains};
+///
+/// let errors = vec![Simple::custom(0..1, "different message")];
+/// assert_no_custom_parse_error_contains(&errors, "forbidden text");
+/// ```
+///
+/// # Panics
+/// Panics if any custom error message contains `forbidden_pattern`.
+#[track_caller]
+pub fn assert_no_custom_parse_error_contains(
+    errors: &[Simple<SyntaxKind>],
+    forbidden_pattern: impl AsRef<str>,
+) {
+    let forbidden_pattern = normalise_tokens(forbidden_pattern.as_ref());
+    let has_forbidden_error = errors.iter().any(|error| match error.reason() {
+        SimpleReason::Custom(message) => normalise_tokens(message).contains(&forbidden_pattern),
+        _ => false,
+    });
+    assert!(
+        !has_forbidden_error,
+        "expected no custom error containing `{forbidden_pattern}`, but found one in {errors:?}"
+    );
+}
+
 /// Find the first error in `errors` whose rendered text contains `pattern`.
 ///
 /// Returns `Some(index)` for the matching error, or `None` if no error

--- a/src/test_util/assertions.rs
+++ b/src/test_util/assertions.rs
@@ -132,6 +132,16 @@ pub fn assert_parse_error(
     assert_eq!(error.span(), start..end);
 }
 
+/// Return `true` if any error in `errors` is a [`SimpleReason::Custom`] whose
+/// normalised message contains the normalised `pattern`.
+fn any_custom_error_contains(errors: &[Simple<SyntaxKind>], pattern: &str) -> bool {
+    let normalised = normalise_tokens(pattern);
+    errors.iter().any(|error| match error.reason() {
+        SimpleReason::Custom(message) => normalise_tokens(message).contains(&normalised),
+        _ => false,
+    })
+}
+
 /// Assert that at least one custom parser error message contains
 /// `expected_pattern`.
 ///
@@ -155,14 +165,11 @@ pub fn assert_custom_parse_error_contains(
     errors: &[Simple<SyntaxKind>],
     expected_pattern: impl AsRef<str>,
 ) {
-    let expected_pattern = normalise_tokens(expected_pattern.as_ref());
-    let has_expected_error = errors.iter().any(|error| match error.reason() {
-        SimpleReason::Custom(message) => normalise_tokens(message).contains(&expected_pattern),
-        _ => false,
-    });
+    let pattern = expected_pattern.as_ref();
     assert!(
-        has_expected_error,
-        "expected custom error containing `{expected_pattern}`, got {errors:?}"
+        any_custom_error_contains(errors, pattern),
+        "expected custom error containing `{}`, got {errors:?}",
+        normalise_tokens(pattern),
     );
 }
 
@@ -188,14 +195,11 @@ pub fn assert_no_custom_parse_error_contains(
     errors: &[Simple<SyntaxKind>],
     forbidden_pattern: impl AsRef<str>,
 ) {
-    let forbidden_pattern = normalise_tokens(forbidden_pattern.as_ref());
-    let has_forbidden_error = errors.iter().any(|error| match error.reason() {
-        SimpleReason::Custom(message) => normalise_tokens(message).contains(&forbidden_pattern),
-        _ => false,
-    });
+    let pattern = forbidden_pattern.as_ref();
     assert!(
-        !has_forbidden_error,
-        "expected no custom error containing `{forbidden_pattern}`, but found one in {errors:?}"
+        !any_custom_error_contains(errors, pattern),
+        "expected no custom error containing `{}`, but found one in {errors:?}",
+        normalise_tokens(pattern),
     );
 }
 

--- a/src/test_util/mod.rs
+++ b/src/test_util/mod.rs
@@ -10,9 +10,9 @@ mod literals;
 
 pub use assertions::{
     assert_custom_parse_error_contains, assert_delimiter_error,
-    assert_first_rule_without_parse_stage_aggregation_errors, assert_no_parse_errors,
-    assert_panic_with_message, assert_parse_error, assert_unclosed_delimiter_error,
-    find_matching_error,
+    assert_first_rule_without_parse_stage_aggregation_errors,
+    assert_no_custom_parse_error_contains, assert_no_parse_errors, assert_panic_with_message,
+    assert_parse_error, assert_unclosed_delimiter_error, find_matching_error,
 };
 pub const MISSING_OUTPUT_SIGNATURE_ERROR: &str =
     crate::parser::error_messages::MISSING_OUTPUT_SIGNATURE_ERROR;

--- a/src/test_util/mod.rs
+++ b/src/test_util/mod.rs
@@ -16,6 +16,8 @@ pub use assertions::{
 };
 pub const MISSING_OUTPUT_SIGNATURE_ERROR: &str =
     crate::parser::error_messages::MISSING_OUTPUT_SIGNATURE_ERROR;
+pub const CAPITALIZED_TRANSFORMER_NAME_ERROR: &str =
+    crate::parser::error_messages::CAPITALIZED_TRANSFORMER_NAME_ERROR;
 pub use expressions::{
     bit_slice, break_expr, call, call_expr, closure, continue_expr, field, field_access, for_loop,
     if_expr, map_entry, map_lit, match_arm, match_expr, method_call, pat, qualified_call,

--- a/src/test_util/mod.rs
+++ b/src/test_util/mod.rs
@@ -14,6 +14,8 @@ pub use assertions::{
     assert_panic_with_message, assert_parse_error, assert_unclosed_delimiter_error,
     find_matching_error,
 };
+pub const MISSING_OUTPUT_SIGNATURE_ERROR: &str =
+    crate::parser::error_messages::MISSING_OUTPUT_SIGNATURE_ERROR;
 pub use expressions::{
     bit_slice, break_expr, call, call_expr, closure, continue_expr, field, field_access, for_loop,
     if_expr, map_entry, map_lit, match_arm, match_expr, method_call, pat, qualified_call,

--- a/tests/apply_items.rs
+++ b/tests/apply_items.rs
@@ -1,9 +1,9 @@
 //! Behavioural tests for `apply` statements.
 
-use chumsky::error::SimpleReason;
-use ddlint::SyntaxKind;
-use ddlint::parse;
-use rstest::rstest;
+use ddlint::{parse, test_util::assert_custom_parse_error_contains};
+
+const MISSING_OUTPUT_SIGNATURE_ERROR: &str =
+    "transformer declarations require ':' followed by at least one output identifier";
 
 #[test]
 fn parses_apply_items_in_program() {
@@ -27,47 +27,11 @@ fn parses_apply_items_in_program() {
     assert_eq!(apply.outputs(), vec!["Normalised".to_string()]);
 }
 
-fn assert_missing_colon_error(
-    errors: &[chumsky::error::Simple<SyntaxKind>],
-    expected_found: Option<SyntaxKind>,
-) {
-    let [error] = errors else {
-        panic!("expected one parse error, got {errors:?}");
-    };
-    assert!(matches!(error.reason(), SimpleReason::Unexpected));
-    assert!(
-        error
-            .expected()
-            .filter_map(|expected| expected.as_ref())
-            .any(|kind| *kind == SyntaxKind::T_COLON),
-        "expected missing-colon error, got {error:?}",
-    );
-    assert_eq!(error.found().copied(), expected_found);
-}
-
-#[rstest]
-#[case("extern transformer missing_colon(input: SomeData)", None, Vec::new())]
-#[case(
-    concat!(
-        "extern transformer missing_colon(input: SomeData)\n",
-        "extern transformer ok(input: SomeData): OtherData\n",
-        "extern transformer another(input: OtherData): FinalData",
-    ),
-    Some(SyntaxKind::K_EXTERN),
-    vec![Some(String::from("ok")), Some(String::from("another"))],
-)]
-fn transformer_missing_colon_behaviour(
-    #[case] src: &str,
-    #[case] expected_found: Option<SyntaxKind>,
-    #[case] expected_names: Vec<Option<String>>,
-) {
+#[test]
+fn transformer_declarations_require_a_non_empty_output_signature() {
+    let src = "extern transformer normalise(input: User):";
     let parsed = parse(src);
-    assert_missing_colon_error(parsed.errors(), expected_found);
 
-    let transformers = parsed.root().transformers();
-    let names: Vec<_> = transformers
-        .iter()
-        .map(ddlint::ast::Transformer::name)
-        .collect();
-    assert_eq!(names, expected_names);
+    assert_custom_parse_error_contains(parsed.errors(), MISSING_OUTPUT_SIGNATURE_ERROR);
+    assert!(parsed.root().transformers().is_empty());
 }

--- a/tests/apply_items.rs
+++ b/tests/apply_items.rs
@@ -1,9 +1,9 @@
 //! Behavioural tests for `apply` statements.
 
-use ddlint::{parse, test_util::assert_custom_parse_error_contains};
-
-const MISSING_OUTPUT_SIGNATURE_ERROR: &str =
-    "transformer declarations require ':' followed by at least one output identifier";
+use ddlint::{
+    parse,
+    test_util::{MISSING_OUTPUT_SIGNATURE_ERROR, assert_custom_parse_error_contains},
+};
 
 #[test]
 fn parses_apply_items_in_program() {
@@ -30,6 +30,15 @@ fn parses_apply_items_in_program() {
 #[test]
 fn transformer_declarations_require_a_non_empty_output_signature() {
     let src = "extern transformer normalise(input: User):";
+    let parsed = parse(src);
+
+    assert_custom_parse_error_contains(parsed.errors(), MISSING_OUTPUT_SIGNATURE_ERROR);
+    assert!(parsed.root().transformers().is_empty());
+}
+
+#[test]
+fn legacy_missing_colon_transformer_reports_missing_output_signature_and_no_transformers() {
+    let src = "extern transformer normalise(input: User)";
     let parsed = parse(src);
 
     assert_custom_parse_error_contains(parsed.errors(), MISSING_OUTPUT_SIGNATURE_ERROR);

--- a/tests/apply_items.rs
+++ b/tests/apply_items.rs
@@ -4,6 +4,7 @@ use ddlint::{
     parse,
     test_util::{MISSING_OUTPUT_SIGNATURE_ERROR, assert_custom_parse_error_contains},
 };
+use rstest::rstest;
 
 #[test]
 fn parses_apply_items_in_program() {
@@ -27,18 +28,10 @@ fn parses_apply_items_in_program() {
     assert_eq!(apply.outputs(), vec!["Normalised".to_string()]);
 }
 
-#[test]
-fn transformer_declarations_require_a_non_empty_output_signature() {
-    let src = "extern transformer normalise(input: User):";
-    let parsed = parse(src);
-
-    assert_custom_parse_error_contains(parsed.errors(), MISSING_OUTPUT_SIGNATURE_ERROR);
-    assert!(parsed.root().transformers().is_empty());
-}
-
-#[test]
-fn legacy_missing_colon_transformer_reports_missing_output_signature_and_no_transformers() {
-    let src = "extern transformer normalise(input: User)";
+#[rstest]
+#[case("extern transformer normalise(input: User):")]
+#[case("extern transformer normalise(input: User)")]
+fn transformer_missing_output_signature_cases(#[case] src: &str) {
     let parsed = parse(src);
 
     assert_custom_parse_error_contains(parsed.errors(), MISSING_OUTPUT_SIGNATURE_ERROR);


### PR DESCRIPTION
## Summary
- Adds an ExecPlan document at `docs/execplans/2-6-5-align-transformer-declaration-grammar.md` describing the plan to align transformer declaration grammar and output signatures, and notes that the plan has progressed to implementation and validation. The roadmap item `2.6.5` is now implemented.
- Implements a deterministic diagnostic for missing/empty transformer outputs and updates tests and parser to reflect the final contract.
- Enforces lowercase transformer names (start with a lowercase letter or underscore) and adds a dedicated diagnostic for capitalized transformer names.
- The ExecPlan itself is maintained as a living document, updated with progress, validation gates, and outcomes.
- The changes include updates to the syntax spec, conformance docs, and multiple parser/tests areas to align with the final contract.

## Rationale
- The repository previously exhibited a mismatch between the syntax spec and the parser contract for transformer declarations. This work aligns the public contract (including outputs exposure) with the implemented AST surface and deterministic diagnostics, while preserving existing AST exposure and downstream usage.

## Changes
- New file: `docs/execplans/2-6-5-align-transformer-declaration-grammar.md` containing the full, updated plan and status.
- Updated documentation:
  - `docs/differential-datalog-parser-syntax-spec-updated.md` to reflect the mandatory output list after `:` and to document the deterministic diagnostic for missing/empty outputs.
  - `docs/parser-conformance-register.md` item 12 now marked as implemented and expanded to reflect the deterministic diagnostics.
  - `docs/parser-implementation-notes.md` updated to describe the transformer output-signature contract and the deterministic diagnostic.
  - `docs/roadmap.md` updated to mark item 2.6.5 as implemented.
- Code changes:
  - `src/parser/span_scanners/transformers.rs` implemented explicit handling for transformer declarations with a colon and non-empty outputs, added a dedicated diagnostic for missing/empty output signatures, and preserved existing non-extern transformer diagnostics. Also enforces lowercase transformer names and emits a dedicated diagnostic for capitalized names.
- Tests:
  - Updated unit tests to expect the transformer-specific missing-output diagnostic for both missing-colon and empty-output forms.
  - Updated integration/behavioural tests to reflect the new contract and diagnostics (including an explicit legacy-form rejection case).
  - Updated related test fixtures and references to align with the final transformer grammar.
- Roadmap and tests integration:
  - The conformance/register docs, syntax spec, and parser notes now reflect the final, implemented contract and mandatory output-signature grammar.

## Plan of work (high level)
- Stage A: establish red tests for the intended contract
  - Update unit tests to describe the chosen grammar and deterministic diagnostics.
  - Add a legacy semicolon-only rejection case.
  - Ensure success coverage for zero inputs, single output, and multiple outputs.
- Stage B: Implement deterministic grammar handling
  - Refactor scanner logic to enforce the colon + output list contract explicitly.
  - Preserve recovery behavior for malformed declarations.
  - Keep existing success fixtures intact.
- Stage C: Align documentation and public contract text
  - Update parser conformance docs and differential-datalog syntax spec to reflect the chosen grammar.
  - Document parser-boundaries and AST exposure of outputs.
- Stage D: Add behavioural coverage for end-to-end parser behaviour
  - Add or adjust behavioural tests to prove the decision and end-to-end parsing.
- Stage E: Validation and close-out
  - Run full validation gates (formatting, linting, tests) and mark roadmap item done when green.

## Validation plan
- Run repository quality gates and tests as documented in the ExecPlan:
  - `make fmt`, `make markdownlint`, `make nixie`, `make check-fmt`, `make lint`, `make test`.
- All commands should pass to close the roadmap item.

## Risks and mitigations
- Risk: overlapping transformer contracts and potential scope creep. Mitigation: keep changes scoped to the transformer declaration grammar and deterministic output signatures; escalate if cross-cutting changes are required.
- Risk: downstream consumers rely on legacy grammar. Mitigation: provide precise, deterministic diagnostics and maintain existing AST surface where feasible.

## Outcomes & Retrospective (continued)
- Implementation landed with full validation. The parser, unit tests, behavioural tests, syntax spec, conformance register, parser implementation notes, roadmap, and this ExecPlan now agree on the transformer contract: `extern transformer name(params...): output(, output)*`, with a deterministic diagnostic when the output signature is missing or empty. Validation passed via `make fmt`, `make markdownlint`, `make nixie`, `make check-fmt`, `make lint`, and `CI=1 make test`.

## Context and orientation
- The relevant code and documents are concentrated in a small set of files:
  - `src/parser/span_scanners/transformers.rs` recognizes top-level transformer declarations and already enforces the `extern` requirement plus the current colon-output grammar.
  - `src/parser/ast/transformer.rs` exposes `Transformer::name()`, `Transformer::inputs()`, and `Transformer::outputs()`.
  - `src/parser/ast/parse_utils/outputs.rs` contains the output-list extraction helper and its local tests.
  - `src/parser/tests/transformers.rs` contains the feature-focused unit tests for accepted and rejected transformer declarations.
  - `src/parser/tests/programs.rs`, `src/parser/tests/specs.rs`, and `src/parser/tests/parser.rs` define parser-level integration fixtures and assertions for transformer declarations.
  - `tests/apply_items.rs`, `tests/attribute_placement.rs`, and `tests/name_uniqueness.rs` provide behavioural coverage that already touches transformers indirectly.
  - `docs/differential-datalog-parser-syntax-spec-updated.md`,
    `docs/parser-conformance-register.md`, `docs/parser-implementation-notes.md`,
    and `docs/ddlint-design.md` carry the active written contract.

## Concrete steps (summary)
- Update unit tests in `src/parser/tests/transformers.rs` to reflect deterministic missing-output diagnostic and legacy-form rejection.
- Update parser-level shared fixtures and assertions.
- Implement scanner diagnostics in `src/parser/span_scanners/transformers.rs` for missing/empty outputs and capitalized names, preserving non-extern diagnostics.
- Re-export new error messages in test utilities and wire tests to use `MISSING_OUTPUT_SIGNATURE_ERROR` and `CAPITALIZED_TRANSFORMER_NAME_ERROR`.
- Update behavioural tests and fixtures to reflect the new contract.
- Update the active documentation and roadmap to mark item `2.6.5` implemented.

## Validation commands
Run the following from the repository root, capturing output with `tee`:

```shell
set -o pipefail; make fmt 2>&1 | tee /tmp/2-6-5-make-fmt.log
set -o pipefail; make markdownlint 2>&1 | tee /tmp/2-6-5-make-markdownlint.log
set -o pipefail; make nixie 2>&1 | tee /tmp/2-6-5-make-nixie.log
set -o pipefail; make check-fmt 2>&1 | tee /tmp/2-6-5-make-check-fmt.log
set -o pipefail; make lint 2>&1 | tee /tmp/2-6-5-make-lint.log
set -o pipefail; CI=1 make test 2>&1 | tee /tmp/2-6-5-make-test.log
```

Successful completion means all six commands exit with status `0`, the new transformer unit and behavioural tests pass, and the roadmap item can be closed without leaving the conformance register in `scheduled` state.

📎 **Task**: https://www.devboxer.com/task/dcc5470a-48d0-4418-bbe0-50b12a8781df