### PR TITLE
Align transformer spec, add tests, update docs

### DIFF
--- a/docs/differential-datalog-parser-syntax-spec-updated.md
+++ b/docs/differential-datalog-parser-syntax-spec-updated.md
@@ -568,7 +568,9 @@ porting and testing.
 - **Typedef:** `TypeDef { name, params, body }`.
 - **Function:** `FuncDef { name, params, ret, body }`, collated into
   `FuncGroup` by name.
-- **Transformer:** `TransformerDef { extern: true, name, params }`.
+- **Transformer:** `TransformerDef { extern: true, name, params, outputs }`,
+  where `outputs` is the ordered list of `Ident` values parsed from
+  `TransformerOutputs`.
 - **Apply:** `Apply { transformer, inputs, outputs }`.
 - **RelationDecl:** `Relation { role, kind, name, typeOrFields, primaryKey? }`.
 - **IndexDecl:** `Index { name, fields: [(name, type)], on: Atom }`.

--- a/docs/differential-datalog-parser-syntax-spec-updated.md
+++ b/docs/differential-datalog-parser-syntax-spec-updated.md
@@ -231,10 +231,18 @@ Closure   ::= 'function' '(' Params? ')' RetType? Block
 ### 5.4 Transformers (extern‑only)
 
 ```ebnf
-Transformer ::= 'extern' 'transformer' UcName '(' Params? ')' ';'
+Transformer        ::= 'extern' 'transformer' Ident '(' Params? ')'
+                       ':' TransformerOutputs
+TransformerOutputs ::= Ident (',' Ident)*
 ```
 
-A non‑extern `transformer` is rejected.
+- A non‑extern `transformer` is rejected.
+- The current parser accepts any non-keyword identifier token for transformer
+  names and output names; it does not apply a case-class restriction such as
+  `LcName` or `UcName`.
+- Transformer declarations are expected to remain on one physical line.
+  Recovery for malformed declarations is line-oriented: once parsing fails, the
+  scanner discards tokens through the next newline boundary before resuming.
 
 ### 5.5 Relations
 

--- a/docs/parser-conformance-register.md
+++ b/docs/parser-conformance-register.md
@@ -140,12 +140,19 @@ This register tracks parser behaviour against the syntax specification.
 
 ### 12. Transformer declaration grammar
 
-- Topic: output signature requirements.
+- Topic: output signature requirements and transformer-name token class.
 - Current behaviour (code): parser requires output list after `:`
-  (`src/parser/span_scanners/transformers.rs`).
-- Spec/target behaviour: section 5.4 currently documents extern-only
-  transformer shape without equivalent output-list requirement.
-- Decision status: `scheduled`.
+  (`src/parser/span_scanners/transformers.rs`). Transformer names and output
+  names are parsed through the generic identifier helper, so the parser accepts
+  any non-keyword identifier token rather than enforcing a lowercase-only name
+  class. The required output list is enforced directly in the chumsky grammar
+  via `.at_least(1)`, and malformed declarations recover by skipping to the
+  next newline boundary through shared scanner utilities.
+- Spec/target behaviour: section 5.4 now matches the implementation by
+  requiring `:` plus at least one output identifier, documenting generic
+  identifier acceptance for transformer names, and recording the single-line
+  recovery contract.
+- Decision status: `implemented`.
 - Roadmap item: `docs/roadmap.md` item `2.6.5`.
 
 ### 13. Relation forms and role/kind grammar

--- a/docs/parser-implementation-notes.md
+++ b/docs/parser-implementation-notes.md
@@ -249,6 +249,16 @@ Important invariants:
 These helpers are shared intentionally to keep declaration parsing consistent
 across top-level constructs.
 
+Declaration recovery is intentionally line-oriented. Shared scanner utilities
+call `SpanCollector::skip_line()` when a declaration head does not match the
+expected grammar or when `parse_and_record()` cannot consume a full
+declaration. Transformer declarations therefore enforce their required output
+signature through the `transformer_decl()` chumsky grammar itself, with
+`.at_least(1)` on the output list; there is no separate token-walking heuristic
+for missing outputs to keep in sync. Function and other top-level declaration
+scanners follow the same newline-bounded recovery pattern for malformed
+declaration heads.
+
 ## Diagnostics policy
 
 The parser prefers localized, span-precise diagnostics and recovery over hard

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -213,7 +213,7 @@ split parser library surfaces defined in `docs/adr-001-parser-crate-split.md`.
   docs/parser-conformance-register.md item 10.
 - [x] 2.6.4. Align index declaration grammar between scanner implementation and
   syntax specification. See docs/parser-conformance-register.md item 11.
-- [ ] 2.6.5. Align transformer declaration grammar, including output signature
+- [x] 2.6.5. Align transformer declaration grammar, including output signature
   requirements. See docs/parser-conformance-register.md item 12.
 - [ ] 2.6.6. Resolve relation form coverage (role/kind/bracket variants) and
   document supported forms explicitly. See docs/parser-conformance-register.md

--- a/tests/apply_items.rs
+++ b/tests/apply_items.rs
@@ -1,6 +1,7 @@
 //! Behavioural tests for `apply` statements.
 
 use ddlint::parse;
+use ddlint::test_util::assert_parse_error;
 
 #[test]
 fn parses_apply_items_in_program() {
@@ -22,4 +23,13 @@ fn parses_apply_items_in_program() {
     assert_eq!(apply.transformer_name().as_deref(), Some("normalise"));
     assert_eq!(apply.inputs(), vec!["User".to_string()]);
     assert_eq!(apply.outputs(), vec!["Normalised".to_string()]);
+}
+
+#[test]
+fn transformer_declarations_require_a_colon_before_outputs() {
+    let src = "extern transformer missing_colon(input: SomeData)";
+    let parsed = parse(src);
+
+    assert_parse_error(parsed.errors(), "Unexpected", 0, src.len());
+    assert!(parsed.root().transformers().is_empty());
 }

--- a/tests/apply_items.rs
+++ b/tests/apply_items.rs
@@ -1,7 +1,8 @@
 //! Behavioural tests for `apply` statements.
 
+use chumsky::error::SimpleReason;
+use ddlint::SyntaxKind;
 use ddlint::parse;
-use ddlint::test_util::assert_parse_error;
 
 #[test]
 fn parses_apply_items_in_program() {
@@ -29,7 +30,51 @@ fn parses_apply_items_in_program() {
 fn transformer_declarations_require_a_colon_before_outputs() {
     let src = "extern transformer missing_colon(input: SomeData)";
     let parsed = parse(src);
+    let errors = parsed.errors();
 
-    assert_parse_error(parsed.errors(), "Unexpected", 0, src.len());
+    let [error] = errors else {
+        panic!("expected one parse error, got {errors:?}");
+    };
+    assert!(matches!(error.reason(), SimpleReason::Unexpected));
+    assert!(
+        error
+            .expected()
+            .filter_map(|expected| expected.as_ref())
+            .any(|kind| *kind == SyntaxKind::T_COLON),
+        "expected missing-colon error, got {error:?}",
+    );
+    assert_eq!(error.found(), None);
     assert!(parsed.root().transformers().is_empty());
+}
+
+#[test]
+fn malformed_transformer_does_not_prevent_parsing_subsequent_declarations() {
+    let src = concat!(
+        "extern transformer missing_colon(input: SomeData)\n",
+        "extern transformer ok(input: SomeData): OtherData\n",
+        "extern transformer another(input: OtherData): FinalData",
+    );
+    let parsed = parse(src);
+    let errors = parsed.errors();
+
+    let [error] = errors else {
+        panic!("expected one parse error, got {errors:?}");
+    };
+    assert!(matches!(error.reason(), SimpleReason::Unexpected));
+    assert!(
+        error
+            .expected()
+            .filter_map(|expected| expected.as_ref())
+            .any(|kind| *kind == SyntaxKind::T_COLON),
+        "expected missing-colon error, got {error:?}",
+    );
+    assert_eq!(error.found(), Some(&SyntaxKind::K_EXTERN));
+
+    let transformers = parsed.root().transformers();
+    assert_eq!(transformers.len(), 2);
+    let names: Vec<_> = transformers
+        .iter()
+        .map(ddlint::ast::Transformer::name)
+        .collect();
+    assert_eq!(names, vec![Some("ok".into()), Some("another".into())]);
 }

--- a/tests/apply_items.rs
+++ b/tests/apply_items.rs
@@ -3,6 +3,7 @@
 use chumsky::error::SimpleReason;
 use ddlint::SyntaxKind;
 use ddlint::parse;
+use rstest::rstest;
 
 #[test]
 fn parses_apply_items_in_program() {
@@ -26,12 +27,10 @@ fn parses_apply_items_in_program() {
     assert_eq!(apply.outputs(), vec!["Normalised".to_string()]);
 }
 
-#[test]
-fn transformer_declarations_require_a_colon_before_outputs() {
-    let src = "extern transformer missing_colon(input: SomeData)";
-    let parsed = parse(src);
-    let errors = parsed.errors();
-
+fn assert_missing_colon_error(
+    errors: &[chumsky::error::Simple<SyntaxKind>],
+    expected_found: Option<SyntaxKind>,
+) {
     let [error] = errors else {
         panic!("expected one parse error, got {errors:?}");
     };
@@ -43,38 +42,32 @@ fn transformer_declarations_require_a_colon_before_outputs() {
             .any(|kind| *kind == SyntaxKind::T_COLON),
         "expected missing-colon error, got {error:?}",
     );
-    assert_eq!(error.found(), None);
-    assert!(parsed.root().transformers().is_empty());
+    assert_eq!(error.found().copied(), expected_found);
 }
 
-#[test]
-fn malformed_transformer_does_not_prevent_parsing_subsequent_declarations() {
-    let src = concat!(
+#[rstest]
+#[case("extern transformer missing_colon(input: SomeData)", None, Vec::new())]
+#[case(
+    concat!(
         "extern transformer missing_colon(input: SomeData)\n",
         "extern transformer ok(input: SomeData): OtherData\n",
         "extern transformer another(input: OtherData): FinalData",
-    );
+    ),
+    Some(SyntaxKind::K_EXTERN),
+    vec![Some(String::from("ok")), Some(String::from("another"))],
+)]
+fn transformer_missing_colon_behaviour(
+    #[case] src: &str,
+    #[case] expected_found: Option<SyntaxKind>,
+    #[case] expected_names: Vec<Option<String>>,
+) {
     let parsed = parse(src);
-    let errors = parsed.errors();
-
-    let [error] = errors else {
-        panic!("expected one parse error, got {errors:?}");
-    };
-    assert!(matches!(error.reason(), SimpleReason::Unexpected));
-    assert!(
-        error
-            .expected()
-            .filter_map(|expected| expected.as_ref())
-            .any(|kind| *kind == SyntaxKind::T_COLON),
-        "expected missing-colon error, got {error:?}",
-    );
-    assert_eq!(error.found(), Some(&SyntaxKind::K_EXTERN));
+    assert_missing_colon_error(parsed.errors(), expected_found);
 
     let transformers = parsed.root().transformers();
-    assert_eq!(transformers.len(), 2);
     let names: Vec<_> = transformers
         .iter()
         .map(ddlint::ast::Transformer::name)
         .collect();
-    assert_eq!(names, vec![Some("ok".into()), Some("another".into())]);
+    assert_eq!(names, expected_names);
 }


### PR DESCRIPTION
## Summary
- Align transformer declaration grammar with the syntax spec by requiring a colon and an outputs list.
- Add tests to cover the new grammar and recovery behavior.
- Update docs to reflect the changes and update roadmap status.

## Changes
### Documentation updates
- docs/differential-datalog-parser-syntax-spec-updated.md
  - Transformer grammar now defined as:
    Transformer        ::= 'extern' 'transformer' Ident '(' Params? ')' ':' TransformerOutputs
    TransformerOutputs ::= Ident (',' Ident)*
  - Clarified that transformer names and output names use a generic Ident token class and that the outputs list is required.
  - Noted line-oriented recovery: malformed transformer declarations recover by skipping to the next newline.

- docs/parser-conformance-register.md
  - Transformer declaration section updated to reflect:
    - Transformer names and outputs parsed via the generic Ident helper
    - Outputs require ':' and at least one output
    - Recovery behavior described (skip to next newline)
  - Marked the implemented status for this alignment.

- docs/parser-implementation-notes.md
  - Added note on line-oriented declaration recovery and that transformer output requirements are enforced directly in the transformer_decl grammar via .at_least(1).

- docs/roadmap.md
  - 2.6.5: Align transformer declaration grammar, including output signature requirements - now marked as implemented.

### Tests
- tests/apply_items.rs
  - Import introduced: use ddlint::test_util::assert_parse_error;
  - Added test: transformer_declarations_require_a_colon_before_outputs
    - Verifies that missing colon after extern transformer yields a parse error and that no transformers are parsed.

## Test plan
- [x] Run cargo test locally
- [x] Validate that transformer declarations without a colon fail with a parse error
- [x] Ensure no regressions in unrelated parsing tests


◳ Generated by [DevBoxer](https://www.devboxer.com) ◰

---

ℹ️ Tag @devboxerhub to ask questions and address PR feedback

📎 **Task**: https://www.devboxer.com/task/f3212383-3f9c-465d-8b96-358d66bfc8de

📝 Closes #249

## Summary by Sourcery

Align transformer declaration grammar and parser behavior with the documented syntax and mark the roadmap item as implemented.

Enhancements:
- Document the transformer declaration grammar to require a colon and at least one output identifier, using generic identifiers for transformer names and outputs, and describe line-oriented recovery semantics in implementation notes.
- Update the parser conformance register to reflect the implemented transformer grammar, identifier handling, and recovery behavior.

Documentation:
- Revise the differential datalog parser syntax spec to define the new transformer grammar shape and clarify identifier and recovery behavior.
- Mark the transformer grammar alignment roadmap item as completed.

Tests:
- Add a behavioral test ensuring extern transformer declarations without a colon before outputs produce a parse error and no transformers are recorded.