### PR TITLE
Consolidate test-rule runner into generic run_rule helper

### DIFF
--- a/src/linter/mod.rs
+++ b/src/linter/mod.rs
@@ -10,6 +10,8 @@ pub mod rules;
 mod runner;
 mod span_utils;
 mod store;
+#[cfg(test)]
+pub(crate) mod testing;
 
 pub use rule::{CstRule, LintDiagnostic, Rule, RuleConfig, RuleConfigValue, RuleCtx, RuleLevel};
 pub use runner::Runner;

--- a/src/linter/rules/correctness/unused_relation.rs
+++ b/src/linter/rules/correctness/unused_relation.rs
@@ -52,31 +52,19 @@ declare_lint! {
 
 #[cfg(test)]
 mod tests {
+    use crate::linter::testing::run_rule;
     use rstest::rstest;
-
-    // Import the shared test helper from the tests/support module.
-    // This ensures unit and behavioral tests use identical rule-running logic.
-    fn run_rule(source: &str) -> Vec<crate::linter::LintDiagnostic> {
-        // We can't directly use the tests/support module from src/ unit tests,
-        // so we duplicate the minimal logic here but keep it aligned.
-        let parsed = crate::parse(source);
-        assert!(
-            parsed.errors().is_empty(),
-            "unused-relation test source should parse cleanly: {:?}",
-            parsed.errors()
-        );
-        let mut store = crate::linter::CstRuleStore::new();
-        store.register(Box::new(super::UnusedRelationRule));
-        crate::linter::Runner::new(&store, source, &parsed, crate::linter::RuleConfig::new()).run()
-    }
 
     #[rstest]
     fn warns_for_declared_relation_with_no_reads() {
-        let diagnostics = run_rule(concat!(
-            "input relation Source(x: u32)\n",
-            "relation Sink(x: u32)\n",
-            "Sink(x) :- Source(x).\n",
-        ));
+        let diagnostics = run_rule(
+            super::UnusedRelationRule,
+            concat!(
+                "input relation Source(x: u32)\n",
+                "relation Sink(x: u32)\n",
+                "Sink(x) :- Source(x).\n",
+            ),
+        );
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(
@@ -95,13 +83,16 @@ mod tests {
 
     #[rstest]
     fn does_not_warn_for_relation_with_resolved_read() {
-        let diagnostics = run_rule(concat!(
-            "input relation Source(x: u32)\n",
-            "relation Used(x: u32)\n",
-            "relation Sink(x: u32)\n",
-            "Used(x) :- Source(x).\n",
-            "Sink(x) :- Used(x).\n",
-        ));
+        let diagnostics = run_rule(
+            super::UnusedRelationRule,
+            concat!(
+                "input relation Source(x: u32)\n",
+                "relation Used(x: u32)\n",
+                "relation Sink(x: u32)\n",
+                "Used(x) :- Source(x).\n",
+                "Sink(x) :- Used(x).\n",
+            ),
+        );
 
         assert!(
             diagnostics.iter().all(|diagnostic| diagnostic.message()
@@ -112,11 +103,14 @@ mod tests {
 
     #[rstest]
     fn ignores_unresolved_relation_uses_when_checking_reads() {
-        let diagnostics = run_rule(concat!(
-            "relation Declared(x: u32)\n",
-            "relation Sink(x: u32)\n",
-            "Sink(x) :- Missing(x).\n",
-        ));
+        let diagnostics = run_rule(
+            super::UnusedRelationRule,
+            concat!(
+                "relation Declared(x: u32)\n",
+                "relation Sink(x: u32)\n",
+                "Sink(x) :- Missing(x).\n",
+            ),
+        );
 
         let messages: Vec<_> = diagnostics
             .iter()

--- a/src/linter/rules/correctness/unused_variable.rs
+++ b/src/linter/rules/correctness/unused_variable.rs
@@ -49,23 +49,12 @@ declare_lint! {
 
 #[cfg(test)]
 mod tests {
+    use crate::linter::testing::run_rule;
     use rstest::rstest;
-
-    fn run_rule(source: &str) -> Vec<crate::linter::LintDiagnostic> {
-        let parsed = crate::parse(source);
-        assert!(
-            parsed.errors().is_empty(),
-            "unused-variable test source should parse cleanly: {:?}",
-            parsed.errors()
-        );
-        let mut store = crate::linter::CstRuleStore::new();
-        store.register(Box::new(super::UnusedVariableRule));
-        crate::linter::Runner::new(&store, source, &parsed, crate::linter::RuleConfig::new()).run()
-    }
 
     #[rstest]
     fn warns_for_unused_head_binding() {
-        let diagnostics = run_rule("Output(head_x) :- Source(_).");
+        let diagnostics = run_rule(super::UnusedVariableRule, "Output(head_x) :- Source(_).");
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(
@@ -85,6 +74,7 @@ mod tests {
     #[rstest]
     fn does_not_warn_for_binding_with_resolved_use() {
         let diagnostics = run_rule(
+            super::UnusedVariableRule,
             "Output(head_x) :- Source(head_x), var assigned_x = Seed(head_x), Use(assigned_x).",
         );
 
@@ -96,7 +86,10 @@ mod tests {
 
     #[rstest]
     fn ignores_wildcards_and_unresolved_names() {
-        let diagnostics = run_rule("Output(head_x) :- Missing(other_y).");
+        let diagnostics = run_rule(
+            super::UnusedVariableRule,
+            "Output(head_x) :- Missing(other_y).",
+        );
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(

--- a/src/linter/testing.rs
+++ b/src/linter/testing.rs
@@ -1,0 +1,25 @@
+//! Shared unit-test helpers for linter modules.
+
+use crate::linter::{CstRule, CstRuleStore, LintDiagnostic, RuleConfig, Runner};
+
+/// Run a single CST rule against the provided source text.
+///
+/// # Panics
+///
+/// Panics if the source code fails to parse cleanly.
+#[must_use]
+pub(crate) fn run_rule<R>(rule: R, source: &str) -> Vec<LintDiagnostic>
+where
+    R: CstRule + 'static,
+{
+    let parsed = crate::parse(source);
+    assert!(
+        parsed.errors().is_empty(),
+        "test source should parse cleanly: {:?}",
+        parsed.errors()
+    );
+
+    let mut store = CstRuleStore::new();
+    store.register(Box::new(rule));
+    Runner::new(&store, source, &parsed, RuleConfig::new()).run()
+}

--- a/tests/support/lint.rs
+++ b/tests/support/lint.rs
@@ -1,0 +1,25 @@
+//! Shared integration-test helpers for running a single CST lint rule.
+
+use ddlint::linter::{CstRule, CstRuleStore, LintDiagnostic, RuleConfig, Runner};
+
+/// Run a single CST rule against the provided source text.
+///
+/// # Panics
+///
+/// Panics if the source code fails to parse cleanly.
+#[must_use]
+pub fn run_rule<R>(rule: R, source: &str) -> Vec<LintDiagnostic>
+where
+    R: CstRule + 'static,
+{
+    let parsed = ddlint::parse(source);
+    assert!(
+        parsed.errors().is_empty(),
+        "test source should parse cleanly: {:?}",
+        parsed.errors()
+    );
+
+    let mut store = CstRuleStore::new();
+    store.register(Box::new(rule));
+    Runner::new(&store, source, &parsed, RuleConfig::new()).run()
+}

--- a/tests/support/unused_relation.rs
+++ b/tests/support/unused_relation.rs
@@ -1,8 +1,9 @@
-//! Shared runner setup for `unused-relation` behavioural tests.
+//! Support helper for the `unused-relation` integration tests.
+
+#[path = "lint.rs"]
+mod lint;
 
 use ddlint::linter::rules::correctness::UnusedRelationRule;
-use ddlint::linter::{CstRuleStore, RuleConfig, Runner};
-use ddlint::parse;
 
 /// Run the `unused-relation` lint rule on the given source code.
 ///
@@ -11,14 +12,5 @@ use ddlint::parse;
 /// Panics if the source code fails to parse cleanly.
 #[must_use]
 pub fn run_unused_relation_rule(source: &str) -> Vec<ddlint::linter::LintDiagnostic> {
-    let parsed = parse(source);
-    assert!(
-        parsed.errors().is_empty(),
-        "unused-relation test source should parse cleanly: {:?}",
-        parsed.errors()
-    );
-
-    let mut store = CstRuleStore::new();
-    store.register(Box::new(UnusedRelationRule));
-    Runner::new(&store, source, &parsed, RuleConfig::new()).run()
+    lint::run_rule(UnusedRelationRule, source)
 }

--- a/tests/support/unused_variable.rs
+++ b/tests/support/unused_variable.rs
@@ -1,8 +1,9 @@
-//! Shared runner setup for `unused-variable` behavioural tests.
+//! Support helper for the `unused-variable` integration tests.
+
+#[path = "lint.rs"]
+mod lint;
 
 use ddlint::linter::rules::correctness::UnusedVariableRule;
-use ddlint::linter::{CstRuleStore, RuleConfig, Runner};
-use ddlint::parse;
 
 /// Run the `unused-variable` lint rule on the given source code.
 ///
@@ -11,14 +12,5 @@ use ddlint::parse;
 /// Panics if the source code fails to parse cleanly.
 #[must_use]
 pub fn run_unused_variable_rule(source: &str) -> Vec<ddlint::linter::LintDiagnostic> {
-    let parsed = parse(source);
-    assert!(
-        parsed.errors().is_empty(),
-        "unused-variable test source should parse cleanly: {:?}",
-        parsed.errors()
-    );
-
-    let mut store = CstRuleStore::new();
-    store.register(Box::new(UnusedVariableRule));
-    Runner::new(&store, source, &parsed, RuleConfig::new()).run()
+    lint::run_rule(UnusedVariableRule, source)
 }


### PR DESCRIPTION
## Summary
- Consolidates test-rule runner into a generic run_rule helper and introduces shared test utilities for unit and integration tests.

## Changes
- Added src/linter/testing.rs with a generic run_rule<R>(rule, source) helper:
  - R: CstRule + 'static
  - Parses source, asserts clean parse, builds a CstRuleStore, registers the provided rule, and runs via Runner.
- Exposed the testing module in src/linter/mod.rs under #[cfg(test)] pub(crate) mod testing;
- Introduced tests/support/lint.rs providing a test-oriented run_rule for integration tests (CstRuleStore, Runner, RuleConfig).
- Updated behavioural tests to use the new helpers:
  - tests/support/unused_relation.rs now calls lint::run_rule(UnusedRelationRule, source) instead of duplicating runner logic.
  - tests/support/unused_variable.rs now calls lint::run_rule(UnusedVariableRule, source) similarly.
- Updated unit tests to leverage the new generic run_rule in src/linter/testing.rs, removing in-file duplicated setup.

## Why
- Unifies and reduces duplication between unit and behavioural tests by centralizing rule-running logic.
- Makes it easier to add new rule tests with a single shared helper.

## How to test
- Run cargo test to ensure unit and integration tests pass:
  - Unit tests for unused-relation and unused-variable
  - Integration tests that rely on tests/support/lint.rs

## Notes
- The new run_rule helper enforces a clean parse assertion and returns the vector of LintDiagnostic, matching existing expectations.
- Integration tests now import the lint::run_rule helper via tests/support/lint.rs, reducing boilerplate in test support modules.

◳ Generated by [DevBoxer](https://www.devboxer.com) ◰

---

ℹ️ Tag @devboxerhub to ask questions and address PR feedback

📎 **Task**: https://www.devboxer.com/task/8bc4436c-6542-4fa2-903f-d7b045e95896

📝 Closes #251

## Summary by Sourcery

Consolidate lint rule test execution into shared helpers for unit and integration tests to remove duplicated runner logic.

Enhancements:
- Add a generic run_rule helper in the linter testing module and expose it under cfg(test) for unit tests.
- Introduce a shared tests/support/lint.rs helper to run individual CST rules in integration tests.

Tests:
- Update unused_relation and unused_variable unit tests to use the new linter::testing::run_rule helper.
- Refactor unused_relation and unused_variable integration test support modules to delegate to the shared tests/support/lint::run_rule helper.