### PR TITLE
Centralize Span to TextRange helper in linter design

### DIFF
--- a/docs/ddlint-design.md
+++ b/docs/ddlint-design.md
@@ -739,7 +739,9 @@ still point at the enclosing rule or literal site rather than the exact
 identifier token, so diagnostics for these rules use that existing coarse
 provenance. The semantic model deliberately stays on the `Span` side of that
 boundary; conversion into diagnostic `rowan::TextRange` values happens in the
-linter layer so correctness rules share one linter-owned mapping seam.
+linter layer through one shared boundary helper in `src/linter/span_utils.rs`.
+This keeps a single conversion point, rather than per-rule glue, for
+correctness diagnostics.
 
 Resolution is deliberately tri-state:
 

--- a/docs/ddlint-design.md
+++ b/docs/ddlint-design.md
@@ -737,7 +737,9 @@ wildcard `_` remains an explicit ignore and is never recorded as a
 warning-eligible binding. As of roadmap item `4.1.2`, rule-local binding spans
 still point at the enclosing rule or literal site rather than the exact
 identifier token, so diagnostics for these rules use that existing coarse
-provenance.
+provenance. The semantic model deliberately stays on the `Span` side of that
+boundary; conversion into diagnostic `rowan::TextRange` values happens in the
+linter layer so correctness rules share one linter-owned mapping seam.
 
 Resolution is deliberately tri-state:
 


### PR DESCRIPTION
## Summary
- Clarifies centralized Span to TextRange mapping in the ddlint design docs.
- The semantic model remains on the Span side; conversion to diagnostic TextRange values happens in the linter layer, establishing a single mapping seam.

## Changes
### Documentation
- docs/ddlint-design.md: Updated the boundary description to reflect centralized Span-to-TextRange helper and the location of the conversion logic.

## Rationale
- Aligns design with implementation, ensuring correctness rules share one linter-owned mapping seam and reducing cross-layer duplication.

## Testing
- [x] Rendered Markdown locally without issues
- [x] No code changes; no runtime tests required


◳ Generated by [DevBoxer](https://www.devboxer.com) ◰

---

ℹ️ Tag @devboxerhub to ask questions and address PR feedback

📎 **Task**: https://www.devboxer.com/task/a2d6774d-8120-4b8b-ba52-a3d4bb2af00f

📝 Closes #250

## Summary by Sourcery

Documentation:
- Update ddlint design documentation to state that the semantic model uses Spans and that conversion to diagnostic TextRange values is centralized in the linter layer.