### PR TITLE
Add scheduled mutation testing via the shared workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,13 @@ jobs:
         run: make check-fmt
       - name: Lint
         run: make lint
+      - name: Setup uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39
+        with:
+          python-version: '3.13'
+          enable-cache: true
+      - name: Workflow contract tests
+        run: make test-workflow-contracts
       - name: Generate coverage
         uses: leynos/shared-actions/.github/actions/generate-coverage@aebb3f5b831102e2a10ef909c83d7d50ea86c332
         with:

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -1,0 +1,36 @@
+name: Mutation testing
+
+# Thin caller of the shared mutation-testing reusable workflow; caller
+# guide: leynos/shared-actions docs/mutation-cargo-workflow.md.
+# Scheduled runs mutate only files changed within the detection window;
+# manual dispatch runs mutate everything, fanned out across shards. To
+# test a branch, select it in the Actions "Run workflow" control.
+
+on:
+  schedule:
+    - cron: "5 4 * * *" # Daily, 04:05 UTC
+  workflow_dispatch:
+
+# Default the token to no scopes; the job opts in explicitly.
+permissions: {}
+
+# Serialize runs per ref: a dispatch during a scheduled run (or vice
+# versa) queues rather than racing. Runs are informational, so queued
+# runs wait instead of cancelling.
+concurrency:
+  group: mutation-testing-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  mutation:
+    permissions:
+      contents: read
+      id-token: write # OIDC workflow-source resolution
+    uses: leynos/shared-actions/.github/workflows/mutation-cargo.yml@47aea18960d24f33aedc4782ec6b73e365418313
+    with:
+      # Test-support scaffolding gated on the test-support feature; it
+      # is compiled under --all-features, so its survivors are noise.
+      exclude-globs: "src/test_util/**"
+      # Match the CI baseline (`make test` runs --all-features) so
+      # feature-gated tests run against mutants.
+      extra-args: "--all-features"

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ target/
 Cargo.lock
 .crush/
 .grepai/
+__pycache__/

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: help all clean test build release check lint typecheck fmt check-fmt \
-        markdownlint nixie tools
+        markdownlint nixie tools test-workflow-contracts
 
 APP ?= ddlint
 CARGO ?= $(or $(shell command -v cargo 2>/dev/null),$(HOME)/.cargo/bin/cargo)
@@ -20,6 +20,9 @@ clean: ## Remove build artifacts
 
 test: ## Run tests with warnings treated as errors
 	RUSTFLAGS="-D warnings" $(CARGO) test --all-targets --all-features $(BUILD_JOBS)
+
+test-workflow-contracts: ## Validate the mutation-testing caller contract
+	uv run --with 'pytest>=8' --with 'pyyaml>=6' pytest tests/workflow_contracts -q
 
 target/%/$(APP): ## Build binary in debug or release mode
 	$(CARGO) build $(BUILD_JOBS) $(if $(filter release,$*),--release) --bin $(APP)

--- a/tests/workflow_contracts/mutation_testing_test.py
+++ b/tests/workflow_contracts/mutation_testing_test.py
@@ -1,0 +1,139 @@
+"""Contract tests for the mutation-testing caller workflow.
+
+The executable logic lives in the ``leynos/shared-actions`` reusable
+workflow, which carries its own unit and integration tests; ddlint's
+caller is declarative configuration. These tests parse the caller with
+PyYAML and pin the contract it must uphold, so drift (repointing the pin
+at a branch, widening permissions, or losing the exclude and feature
+configuration) fails CI on the pull request rather than surfacing in a
+scheduled or manual run.
+
+Run via ``make test-workflow-contracts``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+WORKFLOW_PATH = (
+    Path(__file__).resolve().parents[2] / ".github" / "workflows" / "mutation-testing.yml"
+)
+
+#: The pinned commit of leynos/shared-actions (the merge commit of
+#: leynos/shared-actions PR #319). Bump the workflow and this test
+#: together.
+PINNED_SHA = "47aea18960d24f33aedc4782ec6b73e365418313"
+
+EXPECTED_USES = (
+    "leynos/shared-actions/.github/workflows/mutation-cargo.yml@" + PINNED_SHA
+)
+
+EXPECTED_WITH = {
+    "exclude-globs": "src/test_util/**",
+    "extra-args": "--all-features",
+}
+
+
+def _load() -> dict[str, object]:
+    """Parse the workflow file."""
+    return yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+
+
+def _triggers(workflow: dict[str, object]) -> dict[str, object]:
+    """Return the ``on:`` mapping (PyYAML parses the bare key as True)."""
+    triggers = workflow.get("on", workflow.get(True))
+    assert isinstance(triggers, dict), "the workflow must declare an on: mapping"
+    return triggers
+
+
+def _mutation_job(workflow: dict[str, object]) -> dict[str, object]:
+    """Return the single calling job."""
+    jobs = workflow.get("jobs")
+    assert isinstance(jobs, dict), "the workflow must declare a jobs mapping"
+    assert jobs, "the workflow must declare at least one job"
+    assert list(jobs) == ["mutation"], (
+        f"expected a single job named 'mutation', found {sorted(jobs)}"
+    )
+    return jobs["mutation"]
+
+
+def test_uses_reference_is_pinned_to_the_documented_sha() -> None:
+    """The job must call the shared workflow at the exact documented SHA."""
+    uses = _mutation_job(_load()).get("uses")
+    assert uses is not None, "jobs.mutation.uses is missing"
+    path, _, ref = uses.partition("@")
+    assert path == "leynos/shared-actions/.github/workflows/mutation-cargo.yml", (
+        f"jobs.mutation.uses must reference mutation-cargo.yml, got {path!r}"
+    )
+    assert len(ref) == 40, (
+        f"jobs.mutation.uses must pin a full 40-character commit SHA, "
+        f"not a branch or tag: {ref!r}"
+    )
+    assert all(c in "0123456789abcdef" for c in ref), (
+        f"jobs.mutation.uses must pin a lowercase hex commit SHA, "
+        f"not a branch or tag: {ref!r}"
+    )
+    assert uses == EXPECTED_USES, (
+        f"jobs.mutation.uses pins {ref!r}; the execution plan documents {PINNED_SHA!r} — "
+        "bump the plan and this test together with the workflow"
+    )
+
+
+def test_job_permissions_are_exactly_least_privilege() -> None:
+    """The job grants contents: read and id-token: write, nothing broader."""
+    permissions = _mutation_job(_load()).get("permissions")
+    assert permissions == {"contents": "read", "id-token": "write"}, (
+        "jobs.mutation.permissions must be exactly "
+        f"{{'contents': 'read', 'id-token': 'write'}}, got {permissions!r}"
+    )
+
+
+def test_workflow_default_permissions_are_empty() -> None:
+    """The workflow-level default token scope is empty."""
+    workflow = _load()
+    assert workflow.get("permissions") == {}, (
+        f"top-level permissions must be an empty mapping, got "
+        f"{workflow.get('permissions')!r}"
+    )
+
+
+def test_concurrency_serializes_per_ref_without_cancelling() -> None:
+    """Runs queue per ref instead of cancelling one another."""
+    concurrency = _load().get("concurrency")
+    assert isinstance(concurrency, dict), "the workflow must declare concurrency"
+    assert concurrency.get("group") == "mutation-testing-${{ github.ref }}", (
+        f"concurrency.group must key on the triggering ref, got "
+        f"{concurrency.get('group')!r}"
+    )
+    assert concurrency.get("cancel-in-progress") is False, (
+        f"concurrency.cancel-in-progress must be false, got "
+        f"{concurrency.get('cancel-in-progress')!r}"
+    )
+
+
+def test_triggers_keep_schedule_and_plain_dispatch() -> None:
+    """The daily schedule stays; dispatch has no legacy branch input."""
+    triggers = _triggers(_load())
+    schedule = triggers.get("schedule")
+    assert schedule == [{"cron": "5 4 * * *"}], (
+        f"on.schedule must be the daily 04:05 UTC cron, got {schedule!r}"
+    )
+    assert "workflow_dispatch" in triggers, "on.workflow_dispatch is missing"
+    dispatch = triggers.get("workflow_dispatch") or {}
+    inputs = dispatch.get("inputs") or {}
+    assert "branch" not in inputs, (
+        "on.workflow_dispatch must not declare a branch input; the Actions "
+        "run-workflow control selects the ref"
+    )
+
+
+def test_with_block_carries_the_caller_configuration() -> None:
+    """The caller passes exactly the test-util exclude and feature args."""
+    with_block = _mutation_job(_load()).get("with")
+    assert with_block == EXPECTED_WITH, (
+        "jobs.mutation.with must exclude the test-support scaffolding and "
+        f"mirror the CI --all-features baseline: expected {EXPECTED_WITH!r}, "
+        f"got {with_block!r}"
+    )


### PR DESCRIPTION
## Summary

Adopts scheduled mutation testing for ddlint as a thin caller of the
`leynos/shared-actions` reusable workflow `mutation-cargo.yml`, pinned to
commit `47aea1896`. Runs are informational only: a daily guard at 04:05 UTC
mutates recently changed files, while manual dispatch fans a full run out
across shards.

## Configuration for this repository

- `extra-args: "--all-features"` mirrors the CI baseline (`make test` runs
  `--all-features`), so feature-gated tests run against mutants.
- `exclude-globs: "src/test_util/**"` excludes the test-support scaffolding
  gated on the `test-support` feature; under `--all-features` it is compiled
  into the mutable surface, and its survivors would be noise.
- The default mutation paths are kept: ddlint is a single root crate with all
  Rust source under `src/`, and `examples/` contains only DDlog fixture files.
  Modules under `#[cfg(test)]` (`src/parser/tests`, `src/sema/tests`,
  `src/linter/testing.rs`) are skipped by cargo-mutants automatically.

A contract test suite (`tests/workflow_contracts/mutation_testing_test.py`)
pins the caller's `uses:` reference, least-privilege permissions, concurrency
settings, triggers, and `with:` block, so drift fails CI on the pull request
rather than in a scheduled run. It is wired into CI through a new
`test-workflow-contracts` Makefile target with a uv setup step after Lint.

## Validation

- YAML parse of both workflows via PyYAML.
- `actionlint` on `mutation-testing.yml` and `ci.yml`: clean.
- `make test-workflow-contracts`: 6 passed, including a negative test in
  which the pin was temporarily repointed at `@v1` (the SHA assertion failed
  as expected) before being restored to green.

## References

- Caller guide: https://github.com/leynos/shared-actions/blob/main/docs/mutation-cargo-workflow.md
- Estate template PR: https://github.com/leynos/wireframe/pull/572
