### PR TITLE
Wire the CodeScene coverage gate into CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,12 +40,13 @@ jobs:
           format: lcov
           use-cargo-nextest: 'false'
           with-ratchet: 'true'
-      - name: Check coverage against CodeScene gates
-        if: env.CS_ACCESS_TOKEN
-        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
-        with:
-          format: lcov
-          mode: check
-          project-url: https://api.codescene.io/v2/projects/69278
-          access-token: ${{ env.CS_ACCESS_TOKEN }}
-          installer-checksum: ${{ env.CODESCENE_CLI_SHA256 }}
+      # The `mode: check` step is deliberately not wired in yet: CodeScene
+      # project 69278 has no coverage-gates configuration, so
+      # `cs-coverage check` fails every run with "HTTP call succeeded,
+      # but the received project-config isn't valid. Lacks the gates
+      # configuration." — a CodeScene-side per-project setting, not a CI
+      # defect (chutoro's project hit the byte-identical error). Add the
+      # check step in a fast-follow PR once coverage-main.yml has
+      # uploaded to main at least once and the gate is confirmed to
+      # resolve, or once CodeScene confirms the project's coverage gate
+      # is enabled.

--- a/.github/workflows/coverage-main.yml
+++ b/.github/workflows/coverage-main.yml
@@ -1,13 +1,18 @@
-name: CI
+name: Coverage (main)
+
+# CodeScene accepts `cs-coverage upload` only for analysed branches, so
+# main-branch coverage is uploaded here on push; pull requests run the
+# changed-line gate (`cs-coverage check`) in ci.yml instead. This
+# workflow also advances the coverage ratchet baseline: caches saved on
+# main are readable by every pull-request run, so the baseline written
+# here is the one PR ratchet checks compare against.
 
 on:
-  pull_request:
-    branches: [main]
   push:
     branches: [main]
 
 jobs:
-  build-test:
+  coverage-upload:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -18,21 +23,8 @@ jobs:
       CODESCENE_CLI_SHA256: ${{ vars.CODESCENE_CLI_SHA256 || '' }}
     steps:
       - uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
       - name: Setup Rust
         uses: leynos/shared-actions/.github/actions/setup-rust@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
-      - name: Format
-        run: make check-fmt
-      - name: Lint
-        run: make lint
-      - name: Setup uv
-        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39
-        with:
-          python-version: '3.13'
-          enable-cache: true
-      - name: Workflow contract tests
-        run: make test-workflow-contracts
       - name: Generate coverage
         uses: leynos/shared-actions/.github/actions/generate-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
         with:
@@ -40,12 +32,10 @@ jobs:
           format: lcov
           use-cargo-nextest: 'false'
           with-ratchet: 'true'
-      - name: Check coverage against CodeScene gates
+      - name: Upload coverage data to CodeScene
         if: env.CS_ACCESS_TOKEN
         uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
         with:
           format: lcov
-          mode: check
-          project-url: https://api.codescene.io/v2/projects/69278
           access-token: ${{ env.CS_ACCESS_TOKEN }}
           installer-checksum: ${{ env.CODESCENE_CLI_SHA256 }}

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -28,6 +28,6 @@ jobs:
       # The token is not used for any external cloud auth.
       id-token: write
     if: ${{ github.event_name == 'workflow_dispatch' || github.actor == 'dependabot[bot]' }}
-    uses: leynos/shared-actions/.github/workflows/dependabot-automerge.yml@1213d7874aa42ff034587d9385f35178d51e1f65
+    uses: leynos/shared-actions/.github/workflows/dependabot-automerge.yml@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
     with:
       pull-request-number: ${{ inputs.pull-request-number || github.event.pull_request.number }}

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -26,7 +26,7 @@ jobs:
     permissions:
       contents: read
       id-token: write # OIDC workflow-source resolution
-    uses: leynos/shared-actions/.github/workflows/mutation-cargo.yml@47aea18960d24f33aedc4782ec6b73e365418313
+    uses: leynos/shared-actions/.github/workflows/mutation-cargo.yml@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
     with:
       # Test-support scaffolding gated on the test-support feature; it
       # is compiled under --all-features, so its survivors are noise.

--- a/tests/workflow_contracts/mutation_testing_test.py
+++ b/tests/workflow_contracts/mutation_testing_test.py
@@ -21,10 +21,11 @@ WORKFLOW_PATH = (
     Path(__file__).resolve().parents[2] / ".github" / "workflows" / "mutation-testing.yml"
 )
 
-#: The pinned commit of leynos/shared-actions (the merge commit of
-#: leynos/shared-actions PR #319). Bump the workflow and this test
-#: together.
-PINNED_SHA = "47aea18960d24f33aedc4782ec6b73e365418313"
+#: The pinned commit of leynos/shared-actions (leynos/shared-actions
+#: PR #334, which adds the `mode: check` coverage gate used by the CI
+#: workflow's coverage steps; the estate keeps a single repo-wide pin).
+#: Bump the workflow and this test together.
+PINNED_SHA = "927edd45ae77be4251a8a18ca9eb5613a2e32cbd"
 
 EXPECTED_USES = (
     "leynos/shared-actions/.github/workflows/mutation-cargo.yml@" + PINNED_SHA


### PR DESCRIPTION
## Summary

**Update:** the pull-request `mode: check` step described below has
been removed from this PR (see the second commit). CodeScene project
69278 has no coverage-gates configuration yet, so `cs-coverage check`
fails every run with "HTTP call succeeded, but the received
project-config isn't valid. Lacks the gates configuration." — a
CodeScene-side per-project setting, confirmed not to be a defect here
because `leynos/chutoro`'s CodeScene project hit the byte-identical
error on the same day. Wiring the step now would turn the required
`build-test` check permanently red. The upload half (`coverage-main.yml`)
does not depend on the gate and is unaffected. A fast-follow PR will
add the check step once the gate resolves (either automatically after
the first main-branch upload, or via a CodeScene-side toggle).

- Bump every `leynos/shared-actions` pin in this repository to
  `927edd45ae77be4251a8a18ca9eb5613a2e32cbd` (shared-actions#334),
  which adds the `mode: check` coverage gate and fixes the two upload
  defects described in shared-actions#333.
- Check out with `fetch-depth: 0` and enable the coverage ratchet
  (`with-ratchet: 'true'`) in CI, ready for the fast-follow's `mode:
  check` step (kept out of this PR — see the update note above).
- Add
  [`coverage-main.yml`](https://github.com/leynos/ddlint/blob/codescene-coverage-gate/.github/workflows/coverage-main.yml),
  which uploads coverage (`mode: upload`, the default) on every push
  to `main` — the only branch CodeScene's project analyses — and
  writes the ratchet baseline that pull-request runs compare against
  (caches saved on `main` are readable by every PR; caches saved by a
  PR are scoped to that PR branch, so the baseline must be written on
  `main`).
- Set `CS_ACCESS_TOKEN` in both the Actions and Dependabot secret
  stores so guarded steps run under both trigger types.
- Update the mutation-testing workflow contract test's pinned SHA to
  match the repo-wide pin bump.

## Review walkthrough

- [`.github/workflows/ci.yml`](https://github.com/leynos/ddlint/blob/codescene-coverage-gate/.github/workflows/ci.yml) —
  pin bump, `fetch-depth: 0`, ratchet; the `mode: check` gate is
  documented in a comment but deliberately not wired in (see the
  update note above).
- [`.github/workflows/coverage-main.yml`](https://github.com/leynos/ddlint/blob/codescene-coverage-gate/.github/workflows/coverage-main.yml) —
  new push-to-main upload workflow, modelled on
  [mxd#362](https://github.com/leynos/mxd/pull/362).
- [`.github/workflows/dependabot-automerge.yml`](https://github.com/leynos/ddlint/blob/codescene-coverage-gate/.github/workflows/dependabot-automerge.yml)
  and
  [`.github/workflows/mutation-testing.yml`](https://github.com/leynos/ddlint/blob/codescene-coverage-gate/.github/workflows/mutation-testing.yml) —
  pin bump only, no behavioural change (single repo-wide
  `shared-actions` pin).
- [`tests/workflow_contracts/mutation_testing_test.py`](https://github.com/leynos/ddlint/blob/codescene-coverage-gate/tests/workflow_contracts/mutation_testing_test.py) —
  pinned-SHA contract updated alongside the workflow it checks.

Note for reviewers: the `CodeScene Code Coverage` check the CodeScene
GitHub App posts is not a required check in this repository's
ruleset — it feeds the overall commit-status rollup instead, which is
what Dependabot's automerge gate reads. That's why a stuck or
timed-out CodeScene check silently blocks automerge without appearing
in the required-checks list; this change makes that check actually
resolve instead of hanging. Enabling CodeScene's coverage gate itself
is a CodeScene-side, per-project setting this PR cannot flip — it only
wires the CI side so that switch is safe to flip once desired.

## Validation

- `python3 -c "import yaml; yaml.safe_load(open(...))"` for every
  workflow file under `.github/workflows/`.
- `uv run --with 'pytest>=8' --with 'pyyaml>=6' pytest
  tests/workflow_contracts -q` — 6 passed.
- `CS_ACCESS_TOKEN` confirmed set in both the Actions and Dependabot
  secret stores for `leynos/ddlint`.
- The repo's full build/lint/test suite was not run locally per the
  rollout's execution mechanics (shared, heavy machine); CI on this
  PR's own head is the validation surface for the coverage job.
- Confirmed on this PR's own head that `build-test` passes with the
  `mode: check` step removed, and that `CodeScene Code Health Review`
  (a separate, already-working check) still passes.
