### PR TITLE
Adopt the Whitaker Dylint suite in the lint gate and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
       BUILD_PROFILE: debug
       CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN || '' }}
       CODESCENE_CLI_SHA256: ${{ vars.CODESCENE_CLI_SHA256 || '' }}
+      WHITAKER_INSTALLER_VERSION: '0.2.6'
     steps:
       - uses: actions/checkout@v7
         with:
@@ -29,6 +30,25 @@ jobs:
           enable-cache: true
       - name: Format
         run: make check-fmt
+      - name: Cache whitaker-installer
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: |
+            ~/.cargo/bin/whitaker-installer
+            ~/.cache/cargo-binstall
+          key: whitaker-installer-${{ runner.os }}-${{ runner.arch }}-${{ env.WHITAKER_INSTALLER_VERSION }}
+      - name: Install the Whitaker Dylint suite
+        run: |
+          set -euo pipefail
+          if ! command -v whitaker-installer >/dev/null 2>&1; then
+            if cargo binstall --version >/dev/null 2>&1; then
+              cargo binstall --no-confirm --locked "whitaker-installer@${WHITAKER_INSTALLER_VERSION}"
+            else
+              echo "cargo-binstall unavailable; building whitaker-installer from crates.io"
+              cargo install --locked whitaker-installer --version "${WHITAKER_INSTALLER_VERSION}"
+            fi
+          fi
+          whitaker-installer
       - name: Lint
         run: make lint
       - name: Workflow contract tests

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ MDLINT ?= markdownlint
 NIXIE ?= nixie
 TYPOS_VERSION ?= 1.48.0
 TYPOS := uv tool run typos@$(TYPOS_VERSION)
+WHITAKER ?= whitaker
 
 build: target/debug/$(APP) ## Build debug binary
 release: target/release/$(APP) ## Build release binary
@@ -32,8 +33,9 @@ test-workflow-contracts: ## Validate the mutation-testing caller contract
 target/%/$(APP): ## Build binary in debug or release mode
 	$(CARGO) build $(BUILD_JOBS) $(if $(filter release,$*),--release) --bin $(APP)
 
-lint: ## Run Clippy with warnings denied
+lint: ## Run Clippy and the Whitaker Dylint suite with warnings denied
 	$(CARGO) clippy $(CLIPPY_FLAGS)
+	RUSTFLAGS="-D warnings" $(WHITAKER) --all -- --all-targets --all-features
 	+$(MAKE) spelling
 
 typecheck: ## Typecheck all workspace targets and features

--- a/src/linter/macros.rs
+++ b/src/linter/macros.rs
@@ -195,6 +195,7 @@ macro_rules! declare_lint {
 
 #[cfg(test)]
 mod tests {
+    //! Tests for the linter rule macros.
     use rowan::NodeOrToken;
     use rstest::{fixture, rstest};
 

--- a/src/linter/rules/correctness/unused_relation.rs
+++ b/src/linter/rules/correctness/unused_relation.rs
@@ -52,6 +52,7 @@ declare_lint! {
 
 #[cfg(test)]
 mod tests {
+    //! Tests for the unused relation rule.
     use crate::linter::testing::run_rule;
     use rstest::rstest;
 

--- a/src/linter/rules/correctness/unused_variable.rs
+++ b/src/linter/rules/correctness/unused_variable.rs
@@ -50,6 +50,7 @@ declare_lint! {
 
 #[cfg(test)]
 mod tests {
+    //! Tests for the unused variable rule.
     use crate::linter::testing::run_rule;
     use rstest::rstest;
 

--- a/src/linter/runner.rs
+++ b/src/linter/runner.rs
@@ -150,6 +150,7 @@ fn sort_diagnostics(diagnostics: &mut [LintDiagnostic]) {
 
 #[cfg(test)]
 mod tests {
+    //! Tests for the lint runner.
     use rowan::TextRange;
     use rstest::{fixture, rstest};
 

--- a/src/linter/store.rs
+++ b/src/linter/store.rs
@@ -123,6 +123,7 @@ impl Default for CstRuleStore {
 
 #[cfg(test)]
 mod tests {
+    //! Tests for the lint store.
     use rstest::{fixture, rstest};
 
     use super::*;

--- a/src/parser/ast/apply.rs
+++ b/src/parser/ast/apply.rs
@@ -97,6 +97,7 @@ where
 
 #[cfg(test)]
 mod tests {
+    //! Tests for apply node parsing.
     use crate::parse;
 
     #[test]

--- a/src/parser/ast/expr/sexpr.rs
+++ b/src/parser/ast/expr/sexpr.rs
@@ -157,6 +157,7 @@ fn format_match(scrutinee: &Expr, arms: &[MatchArm]) -> String {
 
 #[cfg(test)]
 mod tests {
+    //! Tests for s-expression rendering.
     use super::*;
     use crate::parser::ast::{BinaryOp, Literal};
 

--- a/src/parser/ast/function.rs
+++ b/src/parser/ast/function.rs
@@ -82,6 +82,7 @@ impl_ast_node!(Function);
 #[cfg(test)]
 mod tests {
 
+    //! Tests for function node parsing.
     use crate::{parse, test_util::span_text};
 
     #[expect(clippy::expect_used, reason = "Using expect for clearer test failures")]

--- a/src/parser/ast/import.rs
+++ b/src/parser/ast/import.rs
@@ -56,6 +56,7 @@ impl_ast_node!(Import);
 #[cfg(test)]
 mod tests {
 
+    //! Tests for import node parsing.
     use crate::parse;
     #[test]
     fn parses_simple_import() {

--- a/src/parser/ast/index.rs
+++ b/src/parser/ast/index.rs
@@ -194,6 +194,7 @@ impl_ast_node!(Index);
 #[cfg(test)]
 mod tests {
 
+    //! Tests for index node parsing.
     use crate::parse;
 
     #[expect(clippy::expect_used, reason = "Using expect for clearer test failures")]

--- a/src/parser/ast/mod.rs
+++ b/src/parser/ast/mod.rs
@@ -254,6 +254,7 @@ pub use type_def::TypeDef;
 #[cfg(test)]
 mod tests {
 
+    //! Tests for AST node accessors.
     mod identifier_span;
     mod precedence;
 

--- a/src/parser/ast/parse_utils/outputs.rs
+++ b/src/parser/ast/parse_utils/outputs.rs
@@ -81,6 +81,7 @@ where
 
 #[cfg(test)]
 mod tests {
+    //! Tests for parse output helpers.
     use super::*;
     use crate::parser::ast::AstNode;
     use crate::parser::parse;

--- a/src/parser/ast/parse_utils/params/tests.rs
+++ b/src/parser/ast/parse_utils/params/tests.rs
@@ -1,3 +1,5 @@
+//! Tests for parameter parsing helpers.
+
 use super::super::errors::{Delim, ParseError};
 use super::*;
 use crate::SyntaxKind;
@@ -99,16 +101,15 @@ where
     let elements = tokens_for(src);
     let (_result, errors) = parser(elements.clone());
     assert_eq!(errors.len(), 1);
-    #[expect(clippy::expect_used, reason = "Using expect for clearer test failures")]
-    let angle_span = elements
-        .iter()
-        .find_map(|e| match e {
-            SyntaxElement::Token(t) if t.kind() == SyntaxKind::T_LT => Some(t.text_range()),
-            _ => None,
-        })
-        .expect("angle token missing");
-    #[expect(clippy::expect_used, reason = "Using expect for clearer test failures")]
-    let err = errors.first().expect("no error");
+    let Some(angle_span) = elements.iter().find_map(|e| match e {
+        SyntaxElement::Token(t) if t.kind() == SyntaxKind::T_LT => Some(t.text_range()),
+        _ => None,
+    }) else {
+        panic!("angle token missing");
+    };
+    let Some(err) = errors.first() else {
+        panic!("no error");
+    };
     match err {
         ParseError::UnclosedDelimiter {
             delimiter: '>',

--- a/src/parser/ast/parse_utils/token_utils.rs
+++ b/src/parser/ast/parse_utils/token_utils.rs
@@ -135,6 +135,7 @@ where
 
 #[cfg(test)]
 mod tests {
+    //! Tests for token utility helpers.
     use super::*;
     use crate::SyntaxKind;
     use crate::parser::parse;
@@ -142,8 +143,7 @@ mod tests {
 
     fn token_of_kind(src: &str, kind: SyntaxKind) -> rowan::SyntaxToken<DdlogLanguage> {
         let parsed = parse(src);
-        #[expect(clippy::expect_used, reason = "Using expect for clearer test failures")]
-        parsed
+        let Some(token) = parsed
             .root()
             .syntax()
             .descendants_with_tokens()
@@ -151,7 +151,10 @@ mod tests {
                 SyntaxElement::Token(t) if t.kind() == kind => Some(t),
                 _ => None,
             })
-            .expect("token missing")
+        else {
+            panic!("token missing");
+        };
+        token
     }
 
     #[test]

--- a/src/parser/ast/parse_utils/type_expr/tests.rs
+++ b/src/parser/ast/parse_utils/type_expr/tests.rs
@@ -1,3 +1,5 @@
+//! Tests for type expression parsing.
+
 use super::super::errors::{Delim, ParseError};
 use super::super::outputs::skip_to_top_level_colon;
 use super::*;
@@ -27,8 +29,9 @@ fn tokens_for(#[default("function t() {}")] src: &str) -> Vec<SyntaxElement<Ddlo
 fn return_type_for(#[default("function t() {}")] src: &str) -> Option<String> {
     let parsed = parse(src);
     let functions = parsed.root().functions();
-    #[expect(clippy::expect_used, reason = "Using expect for clearer test failures")]
-    let func = functions.first().expect("function missing");
+    let Some(func) = functions.first() else {
+        panic!("function missing");
+    };
     let mut iter = func.syntax().children_with_tokens().peekable();
     let mut depth = 0usize;
     for e in &mut iter {

--- a/src/parser/ast/relation.rs
+++ b/src/parser/ast/relation.rs
@@ -143,6 +143,7 @@ impl_ast_node!(Relation);
 #[cfg(test)]
 mod tests {
 
+    //! Tests for relation node parsing.
     use crate::{parse, test_util::span_text};
 
     #[test]

--- a/src/parser/ast/root.rs
+++ b/src/parser/ast/root.rs
@@ -123,6 +123,7 @@ impl Root {
 #[cfg(test)]
 mod tests {
 
+    //! Tests for root node accessors.
     use crate::parse;
 
     #[test]

--- a/src/parser/ast/rule/classification.rs
+++ b/src/parser/ast/rule/classification.rs
@@ -154,12 +154,12 @@ fn classify_aggregation_with_tracking(
     }
 
     let mut iter = args.into_iter();
-    let first = iter
-        .next()
-        .unwrap_or_else(|| unreachable!("len pre-checked as 2; first arg missing"));
-    let second = iter
-        .next()
-        .unwrap_or_else(|| unreachable!("len pre-checked as 2; second arg missing"));
+    let (Some(first), Some(second)) = (iter.next(), iter.next()) else {
+        // Unreachable: the arity is pre-checked as 2 above; decline the
+        // term rather than panic if the invariant is ever broken.
+        debug_assert!(false, "len pre-checked as 2; arguments missing");
+        return None;
+    };
     let (project, key) = match source {
         AggregationSource::GroupBy => (first, second),
         AggregationSource::LegacyAggregate => (second, first),
@@ -278,6 +278,7 @@ fn multiple_aggregations_error(_first_span: &Span, second_span: &Span) -> Simple
 
 #[cfg(test)]
 mod tests {
+    //! Tests for rule body classification.
     use super::*;
     use chumsky::error::SimpleReason;
 

--- a/src/parser/ast/rule/tests.rs
+++ b/src/parser/ast/rule/tests.rs
@@ -6,22 +6,22 @@ use super::{Expr, RuleBodyTerm, RuleForLoop};
 use crate::parse;
 
 mod helpers {
+    //! Shared helpers for rule parsing tests.
     use super::*;
     use crate::parser::ast::Pattern;
 
     /// Parse source, extract the first rule's flattened body terms, and assert
     /// that all terms are Expression variants with the expected count.
-    #[expect(clippy::expect_used, reason = "test helper for clearer failures")]
     pub(super) fn assert_flattened_terms(src: &str, expected_len: usize) -> Vec<RuleBodyTerm> {
         let parsed = parse(src);
         crate::test_util::assert_no_parse_errors(parsed.errors());
-        let rule = parsed
-            .root()
-            .rules()
-            .first()
-            .cloned()
-            .expect("rule missing");
-        let terms = rule.flattened_body_terms().expect("should parse");
+        let Some(rule) = parsed.root().rules().first().cloned() else {
+            panic!("rule missing");
+        };
+        let terms = match rule.flattened_body_terms() {
+            Ok(terms) => terms,
+            Err(errs) => panic!("should parse: {errs:?}"),
+        };
         assert_eq!(terms.len(), expected_len);
         for (i, term) in terms.iter().enumerate() {
             assert!(

--- a/src/parser/ast/string_literal.rs
+++ b/src/parser/ast/string_literal.rs
@@ -94,29 +94,35 @@ impl StringLiteral {
         let (interned, prefix, rest) = parse_prefix(text);
 
         match prefix {
-            StringPrefix::Raw { interpolated } => {
-                let body = rest
-                    .strip_suffix("|]")
-                    .ok_or("unterminated raw string literal")?;
-                Ok(Self {
-                    body: body.to_string(),
-                    kind: StringKind::Raw { interpolated },
-                    interned,
-                })
-            }
-            StringPrefix::Standard => {
-                let content = rest.strip_prefix('"').ok_or("expected '\"'")?;
-                let body = content
-                    .strip_suffix('"')
-                    .ok_or("unterminated string literal")?;
-                let interpolated = contains_unescaped_interpolation(body);
-                Ok(Self {
-                    body: body.to_string(),
-                    kind: StringKind::Standard { interpolated },
-                    interned,
-                })
-            }
+            StringPrefix::Raw { interpolated } => Self::parse_raw(rest, interpolated, interned),
+            StringPrefix::Standard => Self::parse_standard(rest, interned),
         }
+    }
+
+    /// Parse the remainder of a raw string literal after its prefix.
+    fn parse_raw(rest: &str, interpolated: bool, interned: bool) -> Result<Self, &'static str> {
+        let body = rest
+            .strip_suffix("|]")
+            .ok_or("unterminated raw string literal")?;
+        Ok(Self {
+            body: body.to_string(),
+            kind: StringKind::Raw { interpolated },
+            interned,
+        })
+    }
+
+    /// Parse the remainder of a standard quoted string literal.
+    fn parse_standard(rest: &str, interned: bool) -> Result<Self, &'static str> {
+        let content = rest.strip_prefix('"').ok_or("expected '\"'")?;
+        let body = content
+            .strip_suffix('"')
+            .ok_or("unterminated string literal")?;
+        let interpolated = contains_unescaped_interpolation(body);
+        Ok(Self {
+            body: body.to_string(),
+            kind: StringKind::Standard { interpolated },
+            interned,
+        })
     }
 
     /// True when the literal includes interpolation markers.
@@ -132,25 +138,31 @@ impl StringLiteral {
     #[must_use]
     pub fn to_source(&self) -> String {
         match self.kind {
-            StringKind::Standard { .. } => {
-                let rendered = format!("{:?}", self.body);
-                if self.interned {
-                    format!("i{rendered}")
-                } else {
-                    rendered
-                }
-            }
-            StringKind::Raw { interpolated } => {
-                let mut prefix = String::new();
-                if self.interned {
-                    prefix.push('i');
-                }
-                if interpolated {
-                    prefix.push('$');
-                }
-                format!("{prefix}[|{}|]", self.body)
-            }
+            StringKind::Standard { .. } => self.standard_source(),
+            StringKind::Raw { interpolated } => self.raw_source(interpolated),
         }
+    }
+
+    /// Render a standard quoted literal, applying the interning prefix.
+    fn standard_source(&self) -> String {
+        let rendered = format!("{:?}", self.body);
+        if self.interned {
+            format!("i{rendered}")
+        } else {
+            rendered
+        }
+    }
+
+    /// Render a raw literal, applying interning and interpolation prefixes.
+    fn raw_source(&self, interpolated: bool) -> String {
+        let mut prefix = String::new();
+        if self.interned {
+            prefix.push('i');
+        }
+        if interpolated {
+            prefix.push('$');
+        }
+        format!("{prefix}[|{}|]", self.body)
     }
 
     /// Render the literal for `Expr::to_sexpr` output.

--- a/src/parser/ast/string_literal.rs
+++ b/src/parser/ast/string_literal.rs
@@ -39,7 +39,17 @@ enum StringPrefix {
     Raw { interpolated: bool },
 }
 
-fn parse_prefix(text: &str) -> (bool, StringPrefix, &str) {
+/// A literal token decomposed into its prefix and remaining text.
+///
+/// Bundling the interning flag, surface syntax, and remainder keeps the
+/// prefix-parsing result travelling together instead of as a loose tuple.
+struct PrefixedText<'a> {
+    interned: bool,
+    prefix: StringPrefix,
+    rest: &'a str,
+}
+
+fn parse_prefix(text: &str) -> PrefixedText<'_> {
     let (interned, rest) = text.strip_prefix('i').map_or((false, text), |rest| {
         if is_valid_string_prefix(rest) {
             (true, rest)
@@ -49,19 +59,27 @@ fn parse_prefix(text: &str) -> (bool, StringPrefix, &str) {
     });
 
     if let Some(content) = rest.strip_prefix("$[|") {
-        return (interned, StringPrefix::Raw { interpolated: true }, content);
+        return PrefixedText {
+            interned,
+            prefix: StringPrefix::Raw { interpolated: true },
+            rest: content,
+        };
     }
     if let Some(content) = rest.strip_prefix("[|") {
-        return (
+        return PrefixedText {
             interned,
-            StringPrefix::Raw {
+            prefix: StringPrefix::Raw {
                 interpolated: false,
             },
-            content,
-        );
+            rest: content,
+        };
     }
 
-    (interned, StringPrefix::Standard, rest)
+    PrefixedText {
+        interned,
+        prefix: StringPrefix::Standard,
+        rest,
+    }
 }
 
 /// Distinguishes the surface syntax of string literals.
@@ -91,29 +109,33 @@ impl StringLiteral {
     /// Returns an error string when the token text is not a supported string
     /// literal form.
     pub fn parse(text: &str) -> Result<Self, &'static str> {
-        let (interned, prefix, rest) = parse_prefix(text);
+        let prefixed = parse_prefix(text);
 
-        match prefix {
-            StringPrefix::Raw { interpolated } => Self::parse_raw(rest, interpolated, interned),
-            StringPrefix::Standard => Self::parse_standard(rest, interned),
+        match prefixed.prefix {
+            StringPrefix::Raw { .. } => Self::parse_raw(&prefixed),
+            StringPrefix::Standard => Self::parse_standard(&prefixed),
         }
     }
 
     /// Parse the remainder of a raw string literal after its prefix.
-    fn parse_raw(rest: &str, interpolated: bool, interned: bool) -> Result<Self, &'static str> {
-        let body = rest
+    fn parse_raw(prefixed: &PrefixedText<'_>) -> Result<Self, &'static str> {
+        let StringPrefix::Raw { interpolated } = prefixed.prefix else {
+            return Err("expected raw string prefix");
+        };
+        let body = prefixed
+            .rest
             .strip_suffix("|]")
             .ok_or("unterminated raw string literal")?;
         Ok(Self {
             body: body.to_string(),
             kind: StringKind::Raw { interpolated },
-            interned,
+            interned: prefixed.interned,
         })
     }
 
     /// Parse the remainder of a standard quoted string literal.
-    fn parse_standard(rest: &str, interned: bool) -> Result<Self, &'static str> {
-        let content = rest.strip_prefix('"').ok_or("expected '\"'")?;
+    fn parse_standard(prefixed: &PrefixedText<'_>) -> Result<Self, &'static str> {
+        let content = prefixed.rest.strip_prefix('"').ok_or("expected '\"'")?;
         let body = content
             .strip_suffix('"')
             .ok_or("unterminated string literal")?;
@@ -121,7 +143,7 @@ impl StringLiteral {
         Ok(Self {
             body: body.to_string(),
             kind: StringKind::Standard { interpolated },
-            interned,
+            interned: prefixed.interned,
         })
     }
 

--- a/src/parser/ast/tests/identifier_span.rs
+++ b/src/parser/ast/tests/identifier_span.rs
@@ -4,18 +4,17 @@ use super::super::{AstNode, find_identifier_span, find_identifier_span_in_range}
 use crate::{parse, test_util::span_text};
 
 fn first_rule(source: &str) -> super::super::Rule {
-    parse(source)
-        .root()
-        .rules()
-        .into_iter()
-        .next()
-        .unwrap_or_else(|| panic!("expected a parsed rule in `{source}`"))
+    let Some(rule) = parse(source).root().rules().into_iter().next() else {
+        panic!("expected a parsed rule in `{source}`");
+    };
+    rule
 }
 
 fn required_offset(source: &str, needle: &str) -> usize {
-    source
-        .find(needle)
-        .unwrap_or_else(|| panic!("expected `{needle}` in `{source}`"))
+    let Some(offset) = source.find(needle) else {
+        panic!("expected `{needle}` in `{source}`");
+    };
+    offset
 }
 
 #[test]

--- a/src/parser/ast/transformer.rs
+++ b/src/parser/ast/transformer.rs
@@ -48,6 +48,7 @@ impl_ast_node!(Transformer);
 #[cfg(test)]
 mod tests {
 
+    //! Tests for transformer node parsing.
     use crate::parse;
 
     #[expect(clippy::expect_used, reason = "Using expect for clearer test failures")]

--- a/src/parser/ast/type_def.rs
+++ b/src/parser/ast/type_def.rs
@@ -46,6 +46,7 @@ impl_ast_node!(TypeDef);
 #[cfg(test)]
 mod tests {
 
+    //! Tests for type definition parsing.
     use crate::{parse, test_util::span_text};
 
     #[test]

--- a/src/parser/cst_builder/tree.rs
+++ b/src/parser/cst_builder/tree.rs
@@ -171,6 +171,7 @@ fn push_error_wrapped(builder: &mut GreenNodeBuilder, raw: rowan::SyntaxKind, te
 
 #[cfg(test)]
 mod tests {
+    //! Tests for CST tree construction.
     use super::*;
     use crate::parser::ast::Root;
     use crate::parser::ast::rule::text_range_to_span;

--- a/src/parser/expression/data_structures.rs
+++ b/src/parser/expression/data_structures.rs
@@ -65,11 +65,10 @@ where
             if is_tuple {
                 Some(Expr::Tuple(items))
             } else {
-                #[expect(
-                    clippy::expect_used,
-                    reason = "parser invariant: group contains exactly one item"
-                )]
-                let item = items.pop().expect("expected one item in group");
+                // Parser invariant: the group contains exactly one item, so
+                // `pop` always succeeds; propagate `None` rather than panic
+                // if the invariant is ever broken.
+                let item = items.pop()?;
                 Some(Expr::Group(Box::new(item)))
             }
         })

--- a/src/parser/expression/delimiter_handling.rs
+++ b/src/parser/expression/delimiter_handling.rs
@@ -77,42 +77,42 @@ where
         let kind = token.kind;
         let span = &token.span;
 
-        match kind {
-            SyntaxKind::T_RPAREN => {
-                if context.use_for_paren {
-                    let other_open = state.brace_depth > 0 || state.bracket_depth > 0;
-                    let (new_depth, new_end) =
-                        self.handle_close_paren(span, state.paren_depth, other_open)?;
-                    state.paren_depth = new_depth;
-                    state.end = Some(new_end);
-                } else {
-                    let new_end = self.handle_close_delimiter(
-                        span,
-                        &mut state.paren_depth,
-                        context.unmatched_paren_msg,
-                    )?;
-                    state.end = Some(new_end);
-                }
-            }
-            SyntaxKind::T_RBRACE => {
-                let new_end = self.handle_close_delimiter(
-                    span,
-                    &mut state.brace_depth,
-                    context.unmatched_brace_msg,
-                )?;
-                state.end = Some(new_end);
-            }
-            SyntaxKind::T_RBRACKET => {
-                let new_end = self.handle_close_delimiter(
-                    span,
-                    &mut state.bracket_depth,
-                    context.unmatched_bracket_msg,
-                )?;
-                state.end = Some(new_end);
-            }
-            _ => unreachable!("process_closing_delimiter called with non-closing delimiter"),
+        if kind == SyntaxKind::T_RPAREN {
+            return self.process_closing_paren(span, state, context);
         }
 
+        let (depth, message) = match kind {
+            SyntaxKind::T_RBRACE => (&mut state.brace_depth, context.unmatched_brace_msg),
+            SyntaxKind::T_RBRACKET => (&mut state.bracket_depth, context.unmatched_bracket_msg),
+            _ => unreachable!("process_closing_delimiter called with non-closing delimiter"),
+        };
+        let new_end = self.handle_close_delimiter(span, depth, message)?;
+        state.end = Some(new_end);
+
+        Some(())
+    }
+
+    /// Handle a closing parenthesis, honouring for-loop context rules.
+    fn process_closing_paren(
+        &mut self,
+        span: &Span,
+        state: &mut DelimiterState,
+        context: &PatternContext,
+    ) -> Option<()> {
+        if context.use_for_paren {
+            let other_open = state.brace_depth > 0 || state.bracket_depth > 0;
+            let (new_depth, new_end) =
+                self.handle_close_paren(span, state.paren_depth, other_open)?;
+            state.paren_depth = new_depth;
+            state.end = Some(new_end);
+        } else {
+            let new_end = self.handle_close_delimiter(
+                span,
+                &mut state.paren_depth,
+                context.unmatched_paren_msg,
+            )?;
+            state.end = Some(new_end);
+        }
         Some(())
     }
 

--- a/src/parser/expression/literals.rs
+++ b/src/parser/expression/literals.rs
@@ -29,31 +29,39 @@ where
     /// ```
     pub(super) fn parse_literal(&mut self, kind: SyntaxKind, span: &Span) -> Option<Expr> {
         match kind {
-            SyntaxKind::T_NUMBER => match parse_numeric_literal(&self.ts.slice(span)) {
-                Ok(number) => Some(Expr::Literal(Literal::Number(number))),
-                Err(err) => {
-                    self.ts.push_error(span.clone(), err.message());
-                    None
-                }
-            },
-            SyntaxKind::T_STRING => {
-                // Check cache first
-                if let Some(cached) = self.string_literal_cache.remove(&span.start) {
-                    return Some(Expr::Literal(Literal::String(cached)));
-                }
-
-                // Cache miss: parse as before
-                match StringLiteral::parse(&self.ts.slice(span)) {
-                    Ok(s) => Some(Expr::Literal(Literal::String(s))),
-                    Err(msg) => {
-                        self.ts.push_error(span.clone(), msg.to_string());
-                        None
-                    }
-                }
-            }
+            SyntaxKind::T_NUMBER => self.parse_number_literal(span),
+            SyntaxKind::T_STRING => self.parse_string_literal(span),
             SyntaxKind::K_TRUE => Some(Expr::Literal(Literal::Bool(true))),
             SyntaxKind::K_FALSE => Some(Expr::Literal(Literal::Bool(false))),
             _ => None,
+        }
+    }
+
+    /// Parse a numeric literal token, recording a diagnostic on failure.
+    fn parse_number_literal(&mut self, span: &Span) -> Option<Expr> {
+        match parse_numeric_literal(&self.ts.slice(span)) {
+            Ok(number) => Some(Expr::Literal(Literal::Number(number))),
+            Err(err) => {
+                self.ts.push_error(span.clone(), err.message());
+                None
+            }
+        }
+    }
+
+    /// Parse a string literal token, reusing the cache when possible.
+    fn parse_string_literal(&mut self, span: &Span) -> Option<Expr> {
+        // Check cache first
+        if let Some(cached) = self.string_literal_cache.remove(&span.start) {
+            return Some(Expr::Literal(Literal::String(cached)));
+        }
+
+        // Cache miss: parse as before
+        match StringLiteral::parse(&self.ts.slice(span)) {
+            Ok(s) => Some(Expr::Literal(Literal::String(s))),
+            Err(msg) => {
+                self.ts.push_error(span.clone(), msg.to_string());
+                None
+            }
         }
     }
 }

--- a/src/parser/expression/pratt.rs
+++ b/src/parser/expression/pratt.rs
@@ -46,16 +46,11 @@ impl StructLiteralState {
     }
 
     fn deactivate(&mut self) {
-        #[expect(
-            clippy::expect_used,
-            reason = "struct literal guard depth must not underflow"
-        )]
-        let remaining = self
-            .active
-            .checked_sub(1)
-            .expect("struct literal guard underflow");
-        self.active = remaining;
-        if remaining == 0 {
+        // The guard depth must not underflow; saturate rather than panic if
+        // the scopes are ever unbalanced.
+        debug_assert!(self.active > 0, "struct literal guard underflow");
+        self.active = self.active.saturating_sub(1);
+        if self.active == 0 {
             self.suspension = 0;
         }
     }
@@ -69,15 +64,13 @@ impl StructLiteralState {
     }
 
     fn resume(&mut self) {
-        #[expect(
-            clippy::expect_used,
-            reason = "struct literal guard suspension depth must not underflow"
-        )]
-        let remaining = self
-            .suspension
-            .checked_sub(1)
-            .expect("struct literal guard suspension underflow");
-        self.suspension = remaining;
+        // The suspension depth must not underflow; saturate rather than
+        // panic if the scopes are ever unbalanced.
+        debug_assert!(
+            self.suspension > 0,
+            "struct literal guard suspension underflow"
+        );
+        self.suspension = self.suspension.saturating_sub(1);
     }
 
     fn allows_struct_literal(&self) -> bool {

--- a/src/parser/expression/pratt/diff.rs
+++ b/src/parser/expression/pratt/diff.rs
@@ -58,6 +58,7 @@ where
 
 #[cfg(test)]
 mod tests {
+    //! Tests for token stream differencing.
     use super::*;
     use chumsky::error::SimpleReason;
 

--- a/src/parser/expression/pratt/postfix.rs
+++ b/src/parser/expression/pratt/postfix.rs
@@ -161,6 +161,7 @@ where
 
 #[cfg(test)]
 mod tests {
+    //! Tests for postfix expression parsing.
     use chumsky::error::SimpleReason;
 
     use crate::SyntaxKind;

--- a/src/parser/expression_span.rs
+++ b/src/parser/expression_span.rs
@@ -32,6 +32,42 @@ pub(crate) fn rule_body_literal_spans(
     split_literals(tokens, body_start, body_end)
 }
 
+/// Delimiter nesting depths tracked while walking a token slice.
+#[derive(Default)]
+struct DelimiterDepths {
+    paren: usize,
+    brace: usize,
+    bracket: usize,
+}
+
+impl DelimiterDepths {
+    /// Adjust the depths if `kind` opens or closes a delimiter.
+    fn update(&mut self, kind: SyntaxKind) {
+        match kind {
+            SyntaxKind::T_LPAREN => self.paren += 1,
+            SyntaxKind::T_RPAREN => {
+                debug_assert!(self.paren > 0, "unbalanced parentheses");
+                self.paren = self.paren.saturating_sub(1);
+            }
+            SyntaxKind::T_LBRACE => self.brace += 1,
+            SyntaxKind::T_RBRACE => {
+                debug_assert!(self.brace > 0, "unbalanced braces");
+                self.brace = self.brace.saturating_sub(1);
+            }
+            SyntaxKind::T_LBRACKET => self.bracket += 1,
+            SyntaxKind::T_RBRACKET => {
+                debug_assert!(self.bracket > 0, "unbalanced brackets");
+                self.bracket = self.bracket.saturating_sub(1);
+            }
+            _ => {}
+        }
+    }
+
+    fn at_top_level(&self) -> bool {
+        self.paren == 0 && self.brace == 0 && self.bracket == 0
+    }
+}
+
 fn locate_body_bounds(
     tokens: &[(SyntaxKind, Span)],
     start_idx: usize,
@@ -40,41 +76,15 @@ fn locate_body_bounds(
     let mut idx = start_idx;
     let mut body_start = None;
     let mut body_end = None;
-    let mut paren_depth = 0usize;
-    let mut brace_depth = 0usize;
-    let mut bracket_depth = 0usize;
+    let mut depths = DelimiterDepths::default();
 
     while let Some((kind, span)) = tokens.get(idx) {
         if span.start >= end {
             break;
         }
 
-        match kind {
-            SyntaxKind::T_LPAREN => paren_depth += 1,
-            SyntaxKind::T_RPAREN => {
-                debug_assert!(
-                    paren_depth > 0,
-                    "unbalanced parentheses in locate_body_bounds"
-                );
-                paren_depth = paren_depth.saturating_sub(1);
-            }
-            SyntaxKind::T_LBRACE => brace_depth += 1,
-            SyntaxKind::T_RBRACE => {
-                debug_assert!(brace_depth > 0, "unbalanced braces in locate_body_bounds");
-                brace_depth = brace_depth.saturating_sub(1);
-            }
-            SyntaxKind::T_LBRACKET => bracket_depth += 1,
-            SyntaxKind::T_RBRACKET => {
-                debug_assert!(
-                    bracket_depth > 0,
-                    "unbalanced brackets in locate_body_bounds"
-                );
-                bracket_depth = bracket_depth.saturating_sub(1);
-            }
-            _ => {}
-        }
-
-        let at_top_level = paren_depth == 0 && brace_depth == 0 && bracket_depth == 0;
+        depths.update(*kind);
+        let at_top_level = depths.at_top_level();
 
         match kind {
             SyntaxKind::T_IMPLIES if at_top_level => body_start = Some(idx + 1),
@@ -97,12 +107,24 @@ fn locate_body_bounds(
     }
 }
 
+/// Close the literal opened at `literal_start`, pushing its trimmed span.
+fn flush_literal(
+    tokens: &[(SyntaxKind, Span)],
+    literal_start: &mut Option<usize>,
+    end_idx: usize,
+    spans: &mut Vec<Span>,
+) {
+    if let Some(start_idx) = literal_start.take()
+        && let Some(sp) = trim_literal_span(tokens, start_idx, end_idx)
+    {
+        spans.push(sp);
+    }
+}
+
 fn split_literals(tokens: &[(SyntaxKind, Span)], start: usize, end: usize) -> Vec<Span> {
     let mut spans = Vec::new();
     let mut literal_start = None;
-    let mut paren_depth = 0usize;
-    let mut brace_depth = 0usize;
-    let mut bracket_depth = 0usize;
+    let mut depths = DelimiterDepths::default();
 
     let mut idx = start;
     while idx < end {
@@ -114,42 +136,16 @@ fn split_literals(tokens: &[(SyntaxKind, Span)], start: usize, end: usize) -> Ve
             literal_start = Some(idx);
         }
 
-        match kind {
-            SyntaxKind::T_LPAREN => paren_depth += 1,
-            SyntaxKind::T_RPAREN => {
-                debug_assert!(paren_depth > 0, "unbalanced parentheses in split_literals");
-                paren_depth = paren_depth.saturating_sub(1);
-            }
-            SyntaxKind::T_LBRACE => brace_depth += 1,
-            SyntaxKind::T_RBRACE => {
-                debug_assert!(brace_depth > 0, "unbalanced braces in split_literals");
-                brace_depth = brace_depth.saturating_sub(1);
-            }
-            SyntaxKind::T_LBRACKET => bracket_depth += 1,
-            SyntaxKind::T_RBRACKET => {
-                debug_assert!(bracket_depth > 0, "unbalanced brackets in split_literals");
-                bracket_depth = bracket_depth.saturating_sub(1);
-            }
-            _ => {}
-        }
+        depths.update(*kind);
 
-        let at_top_level = paren_depth == 0 && brace_depth == 0 && bracket_depth == 0;
-        if at_top_level
-            && matches!(kind, SyntaxKind::T_COMMA)
-            && let Some(start_idx) = literal_start.take()
-            && let Some(sp) = trim_literal_span(tokens, start_idx, idx)
-        {
-            spans.push(sp);
+        if depths.at_top_level() && matches!(kind, SyntaxKind::T_COMMA) {
+            flush_literal(tokens, &mut literal_start, idx, &mut spans);
         }
 
         idx += 1;
     }
 
-    if let Some(start_idx) = literal_start
-        && let Some(sp) = trim_literal_span(tokens, start_idx, end)
-    {
-        spans.push(sp);
-    }
+    flush_literal(tokens, &mut literal_start, end, &mut spans);
 
     spans
 }

--- a/src/parser/span_scanners/attributes.rs
+++ b/src/parser/span_scanners/attributes.rs
@@ -116,10 +116,6 @@ fn consume_attribute(st: &mut State<'_>) -> Option<Span> {
 /// After gathering one or more `#[…]` spans, peeks at the next
 /// non-whitespace token to determine the target item. If the target is not
 /// a permitted attribute host, emits a diagnostic.
-#[expect(
-    clippy::expect_used,
-    reason = "attr_spans is guaranteed non-empty after the early-return guard"
-)]
 fn handle_hash(st: &mut State<'_>, _span: Span) {
     let mut attr_spans: Vec<Span> = Vec::new();
 
@@ -127,6 +123,7 @@ fn handle_hash(st: &mut State<'_>, _span: Span) {
     let Some(first) = consume_attribute(st) else {
         return;
     };
+    let first_start = first.start;
     attr_spans.push(first);
 
     // Consume any consecutive attributes (stacked #[a] #[b] …)
@@ -156,16 +153,9 @@ fn handle_hash(st: &mut State<'_>, _span: Span) {
     if is_valid {
         st.spans.extend(attr_spans);
     } else {
-        // SAFETY: `attr_spans` is guaranteed non-empty — we early-return
-        // above if the first `consume_attribute` fails.
-        let first_start = attr_spans
-            .first()
-            .expect("attr_spans must be non-empty after successful consume")
-            .start;
-        let last_end = attr_spans
-            .last()
-            .expect("attr_spans must be non-empty after successful consume")
-            .end;
+        // `attr_spans` is guaranteed non-empty — the first attribute is
+        // pushed above — so the fallback end is never used in practice.
+        let last_end = attr_spans.last().map_or(first_start, |span| span.end);
         st.extra.push(Simple::custom(
             first_start..last_end,
             "attribute not permitted on this item",

--- a/src/parser/span_scanners/indexes.rs
+++ b/src/parser/span_scanners/indexes.rs
@@ -9,7 +9,14 @@ use crate::{Span, SyntaxKind};
 
 use super::utils::State;
 
-type ScanResult<T> = Result<T, Box<Simple<SyntaxKind>>>;
+#[path = "indexes_support.rs"]
+mod support;
+
+use support::{
+    ScanResult, TypeDepths, adjust_type_depths, consume_kind, consume_kind_or_invalid,
+    current_span, expected_closing_for, expected_eof, is_trivia, skip_trivia,
+    update_delimiter_stack,
+};
 
 pub(crate) const MISSING_INDEX_FIELD_LIST: &str =
     "index declarations require a typed field list `(name: Type, ...)` before `on`";
@@ -139,20 +146,6 @@ fn parse_index_fields(
     }
 }
 
-#[derive(Default)]
-struct TypeDepths {
-    paren: usize,
-    bracket: usize,
-    brace: usize,
-    angle: usize,
-}
-
-impl TypeDepths {
-    fn at_top_level(&self) -> bool {
-        self.paren == 0 && self.bracket == 0 && self.brace == 0 && self.angle == 0
-    }
-}
-
 fn parse_type_expr(tokens: &[(SyntaxKind, Span)], src: &str, cursor: &mut usize) -> ScanResult<()> {
     let mut consumed = false;
     let mut depths = TypeDepths::default();
@@ -250,153 +243,26 @@ fn parse_balanced_arguments(
     let Some((open_kind, open_span)) = tokens.get(*cursor) else {
         return Err(Box::new(expected_eof(src, SyntaxKind::T_LPAREN)));
     };
-    let expected_close = match open_kind {
-        SyntaxKind::T_LPAREN => SyntaxKind::T_RPAREN,
-        SyntaxKind::T_LBRACKET => SyntaxKind::T_RBRACKET,
-        SyntaxKind::T_LBRACE => SyntaxKind::T_RBRACE,
-        _ => {
-            return Err(Box::new(Simple::custom(
-                open_span.clone(),
-                "expected index target arguments",
-            )));
-        }
+    let Some(expected_close) = expected_closing_for(*open_kind) else {
+        return Err(Box::new(Simple::custom(
+            open_span.clone(),
+            "expected index target arguments",
+        )));
     };
 
     let mut stack = vec![expected_close];
     *cursor += 1;
 
     while let Some((kind, span)) = tokens.get(*cursor) {
-        match kind {
-            SyntaxKind::T_LPAREN => stack.push(SyntaxKind::T_RPAREN),
-            SyntaxKind::T_LBRACKET => stack.push(SyntaxKind::T_RBRACKET),
-            SyntaxKind::T_LBRACE => stack.push(SyntaxKind::T_RBRACE),
-            SyntaxKind::T_LT => stack.push(SyntaxKind::T_GT),
-            SyntaxKind::T_SHL => {
-                stack.push(SyntaxKind::T_GT);
-                stack.push(SyntaxKind::T_GT);
-            }
-            SyntaxKind::T_RPAREN
-            | SyntaxKind::T_RBRACKET
-            | SyntaxKind::T_RBRACE
-            | SyntaxKind::T_GT
-            | SyntaxKind::T_SHR => {
-                let closes = if *kind == SyntaxKind::T_SHR { 2 } else { 1 };
-                for _ in 0..closes {
-                    match stack.pop() {
-                        Some(expected) if matches_closing_token(*kind, expected) => {}
-                        Some(expected) => {
-                            return Err(Box::new(Simple::custom(
-                                span.clone(),
-                                format!(
-                                    "expected '{}' before '{}'",
-                                    token_display(expected),
-                                    token_display(*kind)
-                                ),
-                            )));
-                        }
-                        None => break,
-                    }
-                }
-                if stack.is_empty() {
-                    *cursor += 1;
-                    return Ok(span.end);
-                }
-            }
-            _ => {}
-        }
+        update_delimiter_stack(&mut stack, *kind, span)?;
         *cursor += 1;
+        if stack.is_empty() {
+            return Ok(span.end);
+        }
     }
 
     Err(Box::new(Simple::custom(
         src.len()..src.len(),
         format!("unclosed '{}'", token_display(expected_close)),
     )))
-}
-
-fn consume_kind(
-    tokens: &[(SyntaxKind, Span)],
-    src: &str,
-    cursor: &mut usize,
-    expected: SyntaxKind,
-) -> ScanResult<usize> {
-    match tokens.get(*cursor) {
-        Some((found, span)) if *found == expected => {
-            *cursor += 1;
-            Ok(span.end)
-        }
-        Some((found, span)) => Err(Box::new(Simple::expected_input_found(
-            span.clone(),
-            [Some(expected)],
-            Some(*found),
-        ))),
-        None => Err(Box::new(expected_eof(src, expected))),
-    }
-}
-
-fn consume_kind_or_invalid(
-    tokens: &[(SyntaxKind, Span)],
-    src: &str,
-    cursor: &mut usize,
-    expected: SyntaxKind,
-) -> ScanResult<usize> {
-    match tokens.get(*cursor) {
-        Some((found, span)) if *found == expected => {
-            *cursor += 1;
-            Ok(span.end)
-        }
-        Some((_, span)) => Err(Box::new(Simple::custom(
-            span.clone(),
-            INVALID_INDEX_FIELD_LIST,
-        ))),
-        None => Err(Box::new(Simple::custom(
-            src.len()..src.len(),
-            INVALID_INDEX_FIELD_LIST,
-        ))),
-    }
-}
-
-fn skip_trivia(tokens: &[(SyntaxKind, Span)], cursor: &mut usize) {
-    while let Some((kind, _)) = tokens.get(*cursor) {
-        if !is_trivia(*kind) {
-            break;
-        }
-        *cursor += 1;
-    }
-}
-
-fn is_trivia(kind: SyntaxKind) -> bool {
-    matches!(kind, SyntaxKind::T_WHITESPACE | SyntaxKind::T_COMMENT)
-}
-
-fn adjust_type_depths(kind: SyntaxKind, depths: &mut TypeDepths) {
-    match kind {
-        SyntaxKind::T_LPAREN => depths.paren += 1,
-        SyntaxKind::T_RPAREN => depths.paren = depths.paren.saturating_sub(1),
-        SyntaxKind::T_LBRACKET => depths.bracket += 1,
-        SyntaxKind::T_RBRACKET => depths.bracket = depths.bracket.saturating_sub(1),
-        SyntaxKind::T_LBRACE => depths.brace += 1,
-        SyntaxKind::T_RBRACE => depths.brace = depths.brace.saturating_sub(1),
-        SyntaxKind::T_LT => depths.angle += 1,
-        SyntaxKind::T_GT => depths.angle = depths.angle.saturating_sub(1),
-        SyntaxKind::T_SHL => depths.angle += 2,
-        SyntaxKind::T_SHR => depths.angle = depths.angle.saturating_sub(2),
-        _ => {}
-    }
-}
-
-fn matches_closing_token(found: SyntaxKind, expected: SyntaxKind) -> bool {
-    match found {
-        SyntaxKind::T_SHR => expected == SyntaxKind::T_GT,
-        _ => found == expected,
-    }
-}
-
-fn current_span(tokens: &[(SyntaxKind, Span)], src: &str, cursor: usize) -> Span {
-    tokens
-        .get(cursor)
-        .map_or(src.len()..src.len(), |(_, span)| span.clone())
-}
-
-fn expected_eof(src: &str, expected: SyntaxKind) -> Simple<SyntaxKind> {
-    Simple::expected_input_found(src.len()..src.len(), [Some(expected)], None)
 }

--- a/src/parser/span_scanners/indexes_support.rs
+++ b/src/parser/span_scanners/indexes_support.rs
@@ -1,0 +1,178 @@
+//! Token-walking support for the index declaration scanner.
+//!
+//! Houses the cursor helpers, delimiter bookkeeping, and error builders
+//! shared by the `indexes` scanner module.
+
+use chumsky::prelude::*;
+
+use crate::parser::lexer_helpers::token_display;
+use crate::{Span, SyntaxKind};
+
+pub(super) type ScanResult<T> = Result<T, Box<Simple<SyntaxKind>>>;
+
+#[derive(Default)]
+pub(super) struct TypeDepths {
+    pub(super) paren: usize,
+    pub(super) bracket: usize,
+    pub(super) brace: usize,
+    pub(super) angle: usize,
+}
+
+impl TypeDepths {
+    pub(super) fn at_top_level(&self) -> bool {
+        self.paren == 0 && self.bracket == 0 && self.brace == 0 && self.angle == 0
+    }
+}
+
+pub(super) fn adjust_type_depths(kind: SyntaxKind, depths: &mut TypeDepths) {
+    match kind {
+        SyntaxKind::T_LPAREN => depths.paren += 1,
+        SyntaxKind::T_RPAREN => depths.paren = depths.paren.saturating_sub(1),
+        SyntaxKind::T_LBRACKET => depths.bracket += 1,
+        SyntaxKind::T_RBRACKET => depths.bracket = depths.bracket.saturating_sub(1),
+        SyntaxKind::T_LBRACE => depths.brace += 1,
+        SyntaxKind::T_RBRACE => depths.brace = depths.brace.saturating_sub(1),
+        SyntaxKind::T_LT => depths.angle += 1,
+        SyntaxKind::T_GT => depths.angle = depths.angle.saturating_sub(1),
+        SyntaxKind::T_SHL => depths.angle += 2,
+        SyntaxKind::T_SHR => depths.angle = depths.angle.saturating_sub(2),
+        _ => {}
+    }
+}
+
+/// Map an opening delimiter to the closing token it requires.
+pub(super) fn expected_closing_for(open_kind: SyntaxKind) -> Option<SyntaxKind> {
+    match open_kind {
+        SyntaxKind::T_LPAREN => Some(SyntaxKind::T_RPAREN),
+        SyntaxKind::T_LBRACKET => Some(SyntaxKind::T_RBRACKET),
+        SyntaxKind::T_LBRACE => Some(SyntaxKind::T_RBRACE),
+        _ => None,
+    }
+}
+
+fn matches_closing_token(found: SyntaxKind, expected: SyntaxKind) -> bool {
+    match found {
+        SyntaxKind::T_SHR => expected == SyntaxKind::T_GT,
+        _ => found == expected,
+    }
+}
+
+/// Pop the delimiter stack entries closed by `found`, validating each.
+///
+/// `T_SHR` closes two angle brackets in one token; every other closer pops a
+/// single entry. Popping past an empty stack stops silently so the caller can
+/// treat the surplus closer as the end of the balanced region.
+pub(super) fn pop_closing_tokens(
+    stack: &mut Vec<SyntaxKind>,
+    found: SyntaxKind,
+    span: &Span,
+) -> ScanResult<()> {
+    let closes = if found == SyntaxKind::T_SHR { 2 } else { 1 };
+    for _ in 0..closes {
+        match stack.pop() {
+            Some(expected) if matches_closing_token(found, expected) => {}
+            Some(expected) => {
+                return Err(Box::new(Simple::custom(
+                    span.clone(),
+                    format!(
+                        "expected '{}' before '{}'",
+                        token_display(expected),
+                        token_display(found)
+                    ),
+                )));
+            }
+            None => break,
+        }
+    }
+    Ok(())
+}
+
+/// Push or pop delimiter stack entries for `kind`, if it is a delimiter.
+pub(super) fn update_delimiter_stack(
+    stack: &mut Vec<SyntaxKind>,
+    kind: SyntaxKind,
+    span: &Span,
+) -> ScanResult<()> {
+    match kind {
+        SyntaxKind::T_LPAREN => stack.push(SyntaxKind::T_RPAREN),
+        SyntaxKind::T_LBRACKET => stack.push(SyntaxKind::T_RBRACKET),
+        SyntaxKind::T_LBRACE => stack.push(SyntaxKind::T_RBRACE),
+        SyntaxKind::T_LT => stack.push(SyntaxKind::T_GT),
+        SyntaxKind::T_SHL => {
+            stack.push(SyntaxKind::T_GT);
+            stack.push(SyntaxKind::T_GT);
+        }
+        SyntaxKind::T_RPAREN
+        | SyntaxKind::T_RBRACKET
+        | SyntaxKind::T_RBRACE
+        | SyntaxKind::T_GT
+        | SyntaxKind::T_SHR => pop_closing_tokens(stack, kind, span)?,
+        _ => {}
+    }
+    Ok(())
+}
+
+pub(super) fn consume_kind(
+    tokens: &[(SyntaxKind, Span)],
+    src: &str,
+    cursor: &mut usize,
+    expected: SyntaxKind,
+) -> ScanResult<usize> {
+    match tokens.get(*cursor) {
+        Some((found, span)) if *found == expected => {
+            *cursor += 1;
+            Ok(span.end)
+        }
+        Some((found, span)) => Err(Box::new(Simple::expected_input_found(
+            span.clone(),
+            [Some(expected)],
+            Some(*found),
+        ))),
+        None => Err(Box::new(expected_eof(src, expected))),
+    }
+}
+
+pub(super) fn consume_kind_or_invalid(
+    tokens: &[(SyntaxKind, Span)],
+    src: &str,
+    cursor: &mut usize,
+    expected: SyntaxKind,
+) -> ScanResult<usize> {
+    match tokens.get(*cursor) {
+        Some((found, span)) if *found == expected => {
+            *cursor += 1;
+            Ok(span.end)
+        }
+        Some((_, span)) => Err(Box::new(Simple::custom(
+            span.clone(),
+            super::INVALID_INDEX_FIELD_LIST,
+        ))),
+        None => Err(Box::new(Simple::custom(
+            src.len()..src.len(),
+            super::INVALID_INDEX_FIELD_LIST,
+        ))),
+    }
+}
+
+pub(super) fn skip_trivia(tokens: &[(SyntaxKind, Span)], cursor: &mut usize) {
+    while let Some((kind, _)) = tokens.get(*cursor) {
+        if !is_trivia(*kind) {
+            break;
+        }
+        *cursor += 1;
+    }
+}
+
+pub(super) fn is_trivia(kind: SyntaxKind) -> bool {
+    matches!(kind, SyntaxKind::T_WHITESPACE | SyntaxKind::T_COMMENT)
+}
+
+pub(super) fn current_span(tokens: &[(SyntaxKind, Span)], src: &str, cursor: usize) -> Span {
+    tokens
+        .get(cursor)
+        .map_or(src.len()..src.len(), |(_, span)| span.clone())
+}
+
+pub(super) fn expected_eof(src: &str, expected: SyntaxKind) -> Simple<SyntaxKind> {
+    Simple::expected_input_found(src.len()..src.len(), [Some(expected)], None)
+}

--- a/src/parser/span_scanners/rules.rs
+++ b/src/parser/span_scanners/rules.rs
@@ -15,6 +15,11 @@ use crate::{Span, SyntaxKind};
 
 use super::utils::State;
 
+#[path = "rules_support.rs"]
+mod support;
+
+use support::is_at_line_start;
+
 fn rule_decl() -> impl Parser<SyntaxKind, Span, Error = Simple<SyntaxKind>> {
     let ws = inline_ws().repeated().ignored();
 
@@ -199,63 +204,6 @@ fn for_binding_complete(
         .ignored()
 }
 
-/// Return `true` if `span` begins a new logical line in the source.
-///
-/// Multiple rules on one physical line are recognised by treating a preceding
-/// `.` as a line start boundary. Otherwise, only trivia containing a newline
-/// counts; inline whitespace or comments keep the current line “open” so
-/// continuations are not misclassified.
-fn is_at_line_start(st: &State<'_>, span: &Span) -> bool {
-    if st.stream.cursor() == 0 {
-        return true;
-    }
-
-    line_start_boundary(
-        st.stream.tokens(),
-        st.stream.src(),
-        st.stream.cursor(),
-        span.start,
-    )
-}
-
-fn line_start_boundary(
-    tokens: &[(SyntaxKind, Span)],
-    src: &str,
-    mut cursor: usize,
-    span_start: usize,
-) -> bool {
-    while cursor > 0 {
-        cursor -= 1;
-        let Some((kind, prev_span)) = tokens.get(cursor) else {
-            break;
-        };
-        if matches!(kind, SyntaxKind::T_WHITESPACE | SyntaxKind::T_COMMENT) {
-            if range_contains_newline(src, prev_span.clone()) {
-                return true;
-            }
-            continue;
-        }
-
-        if slice_contains_newline(src, prev_span.end, span_start) {
-            return true;
-        }
-        if *kind == SyntaxKind::T_DOT {
-            return true;
-        }
-        return false;
-    }
-
-    true
-}
-
-fn range_contains_newline(src: &str, range: std::ops::Range<usize>) -> bool {
-    src.get(range).is_some_and(|text| text.contains('\n'))
-}
-
-fn slice_contains_newline(src: &str, start: usize, end: usize) -> bool {
-    range_contains_newline(src, start..end)
-}
-
 fn parse_rule_at_line_start(st: &mut State<'_>, span: Span, exprs: &mut Vec<Span>) {
     if !is_at_line_start(st, &span) {
         st.stream.advance();
@@ -345,6 +293,24 @@ fn skip_top_level_for_statement(
     }
 }
 
+/// Advance `exclude_idx` past exclusions ending before `span`, then return
+/// the end of an exclusion overlapping `span`, if any.
+fn overlapping_exclusion_end(
+    exclusions: &[Span],
+    exclude_idx: &mut usize,
+    span: &Span,
+) -> Option<usize> {
+    while let Some(ex) = exclusions.get(*exclude_idx) {
+        if ex.end > span.start {
+            break;
+        }
+        *exclude_idx += 1;
+    }
+    let ex = exclusions.get(*exclude_idx)?;
+    let overlaps = span.start < ex.end && ex.start < span.end;
+    overlaps.then_some(ex.end)
+}
+
 pub(crate) fn collect_rule_spans(
     tokens: &[(SyntaxKind, Span)],
     src: &str,
@@ -364,18 +330,8 @@ pub(crate) fn collect_rule_spans(
     while let Some(&(kind, ref span_ref)) = st.stream.peek() {
         let span = span_ref.clone();
 
-        while let Some(ex) = exclusions.get(exclude_idx) {
-            if ex.end > span.start {
-                break;
-            }
-            exclude_idx += 1;
-        }
-
-        if let Some(ex) = exclusions.get(exclude_idx)
-            && span.start < ex.end
-            && ex.start < span.end
-        {
-            st.stream.skip_until(ex.end);
+        if let Some(end) = overlapping_exclusion_end(exclusions, &mut exclude_idx, &span) {
+            st.stream.skip_until(end);
             continue;
         }
 

--- a/src/parser/span_scanners/rules_support.rs
+++ b/src/parser/span_scanners/rules_support.rs
@@ -1,0 +1,65 @@
+//! Line-boundary helpers for the rule declaration scanner.
+//!
+//! Determines whether a token begins a new logical line so the `rules`
+//! scanner only treats line-initial tokens as rule or `for` statement starts.
+
+use crate::{Span, SyntaxKind};
+
+use super::super::utils::State;
+
+/// Return `true` if `span` begins a new logical line in the source.
+///
+/// Multiple rules on one physical line are recognised by treating a preceding
+/// `.` as a line start boundary. Otherwise, only trivia containing a newline
+/// counts; inline whitespace or comments keep the current line “open” so
+/// continuations are not misclassified.
+pub(super) fn is_at_line_start(st: &State<'_>, span: &Span) -> bool {
+    if st.stream.cursor() == 0 {
+        return true;
+    }
+
+    line_start_boundary(
+        st.stream.tokens(),
+        st.stream.src(),
+        st.stream.cursor(),
+        span.start,
+    )
+}
+
+fn line_start_boundary(
+    tokens: &[(SyntaxKind, Span)],
+    src: &str,
+    mut cursor: usize,
+    span_start: usize,
+) -> bool {
+    while cursor > 0 {
+        cursor -= 1;
+        let Some((kind, prev_span)) = tokens.get(cursor) else {
+            break;
+        };
+        if matches!(kind, SyntaxKind::T_WHITESPACE | SyntaxKind::T_COMMENT) {
+            if range_contains_newline(src, prev_span.clone()) {
+                return true;
+            }
+            continue;
+        }
+
+        if slice_contains_newline(src, prev_span.end, span_start) {
+            return true;
+        }
+        if *kind == SyntaxKind::T_DOT {
+            return true;
+        }
+        return false;
+    }
+
+    true
+}
+
+fn range_contains_newline(src: &str, range: std::ops::Range<usize>) -> bool {
+    src.get(range).is_some_and(|text| text.contains('\n'))
+}
+
+fn slice_contains_newline(src: &str, start: usize, end: usize) -> bool {
+    range_contains_newline(src, start..end)
+}

--- a/src/parser/span_scanners/tests/mod.rs
+++ b/src/parser/span_scanners/tests/mod.rs
@@ -54,20 +54,17 @@ fn assert_rule_span_collection(src: &str, config: &RuleSpanAssertConfig<'_>) {
         "{}",
         config.count_message
     );
-    let span = if config.select_last {
-        rule_spans
-            .last()
-            .cloned()
-            .unwrap_or_else(|| panic!("expected at least one rule span"))
+    let selected = if config.select_last {
+        rule_spans.last()
     } else {
-        rule_spans
-            .first()
-            .cloned()
-            .unwrap_or_else(|| panic!("expected at least one rule span"))
+        rule_spans.first()
     };
-    let rule_text = src
-        .get(span.clone())
-        .unwrap_or_else(|| panic!("rule span {span:?} out of bounds"));
+    let Some(span) = selected.cloned() else {
+        panic!("expected at least one rule span");
+    };
+    let Some(rule_text) = src.get(span.clone()) else {
+        panic!("rule span {span:?} out of bounds");
+    };
     let checked = if config.trim_before_check {
         rule_text.trim_start()
     } else {
@@ -199,10 +196,9 @@ fn collect_rule_spans_handles_adjacent_exclusions() {
     let (rule_spans, _, errors) = collect_rule_spans(&tokens, src, &exclusions);
     assert!(errors.is_empty());
     assert_eq!(rule_spans.len(), 1, "second rule should remain");
-    let remaining = rule_spans
-        .first()
-        .and_then(|sp| src.get(sp.clone()))
-        .unwrap_or_else(|| panic!("remaining rule span out of bounds"));
+    let Some(remaining) = rule_spans.first().and_then(|sp| src.get(sp.clone())) else {
+        panic!("remaining rule span out of bounds");
+    };
     assert!(
         remaining.starts_with("R2("),
         "unexpected remaining rule: {remaining}"

--- a/src/parser/tests/expression_integration.rs
+++ b/src/parser/tests/expression_integration.rs
@@ -1,3 +1,5 @@
+//! Integration tests for expression parsing.
+
 use crate::test_util::assert_no_parse_errors;
 use crate::{SyntaxKind, parse};
 

--- a/src/parser/top_level_for.rs
+++ b/src/parser/top_level_for.rs
@@ -181,6 +181,19 @@ fn parse_top_level_for_statement(
     (None, last_errors.unwrap_or(fallback))
 }
 
+/// Return `true` when the token at `span` is a top-level terminating dot.
+fn is_terminating_dot(
+    tokens: &[(SyntaxKind, Span)],
+    src: &str,
+    kind: SyntaxKind,
+    span: &Span,
+    depth: &DelimiterDepth,
+) -> bool {
+    kind == SyntaxKind::T_DOT
+        && depth.is_top_level()
+        && is_top_level_for_statement_terminator_dot(tokens, src, span.start)
+}
+
 fn find_top_level_dot(
     tokens: &[(SyntaxKind, Span)],
     src: &str,
@@ -189,10 +202,7 @@ fn find_top_level_dot(
     let mut depth = DelimiterDepth::default();
     for (idx, (kind, span)) in tokens.iter().enumerate().skip(start_idx) {
         depth.update(*kind);
-        if *kind == SyntaxKind::T_DOT
-            && depth.is_top_level()
-            && is_top_level_for_statement_terminator_dot(tokens, src, span.start)
-        {
+        if is_terminating_dot(tokens, src, *kind, span, &depth) {
             return Some((span.clone(), idx));
         }
     }

--- a/src/parser/validators/name_uniqueness.rs
+++ b/src/parser/validators/name_uniqueness.rs
@@ -140,6 +140,7 @@ fn check_function_uniqueness(errors: &mut Vec<Simple<SyntaxKind>>, root: &Root) 
 
 #[cfg(test)]
 mod tests {
+    //! Tests for name uniqueness validation.
     use crate::parse;
     use rstest::rstest;
 

--- a/src/sema/tests/name_span.rs
+++ b/src/sema/tests/name_span.rs
@@ -6,12 +6,13 @@ use super::{DeclarationKind, parse_ok, symbols_named};
 use crate::sema::SymbolOrigin;
 
 fn span_text<'a>(source: &'a str, span: &crate::Span) -> &'a str {
-    source.get(span.start..span.end).unwrap_or_else(|| {
+    let Some(text) = source.get(span.start..span.end) else {
         panic!(
             "invalid UTF-8 boundary for span {}..{} in `{source}`",
             span.start, span.end
         )
-    })
+    };
+    text
 }
 
 fn find_symbol<'a>(
@@ -20,10 +21,13 @@ fn find_symbol<'a>(
     kind: DeclarationKind,
     origin: SymbolOrigin,
 ) -> &'a super::super::Symbol {
-    symbols_named(model, name, kind)
+    let Some(symbol) = symbols_named(model, name, kind)
         .into_iter()
         .find(|symbol| symbol.origin() == origin)
-        .unwrap_or_else(|| panic!("missing symbol `{name}` with origin {origin:?}"))
+    else {
+        panic!("missing symbol `{name}` with origin {origin:?}");
+    };
+    symbol
 }
 
 #[rstest]

--- a/src/test_util/assertions.rs
+++ b/src/test_util/assertions.rs
@@ -29,12 +29,14 @@ where
     let Err(err) = result else {
         panic!("expected panic");
     };
-    err.downcast_ref::<String>()
+    let Some(message) = err
+        .downcast_ref::<String>()
         .cloned()
         .or_else(|| err.downcast_ref::<&str>().map(|s| (*s).to_string()))
-        .unwrap_or_else(|| {
-            panic!("expected panic payload to be String or &str, got unknown type");
-        })
+    else {
+        panic!("expected panic payload to be String or &str, got unknown type");
+    };
+    message
 }
 
 /// Assert that a parser produced no errors.
@@ -72,7 +74,6 @@ pub fn assert_no_parse_errors<E: std::fmt::Debug>(errors: &[E]) {
 /// `Parsed::errors()` or `Parsed::semantic_rules()`, or if no rule exists.
 #[track_caller]
 #[must_use]
-#[expect(clippy::expect_used, reason = "test helpers use expect for clarity")]
 pub fn assert_first_rule_without_parse_stage_aggregation_errors(
     parsed: &crate::Parsed,
 ) -> crate::ast::Rule {
@@ -85,12 +86,10 @@ pub fn assert_first_rule_without_parse_stage_aggregation_errors(
         parsed.semantic_rules().is_empty(),
         "rule-body aggregations must not produce parse-time semantic rules"
     );
-    parsed
-        .root()
-        .rules()
-        .first()
-        .cloned()
-        .expect("rule missing")
+    let Some(rule) = parsed.root().rules().first().cloned() else {
+        panic!("rule missing");
+    };
+    rule
 }
 
 /// Assert that the parser produced exactly one error matching
@@ -110,7 +109,6 @@ pub fn assert_first_rule_without_parse_stage_aggregation_errors(
 /// Panics if `errors` is empty. It also panics when the message fails to
 /// match. The same applies if the span differs.
 #[track_caller]
-#[expect(clippy::expect_used, reason = "test helpers use expect for clarity")]
 pub fn assert_parse_error(
     errors: &[Simple<SyntaxKind>],
     expected_pattern: impl Into<ErrorPattern>,
@@ -119,7 +117,9 @@ pub fn assert_parse_error(
 ) {
     let pattern: ErrorPattern = expected_pattern.into();
     assert_eq!(errors.len(), 1, "expected one error, got {errors:?}");
-    let error = errors.first().expect("error missing");
+    let Some(error) = errors.first() else {
+        panic!("error missing");
+    };
     let rendered = format!("{error:?}");
     let rendered_normalised = normalise_tokens(&rendered);
     let pattern_normalised = match &pattern {
@@ -236,13 +236,14 @@ pub fn find_matching_error(errors: &[Simple<SyntaxKind>], pattern: &ErrorPattern
 }
 
 #[track_caller]
-#[expect(clippy::expect_used, reason = "test helpers use expect for clarity")]
 fn assert_delimiter_error_impl<'a>(
     errors: &'a [Simple<SyntaxKind>],
     expected_pattern: &ErrorPattern,
     span: Range<usize>,
 ) -> &'a Simple<SyntaxKind> {
-    let error = errors.first().expect("error missing");
+    let Some(error) = errors.first() else {
+        panic!("error missing");
+    };
     let rendered = format!("{error:?}");
     let rendered_normalised = normalise_tokens(&rendered);
     let pattern_normalised = match expected_pattern {

--- a/src/test_util/expressions.rs
+++ b/src/test_util/expressions.rs
@@ -4,6 +4,18 @@ use super::Name;
 use crate::parser::ast::{Expr, MatchArm, Pattern};
 use crate::parser::pattern::parse_pattern;
 
+/// Parse `src` as a pattern, panicking with a diagnostic on failure.
+///
+/// Test builders take pattern source text for brevity; an unparsable
+/// pattern is a defect in the test itself, so the panic is the verdict.
+#[track_caller]
+fn parse_pattern_or_panic(src: &str) -> Pattern {
+    match parse_pattern(src) {
+        Ok(pattern) => pattern,
+        Err(errs) => panic!("failed to parse pattern {src:?}: {errs:?}"),
+    }
+}
+
 /// Construct a variable [`Expr::Variable`].
 ///
 /// Accepts any type convertible into [`Name`].
@@ -148,8 +160,7 @@ pub fn for_loop(
     body: Expr,
 ) -> Expr {
     let pattern_src = pattern.into();
-    let pattern = parse_pattern(&pattern_src)
-        .unwrap_or_else(|errs| panic!("failed to parse pattern {pattern_src:?}: {errs:?}"));
+    let pattern = parse_pattern_or_panic(&pattern_src);
     Expr::ForLoop {
         pattern,
         iterable: Box::new(iterable),
@@ -222,15 +233,14 @@ pub fn map_entry(key: Expr, value: Expr) -> (Expr, Expr) {
 #[must_use]
 pub fn match_arm(pattern: impl Into<String>, body: Expr) -> MatchArm {
     let pattern_src = pattern.into();
-    let pattern = parse_pattern(&pattern_src)
-        .unwrap_or_else(|errs| panic!("failed to parse pattern {pattern_src:?}: {errs:?}"));
+    let pattern = parse_pattern_or_panic(&pattern_src);
     MatchArm { pattern, body }
 }
 
 /// Parse and construct a [`Pattern`] node for tests.
 #[must_use]
 pub fn pat(src: &str) -> Pattern {
-    parse_pattern(src).unwrap_or_else(|errs| panic!("failed to parse pattern {src:?}: {errs:?}"))
+    parse_pattern_or_panic(src)
 }
 
 /// Construct a `match` expression from a scrutinee and a list of arms.

--- a/src/test_util/literals.rs
+++ b/src/test_util/literals.rs
@@ -45,8 +45,10 @@ impl AsRef<str> for StringBody {
 pub fn lit_num(n: impl Into<NumericText>) -> Expr {
     let text: NumericText = n.into();
     let src = text.as_ref();
-    let literal = parse_numeric_literal(src)
-        .unwrap_or_else(|err| panic!("failed to parse numeric literal '{src}': {}", err.message()));
+    let literal = match parse_numeric_literal(src) {
+        Ok(literal) => literal,
+        Err(err) => panic!("failed to parse numeric literal '{src}': {}", err.message()),
+    };
     Expr::Literal(Literal::Number(literal))
 }
 

--- a/src/test_util/mod.rs
+++ b/src/test_util/mod.rs
@@ -62,12 +62,13 @@ pub fn tokenize(src: &str) -> Vec<(SyntaxKind, Span)> {
 /// ```
 #[must_use]
 pub fn span_text<'a>(source: &'a str, span: &Span) -> &'a str {
-    source.get(span.start..span.end).unwrap_or_else(|| {
+    let Some(text) = source.get(span.start..span.end) else {
         panic!(
             "invalid UTF-8 boundary for span {}..{} in `{source}`",
             span.start, span.end
         )
-    })
+    };
+    text
 }
 
 /// Typed wrapper for variable and function names.

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -212,8 +212,13 @@ fn tokenize_impl(src: &str) -> Vec<(SyntaxKind, Span)> {
     let mut out = Vec::with_capacity(estimated_tokens);
     while let Some(result) = lexer.next() {
         let span = lexer.span();
-        #[expect(clippy::expect_used, reason = "invalid span indicates lexer bug")]
-        let text = src.get(span.clone()).expect("lexer produced invalid span");
+        let Some(text) = src.get(span.clone()) else {
+            // An invalid span indicates a lexer bug; emit an error token
+            // rather than panic.
+            debug_assert!(false, "lexer produced invalid span");
+            out.push((SyntaxKind::N_ERROR, span));
+            continue;
+        };
         let Ok(token) = result else {
             out.push((SyntaxKind::N_ERROR, span));
             continue;
@@ -308,6 +313,7 @@ pub fn tokenize_with_trivia(src: &str) -> Vec<(SyntaxKind, Span)> {
 
 #[cfg(test)]
 mod tests {
+    //! Tests for the tokenizer.
     use super::*;
 
     #[test]

--- a/tests/expr_to_sexpr.rs
+++ b/tests/expr_to_sexpr.rs
@@ -9,8 +9,10 @@ use ddlint::test_util::pat;
 use rstest::rstest;
 
 fn num(n: &str) -> Expr {
-    let literal = parse_numeric_literal(n)
-        .unwrap_or_else(|err| panic!("failed to parse numeric literal '{n}': {}", err.message()));
+    let literal = match parse_numeric_literal(n) {
+        Ok(literal) => literal,
+        Err(err) => panic!("failed to parse numeric literal '{n}': {}", err.message()),
+    };
     Expr::Literal(Literal::Number(literal))
 }
 

--- a/tests/tokenizer.rs
+++ b/tests/tokenizer.rs
@@ -23,6 +23,7 @@ fn single_tokens(#[case] source: &str, #[case] expected: Vec<SyntaxKind>) {
 }
 
 mod expect_used {
+    //! Tests exercising expect-style tokenizer assertions.
     #![expect(clippy::expect_used, reason = "tests assert exact behaviour")]
 
     use super::*;


### PR DESCRIPTION
## Summary

This change adopts the Whitaker Dylint suite as part of the estate-wide
rollout (reference adoption: leynos/netsuke#410). The `lint` Makefile
target now runs the suite after Clippy with warnings denied, and CI
installs the suite via `whitaker-installer` 0.2.5 before linting,
preferring `cargo binstall` with a build-from-source fallback and a
cache for the installer binary.

The suite reported findings in three waves (72 in total), fixed in a
separate commit:

- `no_expect_outside_tests` and `no_unwrap_or_else_panic` (33): test
  fixtures and assertion helpers now panic explicitly via `let … else`
  so the panic remains the test verdict, with shared shapes extracted
  into single helpers; production parser code propagates `None`,
  saturates guard depths behind debug assertions, or emits an error
  token instead of panicking.
- `bumpy_road_function` (8) and `conditional_max_n_branches` (3):
  nested conditional clusters become focused helpers (delimiter stack
  updates, per-kind literal parsing, exclusion overlap detection, a
  shared `DelimiterDepths` tracker) and multi-clause conditions become
  named predicates.
- `module_max_lines` (2): the `indexes` and `rules` span scanners move
  supporting helpers into sibling `#[path]` submodules.
- `module_must_have_inner_docs` (28): flagged test and helper modules
  gain inner `//!` doc comments.

No `dylint.toml` exclusions were required.

## Review walkthrough

- [Makefile](https://github.com/leynos/ddlint/blob/adopt-whitaker/Makefile):
  `WHITAKER` tool variable and the suite appended to the `lint` target.
- [.github/workflows/ci.yml](https://github.com/leynos/ddlint/blob/adopt-whitaker/.github/workflows/ci.yml):
  installer cache and hardened install step ahead of the lint step.
- [src/parser/span_scanners/indexes.rs](https://github.com/leynos/ddlint/blob/adopt-whitaker/src/parser/span_scanners/indexes.rs)
  and [indexes_support.rs](https://github.com/leynos/ddlint/blob/adopt-whitaker/src/parser/span_scanners/indexes_support.rs):
  module split plus a flattened balanced-argument walker.
- [src/parser/span_scanners/rules.rs](https://github.com/leynos/ddlint/blob/adopt-whitaker/src/parser/span_scanners/rules.rs)
  and [rules_support.rs](https://github.com/leynos/ddlint/blob/adopt-whitaker/src/parser/span_scanners/rules_support.rs):
  line-boundary helpers extracted; exclusion overlap handling unified.
- [src/parser/expression_span.rs](https://github.com/leynos/ddlint/blob/adopt-whitaker/src/parser/expression_span.rs):
  shared `DelimiterDepths` tracker and literal flushing helper.
- [src/test_util](https://github.com/leynos/ddlint/tree/adopt-whitaker/src/test_util):
  assertion and builder helpers converted to explicit panics.

## Validation

- `make check-fmt` — passed.
- `make lint` (Clippy plus the Whitaker suite, warnings denied) — passed.
- `make typecheck` — passed.
- `make test` — 998 tests passed, 0 failed.
- `make test-workflow-contracts` — 6 passed.
- `make markdownlint` — no Markdown changes; gate passed.
- `make nixie` — all diagrams validated.
