### PR TITLE
Stop pinning an exact shared-actions SHA in workflow contract test

### DIFF
--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -67,3 +67,38 @@ can still enforce the last known-good policy.
 Add repository-only proper names or quoted upstream terms to
 `typos.local.toml`; never edit generated entries in `typos.toml` by hand. The
 gate also runs the helper's Python 3.13 tests with at least 90% line coverage.
+
+## Workflow pins and Dependabot
+
+Dependabot owns the upgrade of GitHub Actions and reusable workflows,
+including calls into `leynos/shared-actions`. Contract tests that assert a
+caller's exact commit SHA create a lockstep dependency: every time
+Dependabot opens a bump PR, the test fails until a human edits the pinned
+constant to match. That defeats the purpose of automated dependency updates
+and turns a routine bump into a manual chore.
+
+Contract tests may still verify the *shape* of a reusable-workflow caller.
+They must not verify the specific SHA value.
+
+- Do assert the workflow references the correct reusable workflow path.
+- Do assert the ref is pinned to a full 40-character commit SHA, not a
+  mutable branch such as `main` or `rolling`.
+- Do assert the expected `on:` triggers, least-privilege `permissions:`, and
+  the inputs the caller relies on.
+- Do not hard-code the current SHA value as an expected string. Match it
+  with a pattern instead.
+- Do not fail a test purely because Dependabot bumped the pinned SHA.
+
+```python
+import re
+
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+
+def test_uses_pinned_full_sha(caller_step):
+    ref = caller_step["uses"].split("@")[-1]
+    assert SHA_RE.match(ref), f"expected a 40-hex commit SHA, got {ref!r}"
+```
+
+If a workflow's behaviour genuinely depends on a feature only present from a
+particular commit onwards, express that as a comment or a changelog note,
+not as a test assertion on the SHA string.

--- a/tests/workflow_contracts/mutation_testing_test.py
+++ b/tests/workflow_contracts/mutation_testing_test.py
@@ -3,16 +3,21 @@
 The executable logic lives in the ``leynos/shared-actions`` reusable
 workflow, which carries its own unit and integration tests; ddlint's
 caller is declarative configuration. These tests parse the caller with
-PyYAML and pin the contract it must uphold, so drift (repointing the pin
-at a branch, widening permissions, or losing the exclude and feature
-configuration) fails CI on the pull request rather than surfacing in a
-scheduled or manual run.
+PyYAML and assert the shape of the contract it must uphold: the caller
+references the correct reusable workflow at a commit SHA, grants only the
+expected permissions, and keeps its exclude and feature configuration.
+Drift (repointing the reference at a branch, widening permissions, or
+losing the exclude and feature configuration) fails CI on the pull
+request rather than surfacing in a scheduled or manual run. Dependabot
+owns the pinned SHA value itself, so these tests do not assert which
+commit is pinned.
 
 Run via ``make test-workflow-contracts``.
 """
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import yaml
@@ -21,14 +26,8 @@ WORKFLOW_PATH = (
     Path(__file__).resolve().parents[2] / ".github" / "workflows" / "mutation-testing.yml"
 )
 
-#: The pinned commit of leynos/shared-actions (leynos/shared-actions
-#: PR #334, which adds the `mode: check` coverage gate used by the CI
-#: workflow's coverage steps; the estate keeps a single repo-wide pin).
-#: Bump the workflow and this test together.
-PINNED_SHA = "927edd45ae77be4251a8a18ca9eb5613a2e32cbd"
-
-EXPECTED_USES = (
-    "leynos/shared-actions/.github/workflows/mutation-cargo.yml@" + PINNED_SHA
+USES_RE = re.compile(
+    r"^leynos/shared-actions/\.github/workflows/mutation-cargo\.yml@[0-9a-f]{40}$"
 )
 
 EXPECTED_WITH = {
@@ -60,25 +59,19 @@ def _mutation_job(workflow: dict[str, object]) -> dict[str, object]:
     return jobs["mutation"]
 
 
-def test_uses_reference_is_pinned_to_the_documented_sha() -> None:
-    """The job must call the shared workflow at the exact documented SHA."""
+def test_uses_reference_is_pinned_to_a_commit_sha() -> None:
+    """The job must call mutation-cargo.yml pinned to a commit SHA.
+
+    Dependabot owns the pinned SHA value, so this only checks the shape
+    of the reference: the correct reusable workflow path, pinned to a
+    full 40-character lowercase hex commit SHA rather than a mutable
+    branch or tag such as ``main`` or ``rolling``.
+    """
     uses = _mutation_job(_load()).get("uses")
     assert uses is not None, "jobs.mutation.uses is missing"
-    path, _, ref = uses.partition("@")
-    assert path == "leynos/shared-actions/.github/workflows/mutation-cargo.yml", (
-        f"jobs.mutation.uses must reference mutation-cargo.yml, got {path!r}"
-    )
-    assert len(ref) == 40, (
-        f"jobs.mutation.uses must pin a full 40-character commit SHA, "
-        f"not a branch or tag: {ref!r}"
-    )
-    assert all(c in "0123456789abcdef" for c in ref), (
-        f"jobs.mutation.uses must pin a lowercase hex commit SHA, "
-        f"not a branch or tag: {ref!r}"
-    )
-    assert uses == EXPECTED_USES, (
-        f"jobs.mutation.uses pins {ref!r}; the execution plan documents {PINNED_SHA!r} — "
-        "bump the plan and this test together with the workflow"
+    assert USES_RE.match(uses), (
+        "jobs.mutation.uses must reference mutation-cargo.yml pinned to a "
+        f"40-character lowercase hex commit SHA, got {uses!r}"
     )
 
 


### PR DESCRIPTION
## Summary

- The `mutation-testing` workflow contract test asserted `jobs.mutation.uses` matched an exact, hard-coded `leynos/shared-actions` commit SHA. Every Dependabot bump of that reference then failed CI until a human manually updated the pinned constant, defeating the point of automated dependency updates.
- Replace the exact-SHA assertion with a shape assertion: the caller must reference the correct `mutation-cargo.yml` path, pinned to a syntactically valid 40-character lowercase hex commit SHA — but the specific SHA value is no longer checked. This hands SHA ownership to Dependabot while keeping the structural contract (path + SHA-shape check).
- All other structural guards in the test are unchanged: triggers (`schedule`, `workflow_dispatch`), job/workflow `permissions:`, `concurrency`, and the `with:` block (`exclude-globs`, `extra-args`).
- No other pinned-SHA contract-test assertions were found elsewhere in the repo (searched for a `tests/test_workflow_contract.py`-style file, Rust `tests/workflows.rs`, and any other caller pins in `.github/workflows/*.yml`); this is the only workflow contract test in the repo. No "all shared-actions refs must be identical" consistency-assertion anti-pattern exists here either — the workflow files already carry two different SHAs for different `leynos/shared-actions` refs, so no such requirement was ever encoded.
- `.github/dependabot.yml` already has a `github-actions` ecosystem entry with `directory: "/"` and a weekly schedule — no change needed there.
- Added a "Workflow pins and Dependabot" section to `docs/developers-guide.md` documenting the policy for future contract tests.
- No workflow YAML files were touched; the current pinned SHA in `.github/workflows/mutation-testing.yml` is left exactly as-is.

## Review walkthrough

- `tests/workflow_contracts/mutation_testing_test.py`:
  - Removed `PINNED_SHA` and `EXPECTED_USES` constants and the "bump the workflow and this test together" doc comment.
  - Added `USES_RE`, a compiled regex matching `leynos/shared-actions/.github/workflows/mutation-cargo.yml@[0-9a-f]{40}`.
  - Renamed `test_uses_reference_is_pinned_to_the_documented_sha` to `test_uses_reference_is_pinned_to_a_commit_sha`; it now asserts `USES_RE.match(uses)` instead of exact string equality.
  - Updated the module docstring to say the test asserts the caller references the correct reusable workflow at *a* commit SHA, with Dependabot owning the SHA value.
  - All other tests in the file (permissions, workflow-level permissions, concurrency, triggers, `with:` block) are untouched.
- `docs/developers-guide.md`: new `## Workflow pins and Dependabot` section (canonical estate-wide policy text) after the existing `## Spelling policy` section.

## Validation

- `make test-workflow-contracts` passes locally (6 passed), confirming the regex matches the current pinned SHA in `.github/workflows/mutation-testing.yml` today.
- The new regex has no literal SHA baked in — it only requires 40 lowercase hex characters — so it would also match a hypothetical different SHA after a Dependabot bump, and demonstrably rejects a non-SHA ref such as `@main` (verified with a standalone `re.match` check against both cases).
- `make check-fmt`, `make typecheck`, `make test`, and `make nixie` all pass on this branch.
- `make lint` / `make markdownlint` currently fail only due to a pre-existing, unrelated en-GB spelling violation (`Artifacts` vs `Artefacts`) in six untouched `docs/execplans/*.md` files already present on `main`; nothing in this diff triggers it.