### PR TITLE
Correct artifact spelling to artefact in execplans

### DIFF
--- a/docs/execplans/2-5-4-top-level-for-desugaring.md
+++ b/docs/execplans/2-5-4-top-level-for-desugaring.md
@@ -264,7 +264,7 @@ existing parser behaviour:
 If a validation command fails, fix the failure and re-run that command, then
 re-run the full required validation sequence.
 
-## Artifacts and notes
+## Artefacts and notes
 
 Capture the following in PR notes or local logs:
 

--- a/docs/execplans/3-1-1-core-rule-and-cst-rule-traits.md
+++ b/docs/execplans/3-1-1-core-rule-and-cst-rule-traits.md
@@ -329,7 +329,7 @@ If trait signatures must change after tests are written, update tests and
 `docs/ddlint-design.md` in the same change so contracts and documentation stay
 in sync.
 
-## Artifacts and notes
+## Artefacts and notes
 
 Keep command logs under `/tmp/ddlint-*.log` and summarize pass/fail outcomes in
 implementation notes or commit body.

--- a/docs/execplans/3-1-2-rule-context-struct.md
+++ b/docs/execplans/3-1-2-rule-context-struct.md
@@ -334,7 +334,7 @@ old exports and introducing the new context types behind additive constructors,
 then migrate call sites incrementally. Re-run the failing gate first, then
 re-run all gates.
 
-## Artifacts and notes
+## Artefacts and notes
 
 Store gate logs in `/tmp/ddlint-*.log` and summarize pass/fail lines in the
 implementation handoff. Keep new tests concise and fixture-based.

--- a/docs/execplans/3-2-1-declare-lint-macro.md
+++ b/docs/execplans/3-2-1-declare-lint-macro.md
@@ -478,9 +478,9 @@ If formatting or Markdown validation changes files unexpectedly, rerun
 edit generated formatting by hand unless the formatter cannot express the
 required layout.
 
-## Artifacts and notes
+## Artefacts and notes
 
-The most important implementation artifact should be a compact macro example in
+The most important implementation artefact should be a compact macro example in
 `docs/ddlint-design.md` that mirrors the final public API. Keep it small enough
 to read in a terminal. A representative final example should resemble:
 

--- a/docs/execplans/phase-2-enforce-qualified-call-rule.md
+++ b/docs/execplans/phase-2-enforce-qualified-call-rule.md
@@ -270,7 +270,7 @@ land scoped-identifier parsing independently, then re-apply call/apply split
 with tests in smaller commits. If a gate fails, fix the specific failure,
 re-run the failed target, then re-run full gates.
 
-## Artifacts and notes
+## Artefacts and notes
 
 Keep command logs under `/tmp/ddlint-*.log` and summarize relevant pass/fail
 lines in the implementation handoff. Prefer focused fixture additions over

--- a/docs/execplans/phase-2-parse-apply-items.md
+++ b/docs/execplans/phase-2-parse-apply-items.md
@@ -252,7 +252,7 @@ revert to the last passing tests and re-apply modifications incrementally. When
 validation fails, fix the specific failure and re-run the failed command only,
 then re-run the full validation set before marking the work complete.
 
-## Artifacts and notes
+## Artefacts and notes
 
 Keep test fixtures small and place any long sample programmes under `tests/`
 for readability. Ensure any new diagnostic text is stable and asserted in unit


### PR DESCRIPTION
## Summary

The shared en-GB-oxendict `typos` dictionary now flags `Artifacts`/`artifact` as American spellings. Six execplan documents used them in their "Artifacts and notes" headings (and one prose line), which fails the pinned spelling gate and blocks CI on every PR — including unrelated ones. This is a pre-existing estate-wide dictionary drift, not introduced by any recent change to these files.

This PR renames the affected headings and prose to the Oxford `Artefacts`/`artefact`.

## Review walkthrough

- `docs/execplans/2-5-4-top-level-for-desugaring.md`, `docs/execplans/3-1-1-core-rule-and-cst-rule-traits.md`, `docs/execplans/3-1-2-rule-context-struct.md`, `docs/execplans/phase-2-enforce-qualified-call-rule.md`, `docs/execplans/phase-2-parse-apply-items.md`: `## Artifacts and notes` → `## Artefacts and notes`.
- `docs/execplans/3-2-1-declare-lint-macro.md`: the heading plus one prose line ("implementation artifact" → "implementation artefact").

No other files touched; documentation-only change.

## Validation

`make spelling` passes locally on a clean checkout after the change (previously it aborted with `Error 123` on these six files).