### PR TITLE
Add the CodeScene mode: check coverage gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,13 +40,14 @@ jobs:
           format: lcov
           use-cargo-nextest: 'false'
           with-ratchet: 'true'
-      # The `mode: check` step is deliberately not wired in yet: CodeScene
-      # project 69278 has no coverage-gates configuration, so
-      # `cs-coverage check` fails every run with "HTTP call succeeded,
-      # but the received project-config isn't valid. Lacks the gates
-      # configuration." — a CodeScene-side per-project setting, not a CI
-      # defect (chutoro's project hit the byte-identical error). Add the
-      # check step in a fast-follow PR once coverage-main.yml has
-      # uploaded to main at least once and the gate is confirmed to
-      # resolve, or once CodeScene confirms the project's coverage gate
-      # is enabled.
+      - name: Check coverage against CodeScene gates
+        env:
+          CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
+        if: env.CS_ACCESS_TOKEN != '' && github.event_name == 'pull_request'
+        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@29eea2635ee0f92e42c05f4cd360b7f1a2f00b12
+        with:
+          format: lcov
+          mode: check
+          project-url: https://api.codescene.io/v2/projects/69278
+          access-token: ${{ env.CS_ACCESS_TOKEN }}
+          installer-checksum: ${{ vars.CODESCENE_CLI_SHA256 }}


### PR DESCRIPTION
## Summary

- CodeScene project 69278's coverage-gates configuration is now enabled, so the PR coverage job can safely run `cs-coverage check` instead of leaving it deferred.
- Replace the deferred-gate comment in [`ci.yml`](https://github.com/leynos/ddlint/blob/codescene-mode-check/.github/workflows/ci.yml) with the guarded `mode: check` step, using the same `shared-actions` pin as the repo's existing coverage steps.

## Review walkthrough

- The new "Check coverage against CodeScene gates" step runs only when `CS_ACCESS_TOKEN` is set and the event is a pull request, so forks and non-PR runs skip it harmlessly.
- `format: lcov` matches the repo's existing `generate-coverage` step, which already checks out with `fetch-depth: 0` so the merge base is reachable for changed-line coverage.
- `project-url` uses the `/v2/projects/69278` form, matching CodeScene's coverage-check API.
- `coverage-main.yml` is untouched; it continues to use `mode: upload`.

## Validation

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` passes.
- `make test-workflow-contracts` passes (6 tests, none assert on the coverage-gate step shape).
- CI on this PR must show the "Check coverage against CodeScene gates" step executing and succeeding, and the `CodeScene Code Coverage` check completing (not erroring with "Lacks the gates configuration").
