### PR TITLE
Document mutation-testing workflow contract tests

### DIFF
--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -102,3 +102,54 @@ def test_uses_pinned_full_sha(caller_step):
 If a workflow's behaviour genuinely depends on a feature only present from a
 particular commit onwards, express that as a comment or a changelog note,
 not as a test assertion on the SHA string.
+
+## Mutation-testing workflow contract tests
+
+This repository runs scheduled, informational mutation testing through a thin
+caller workflow,
+[`.github/workflows/mutation-testing.yml`](../.github/workflows/mutation-testing.yml),
+which delegates to the shared reusable workflow
+`leynos/shared-actions/.github/workflows/mutation-cargo.yml`. The heavy
+lifting — running `cargo-mutants` and summarizing survivors — lives in
+`shared-actions`; this repository carries only declarative configuration. The
+run is **informational only**: it never gates a pull request. Survivors are
+reported through the job summary and downloadable artefacts so they can be
+triaged into tests, not enforced as a blocking check.
+
+The workflow runs in two modes. A **daily schedule** fires a run scoped to
+files changed within the detection window, so quiet days are cheap no-ops. A
+**manual dispatch** (the Actions "Run workflow" control) mutates the whole
+crate; select a branch in that control to exercise a feature branch.
+
+The caller passes a small set of configuration inputs, each carrying intent:
+
+- `exclude-globs` — excludes `src/test_util/**`, the test-support scaffolding
+  gated behind the `test-support` feature, whose surviving mutants are noise
+  rather than genuine test gaps.
+- `extra-args` — passes `--all-features` to `cargo-mutants` so the mutation
+  run matches the CI test baseline (`make test` runs `--all-features`); a
+  mismatch would report feature-gated code as untested.
+
+The `uses:` reference pins the shared workflow to a full 40-character commit
+SHA rather than a branch or tag, so a force-push upstream cannot silently
+change what runs here. The contract test asserts only that the pin is a full
+commit SHA, not a particular value, so Dependabot bumps it automatically
+without any accompanying test edit.
+
+Because the caller is configuration rather than code, a contract test in
+`tests/workflow_contracts/mutation_testing_test.py` pins the shape it must
+uphold, failing the pull request when the caller drifts — repointing the pin
+at a branch, widening the token scope, or dropping a configuration input —
+rather than letting the breakage surface only in a scheduled run. Run it
+locally with `make test-workflow-contracts`. The test validates:
+
+- the `uses:` reference targets `mutation-cargo.yml` pinned to a full commit
+  SHA;
+- the `with:` block equals exactly `{"exclude-globs": "src/test_util/**",
+  "extra-args": "--all-features"}`;
+- job permissions are least-privilege (`contents: read`, `id-token: write`)
+  and the workflow-level default token scope is empty;
+- `concurrency` serializes runs per ref without cancelling one in progress;
+  and
+- the triggers keep the daily schedule and a plain `workflow_dispatch` with
+  no legacy branch input.


### PR DESCRIPTION
## Summary

- Adds a new `## Mutation-testing workflow contract tests` section to
  `docs/developers-guide.md`, explaining
  `.github/workflows/mutation-testing.yml`, its delegation to
  `leynos/shared-actions/.github/workflows/mutation-cargo.yml`, and the
  contract test that pins the caller's shape.
- Documents the local run command, `make test-workflow-contracts`.

## Permutation

Permutation A — Rust (single crate). `ddlint` is a single-crate package (no
workspace), so the section describes a manual dispatch that "mutates the
whole crate".

## Contract-test style

Shape-only: `tests/workflow_contracts/mutation_testing_test.py` uses a
`USES_RE` regex asserting `...@[0-9a-f]{40}`; the pinned SHA value itself is
not hard-coded, so Dependabot bumps it without any accompanying test edit.
The `with:` block is asserted by equality against a separate `EXPECTED_WITH`
dict (`exclude-globs`, `extra-args` — this repo's caller has no `paths`
input). The module has no `pytestmark`/skip guard; ddlint is a Rust crate, so
there is no mutmut sandbox that omits `.github/`.

## Local run command

`make test-workflow-contracts`, which runs:

```sh
uv run --with 'pytest>=8' --with 'pyyaml>=6' pytest tests/workflow_contracts -q
```

## Roadmap / execplan note

No roadmap or execplan tracking applies. `docs/roadmap.md` and
`docs/execplans/*` were searched for "mutation" and contain no matching task,
so nothing was ticked or annotated.

## TOC / cross-link

`docs/developers-guide.md` has no in-page table of contents (headings run
directly, no index list). `docs/contents.md` already lists the developer
guide as a whole document ("Maintainer-facing workflow and implementation
guidance for the current codebase"), which already covers this addition, so
no cross-link changes were needed.

## Docs lint result

`make markdownlint` passed after the change (it chains `spelling`, which
enforces en-GB Oxford-`ize` spelling via pinned `typos`). Two Oxford-spelling
fixes were needed in the drafted prose (`summarising` → `summarizing`,
`serialises` → `serializes`) before the gate passed cleanly. The gate's
`spelling` step regenerates `typos.toml` from the shared dictionary as a
side effect; that regeneration was unrelated to this change and was reverted
before committing, leaving `typos.toml` untouched in this PR.

Only the docs gate was run, per instructions; the Rust/Python test suites
were not run.

## Changed file

- [`docs/developers-guide.md`](../../blob/docs/mutation-contract-tests/docs/developers-guide.md)
